### PR TITLE
Modified that RTC on system diagram does not disappear. 

### DIFF
--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/factory/ComponentCommandCreator.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/factory/ComponentCommandCreator.java
@@ -44,14 +44,14 @@ public class ComponentCommandCreator {
 		MultiCreateCommand result = new MultiCreateCommand();
 
 		if (!List.class.isAssignableFrom((Class<?>) request.getNewObjectType())) {
-			this.message = "生成対象が正しく指定されませんでした";
+			this.message = "Target RTC is not correctly specified.";
 			return result;
 		}
 
 		List<?> components = (List<?>) request.getNewObject();
 		if (components == null) {
-			// RTCの瞬断などでネームサーバ上のリフレッシュが遅れ、ドラッグ～ドロップの間に RTC選択が空になってしまうことがあるのでスキップ
-			this.message = "生成対象がありません";
+			// Skip when RTC in the list disappear during DnD because of refreshing on NS.
+			this.message = "No target RTC exist.";
 			return result;
 		}
 		List<Component> childComponents = new ArrayList<Component>();

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/factory/ComponentCommandCreator.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/factory/ComponentCommandCreator.java
@@ -44,10 +44,16 @@ public class ComponentCommandCreator {
 		MultiCreateCommand result = new MultiCreateCommand();
 
 		if (!List.class.isAssignableFrom((Class<?>) request.getNewObjectType())) {
+			this.message = "生成対象が正しく指定されませんでした";
 			return result;
 		}
 
 		List<?> components = (List<?>) request.getNewObject();
+		if (components == null) {
+			// RTCの瞬断などでネームサーバ上のリフレッシュが遅れ、ドラッグ～ドロップの間に RTC選択が空になってしまうことがあるのでスキップ
+			this.message = "生成対象がありません";
+			return result;
+		}
 		List<Component> childComponents = new ArrayList<Component>();
 		for (Object o : components) {
 			Component c = (Component) o;

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/SystemDiagramEditor.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/SystemDiagramEditor.java
@@ -6,7 +6,23 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 
-import jp.go.aist.rtm.systemeditor.corba.CORBAHelper;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.gef.ContextMenuProvider;
+import org.eclipse.gef.GraphicalViewer;
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.dialogs.ProgressMonitorDialog;
+import org.eclipse.jface.operation.IRunnableWithProgress;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IEditorSite;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.part.FileEditorInput;
+import org.openrtp.namespaces.rts.version02.RtsProfileExt;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import jp.go.aist.rtm.systemeditor.extension.LoadProfileExtension;
 import jp.go.aist.rtm.systemeditor.factory.ProfileLoader;
 import jp.go.aist.rtm.systemeditor.factory.Rehabilitation;
@@ -26,23 +42,6 @@ import jp.go.aist.rtm.toolscommon.model.component.CorbaComponent;
 import jp.go.aist.rtm.toolscommon.model.component.SystemDiagram;
 import jp.go.aist.rtm.toolscommon.model.component.SystemDiagramKind;
 import jp.go.aist.rtm.toolscommon.util.RtsProfileHandler;
-
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.gef.ContextMenuProvider;
-import org.eclipse.gef.GraphicalViewer;
-import org.eclipse.jface.action.IAction;
-import org.eclipse.jface.dialogs.Dialog;
-import org.eclipse.jface.dialogs.IDialogConstants;
-import org.eclipse.jface.dialogs.MessageDialog;
-import org.eclipse.jface.dialogs.ProgressMonitorDialog;
-import org.eclipse.jface.operation.IRunnableWithProgress;
-import org.eclipse.ui.IEditorInput;
-import org.eclipse.ui.IEditorSite;
-import org.eclipse.ui.PartInitException;
-import org.eclipse.ui.part.FileEditorInput;
-import org.openrtp.namespaces.rts.version02.RtsProfileExt;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * SystemDiagramEditorクラス
@@ -340,7 +339,7 @@ public class SystemDiagramEditor extends AbstractSystemDiagramEditor {
 		handler.restoreCompositeComponentPort(diagram);
 
 		setSystemDiagram(diagram);
-		
+
 		try {
 			RtsProfileHandler handlerProf = new RtsProfileHandler();
 			handlerProf.restoreConnection(getSystemDiagram());
@@ -351,7 +350,7 @@ public class SystemDiagramEditor extends AbstractSystemDiagramEditor {
 			LOGGER.error("Fail to replace diagram", e);
 		}
 	}
-	
+
 	/**
 	 * ロード時の復元を行います。
 	 */

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/SystemDiagramEditorContributor.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/SystemDiagramEditorContributor.java
@@ -3,9 +3,6 @@ package jp.go.aist.rtm.systemeditor.ui.editor;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
-import jp.go.aist.rtm.systemeditor.nl.Messages;
-import jp.go.aist.rtm.systemeditor.ui.editor.editpart.ComponentEditPart;
-
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.ui.actions.ActionBarContributor;
@@ -17,6 +14,8 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.ISelectionListener;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
+
+import jp.go.aist.rtm.systemeditor.ui.editor.editpart.ComponentEditPart;
 
 /**
  * システムダイアグラムのActionBarContributorクラス
@@ -80,7 +79,7 @@ public class SystemDiagramEditorContributor extends ActionBarContributor {
 		private final IStatusLineManager manager;
 
 		private ComponentEditPart componentEditPart;
-		
+
 		private IWorkbenchPage page;
 
 		private StatusLineDrawer(IWorkbenchPage page, IStatusLineManager manager) {
@@ -115,7 +114,7 @@ public class SystemDiagramEditorContributor extends ActionBarContributor {
 			if (componentEditPart != null) {
 				componentEditPart.addPropertyChangeListener(this);
 			}
-			
+
 			drawMessage();
 		}
 

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/command/ECMoveLineCommand.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/command/ECMoveLineCommand.java
@@ -2,21 +2,17 @@ package jp.go.aist.rtm.systemeditor.ui.editor.command;
 
 import java.util.Map;
 
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.gef.commands.Command;
+
 import jp.go.aist.rtm.systemeditor.ui.editor.SystemDiagramStore;
 import jp.go.aist.rtm.systemeditor.ui.editor.editpart.ECConnectionEditPart;
 import jp.go.aist.rtm.toolscommon.model.component.SystemDiagram;
-
-import org.eclipse.draw2d.geometry.Point;
-import org.eclipse.gef.commands.Command;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * EC関連のラインを移動するコマンド
  */
 public class ECMoveLineCommand extends Command {
-
-	private static final Logger LOGGER = LoggerFactory.getLogger(ECMoveLineCommand.class);
 
 	private Integer index;
 	private Point point;

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/editpart/ColorHelper.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/editpart/ColorHelper.java
@@ -8,26 +8,22 @@ import static jp.go.aist.rtm.systemeditor.manager.SystemEditorPreferenceManager.
 import static jp.go.aist.rtm.systemeditor.manager.SystemEditorPreferenceManager.COLOR_RTC_STATE_INACTIVE;
 import static jp.go.aist.rtm.systemeditor.manager.SystemEditorPreferenceManager.COLOR_RTC_STATE_UNCERTAIN;
 import static jp.go.aist.rtm.systemeditor.manager.SystemEditorPreferenceManager.COLOR_RTC_STATE_UNKNOWN;
+
+import org.eclipse.swt.graphics.Color;
+
 import jp.go.aist.rtm.systemeditor.manager.SystemEditorPreferenceManager;
 import jp.go.aist.rtm.toolscommon.model.component.CorbaComponent;
 import jp.go.aist.rtm.toolscommon.model.component.CorbaExecutionContext;
 import jp.go.aist.rtm.toolscommon.model.component.ExecutionContext;
-
-import org.eclipse.swt.graphics.Color;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * システムの色設定から色を取得します。
  */
 public class ColorHelper {
 
-	private static final Logger LOGGER = LoggerFactory
-			.getLogger(ColorHelper.class);
-
 	/**
 	 * システム設定から ECの枠色を取得します。
-	 * 
+	 *
 	 * @param ec
 	 * @return
 	 */
@@ -51,7 +47,7 @@ public class ColorHelper {
 
 	/**
 	 * システム設定から ECの本体色を取得します。
-	 * 
+	 *
 	 * @param ec
 	 * @return
 	 */

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/editpart/SystemDiagramEditPart.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/editpart/SystemDiagramEditPart.java
@@ -10,8 +10,6 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.ui.actions.ActionRegistry;
 import org.eclipse.ui.PlatformUI;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import jp.go.aist.rtm.systemeditor.ui.editor.editpolicy.GraphicalConnectorCreateManager;
 import jp.go.aist.rtm.systemeditor.ui.editor.editpolicy.SystemXYLayoutEditPolicy;
@@ -22,14 +20,12 @@ import jp.go.aist.rtm.toolscommon.model.component.SystemDiagram;
  */
 public class SystemDiagramEditPart extends AbstractEditPart {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(SystemDiagramEditPart.class);
-
 	private GraphicalConnectorCreateManager connectingPortManager;
 	private PortEditPart connectingPortEditPart;
 
 	/**
 	 * コンストラクタ
-	 * 
+	 *
 	 * @param actionRegistry
 	 *            ActionRegistry
 	 */
@@ -93,7 +89,7 @@ public class SystemDiagramEditPart extends AbstractEditPart {
 	/**
 	 * 接続先選択中となっているポートを設定します。<br>
 	 * 選択状態を解除する場合はnullを指定します。
-	 * 
+	 *
 	 * @param connectingPortEditPart
 	 *            接続先選択中のポート
 	 */
@@ -110,7 +106,7 @@ public class SystemDiagramEditPart extends AbstractEditPart {
 
 	/**
 	 * 接続先選択中のポートを取得します。
-	 * 
+	 *
 	 * @return 接続先選択中のポート
 	 */
 	public PortEditPart getConnectingPortEditPart() {
@@ -119,7 +115,7 @@ public class SystemDiagramEditPart extends AbstractEditPart {
 
 	/**
 	 * 現在、接続先選択中のポートと接続可能か判定します。
-	 * 
+	 *
 	 * @param part
 	 *            対象ポート
 	 * @return 接続先選択中のポートと接続可能な場合はtrue

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/editpart/ToolTipHelper.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/editpart/ToolTipHelper.java
@@ -1,28 +1,24 @@
 package jp.go.aist.rtm.systemeditor.ui.editor.editpart;
 
+import org.eclipse.draw2d.Label;
+import org.eclipse.draw2d.Panel;
+import org.eclipse.draw2d.StackLayout;
+
 import jp.go.aist.rtm.toolscommon.model.component.Component;
 import jp.go.aist.rtm.toolscommon.model.component.CorbaComponent;
 import jp.go.aist.rtm.toolscommon.model.component.CorbaExecutionContext;
 import jp.go.aist.rtm.toolscommon.model.component.ExecutionContext;
-
-import org.eclipse.draw2d.Label;
-import org.eclipse.draw2d.Panel;
-import org.eclipse.draw2d.StackLayout;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * ツールチップ作成ヘルパー
  */
 public class ToolTipHelper {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(ToolTipHelper.class);
-
 	private static final String CRLF = "\r\n";
 
 	/**
 	 * ECのツールチップを取得します。
-	 * 
+	 *
 	 * @param ec
 	 * @return
 	 */

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/editpolicy/SystemXYLayoutEditPolicy.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/editpolicy/SystemXYLayoutEditPolicy.java
@@ -1,12 +1,5 @@
 package jp.go.aist.rtm.systemeditor.ui.editor.editpolicy;
 
-import jp.go.aist.rtm.systemeditor.factory.ComponentCommandCreator;
-import jp.go.aist.rtm.systemeditor.nl.Messages;
-import jp.go.aist.rtm.systemeditor.ui.editor.command.ChangeConstraintCommand;
-import jp.go.aist.rtm.systemeditor.ui.editor.editpart.SystemDiagramEditPart;
-import jp.go.aist.rtm.systemeditor.ui.util.Draw2dUtil;
-import jp.go.aist.rtm.toolscommon.model.core.ModelElement;
-
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
@@ -15,6 +8,12 @@ import org.eclipse.gef.editpolicies.XYLayoutEditPolicy;
 import org.eclipse.gef.requests.CreateRequest;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.ui.PlatformUI;
+
+import jp.go.aist.rtm.systemeditor.factory.ComponentCommandCreator;
+import jp.go.aist.rtm.systemeditor.ui.editor.command.ChangeConstraintCommand;
+import jp.go.aist.rtm.systemeditor.ui.editor.editpart.SystemDiagramEditPart;
+import jp.go.aist.rtm.systemeditor.ui.util.Draw2dUtil;
+import jp.go.aist.rtm.toolscommon.model.core.ModelElement;
 
 /**
  * システムダイアグラムに関するEditPolicyクラス

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/figure/ComponentLayout.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/figure/ComponentLayout.java
@@ -4,15 +4,14 @@ import static jp.go.aist.rtm.toolscommon.model.component.Component.OUTPORT_DIREC
 import static jp.go.aist.rtm.toolscommon.model.component.Component.OUTPORT_DIRECTION_LEFT_LITERAL;
 import static jp.go.aist.rtm.toolscommon.model.component.Component.OUTPORT_DIRECTION_RIGHT_LITERAL;
 import static jp.go.aist.rtm.toolscommon.model.component.Component.OUTPORT_DIRECTION_UP_LITERAL;
-import jp.go.aist.rtm.toolscommon.model.component.Component;
 
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.XYLayout;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import jp.go.aist.rtm.toolscommon.model.component.Component;
 
 /**
  * コンポーネントFigureの内部で使用されるレイアウト
@@ -20,8 +19,6 @@ import org.slf4j.LoggerFactory;
  * コンポーネントFigureのデフォルトサイズ（ポートの数から計算）、方向やポートの位置を計算する
  */
 public class ComponentLayout extends XYLayout {
-
-	private static final Logger LOGGER = LoggerFactory.getLogger(ComponentLayout.class);
 
 	/** コンポーネントの周りとコンポーネントのボディまでのスペース(ポート側) */
 	public static final int PORT_SPACE = 32;
@@ -45,7 +42,7 @@ public class ComponentLayout extends XYLayout {
 
 	/**
 	 * コンストラクタ
-	 * 
+	 *
 	 * @param Component
 	 *            モデル
 	 */
@@ -110,28 +107,28 @@ public class ComponentLayout extends XYLayout {
 
 		/**
 		 * 対象の子要素のクラスを取得します。
-		 * 
+		 *
 		 * @return
 		 */
 		public abstract Class<?>[] getTargetClasses();
 
 		/**
 		 * 子要素の向きを取得します。
-		 * 
+		 *
 		 * @return
 		 */
 		public abstract String getChildDirection();
 
 		/**
 		 * 子要素の配置スペックを取得します。
-		 * 
+		 *
 		 * @return
 		 */
 		public abstract Spec getSpec();
 
 		/**
 		 * ベースとなる親要素の向きを表します。
-		 * 
+		 *
 		 * @return
 		 */
 		public String getParentDirection() {
@@ -158,7 +155,7 @@ public class ComponentLayout extends XYLayout {
 
 		/**
 		 * 子要素の数を取得します。
-		 * 
+		 *
 		 * @param parent
 		 * @return
 		 */
@@ -175,7 +172,7 @@ public class ComponentLayout extends XYLayout {
 
 		/**
 		 * 子要素の配置を算出します。
-		 * 
+		 *
 		 * @param parent
 		 * @param child
 		 * @return
@@ -220,7 +217,7 @@ public class ComponentLayout extends XYLayout {
 
 		/**
 		 * 対象の子要素かを判定します。
-		 * 
+		 *
 		 * @param target
 		 * @return
 		 */

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/actionorderview/ActionOrderView.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/actionorderview/ActionOrderView.java
@@ -2,15 +2,7 @@ package jp.go.aist.rtm.systemeditor.ui.views.actionorderview;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
-
-import jp.go.aist.rtm.systemeditor.ui.util.ComponentComparator;
-import jp.go.aist.rtm.toolscommon.model.component.Component;
-import jp.go.aist.rtm.toolscommon.model.component.CorbaComponent;
-import jp.go.aist.rtm.toolscommon.model.component.SystemDiagram;
-import jp.go.aist.rtm.toolscommon.model.component.SystemDiagramKind;
-import jp.go.aist.rtm.toolscommon.util.AdapterUtil;
 
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.ISelection;
@@ -50,12 +42,19 @@ import org.eclipse.ui.ISelectionListener;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.part.ViewPart;
 
+import jp.go.aist.rtm.systemeditor.ui.util.ComponentComparator;
+import jp.go.aist.rtm.toolscommon.model.component.Component;
+import jp.go.aist.rtm.toolscommon.model.component.CorbaComponent;
+import jp.go.aist.rtm.toolscommon.model.component.SystemDiagram;
+import jp.go.aist.rtm.toolscommon.model.component.SystemDiagramKind;
+import jp.go.aist.rtm.toolscommon.util.AdapterUtil;
+
 public class ActionOrderView extends ViewPart {
 	private static final int BUTTON_WIDTH = 40;
-	
+
 	private TableViewer orderTableViewer;
 	private List<TableViewer> actionOrderlistTableViewer;
-	
+
 	private SystemDiagram targetDiagram;
 //	private RTCStore rtcStore;
 	private ActionOrder actionOrder = new ActionOrder();
@@ -116,7 +115,7 @@ public class ActionOrderView extends ViewPart {
 		orderTableViewer = new TableViewer(composite, SWT.FULL_SELECTION | SWT.HIDE_SELECTION
 				| SWT.SINGLE | SWT.BORDER);
 		orderTableViewer.setContentProvider(new ArrayContentProvider());
-		
+
 		Table orderTable = orderTableViewer.getTable();
 		orderTable.setLinesVisible(true);
 		orderTable.setHeaderVisible(true);
@@ -132,7 +131,7 @@ public class ActionOrderView extends ViewPart {
 
 		TableViewerColumn noColumn = createColumn(orderTableViewer, "No.", 40);
 		noColumn.getColumn().setResizable(false);
-		
+
 		orderTableViewer.setLabelProvider(new OrderLabelProvider());
 		orderTableViewer.getTable().addFocusListener(new FocusAdapter() {
 			@Override
@@ -157,12 +156,12 @@ public class ActionOrderView extends ViewPart {
 		gd.verticalAlignment = SWT.FILL;
 		gd.grabExcessVerticalSpace = true;
 		buttonCompsite.setLayoutData(gd);
-		
+
 		Label dummy01 = new Label(buttonCompsite, SWT.NONE);
 		gd = new GridData();
 		gd.grabExcessVerticalSpace = true;
 		dummy01.setLayoutData(gd);
-		
+
 		Button upButton = new Button(buttonCompsite, SWT.NONE);
 		upButton.setText("▲");
 		upButton.setEnabled(true);
@@ -179,12 +178,12 @@ public class ActionOrderView extends ViewPart {
 				actionOrder.upElement(selectedTable, rowIndex);
 			}
 		});
-		
+
 		Label dummy02 = new Label(buttonCompsite, SWT.NONE);
 		gd = new GridData();
 		gd.grabExcessVerticalSpace = true;
 		dummy02.setLayoutData(gd);
-		
+
 		Button downButton = new Button(buttonCompsite, SWT.NONE);
 		downButton.setText("▼");
 		downButton.setEnabled(true);
@@ -206,7 +205,7 @@ public class ActionOrderView extends ViewPart {
 		gd = new GridData();
 		gd.grabExcessVerticalSpace = true;
 		dummy03.setLayoutData(gd);
-		
+
 		return composite;
 	}
 
@@ -216,7 +215,7 @@ public class ActionOrderView extends ViewPart {
 		TableViewer actionTableViewer = new TableViewer(composite, SWT.FULL_SELECTION
 				| SWT.SINGLE | SWT.BORDER);
 		actionTableViewer.setContentProvider(new ArrayContentProvider());
-		
+
 		final Table actionTable = actionTableViewer.getTable();
 		actionTable.setLinesVisible(true);
 		actionTable.setHeaderVisible(true);
@@ -256,7 +255,7 @@ public class ActionOrderView extends ViewPart {
 		}
 
 		actionTableViewer.setLabelProvider(new ActionOrderLabelProvider());
-		
+
 		actionTableViewer.getTable().addFocusListener(new FocusAdapter() {
 			@Override
 			public void focusGained(FocusEvent e) {
@@ -268,14 +267,14 @@ public class ActionOrderView extends ViewPart {
 		Transfer[] types = new Transfer[] { TextTransfer.getInstance() };
 	    DragSource source = new DragSource(actionTable, DND.DROP_MOVE);
 	    source.setTransfer(types);
-	    
+
 	    source.addDragListener(new DragSourceAdapter() {
 	      public void dragSetData(DragSourceEvent event) {
 			int rowIndex = actionTable.getSelectionIndex();
 			event.data = actionOrder.getElement(selectedTable, rowIndex);
 	      }
 	    });
-	    
+
 	    DropTarget dragTarget = new DropTarget(actionTable, DND.DROP_MOVE);
 	    dragTarget.setTransfer(types);
 	    dragTarget.addDropListener(new DropTargetAdapter() {
@@ -321,7 +320,7 @@ public class ActionOrderView extends ViewPart {
 	/** 内部モデル(RTC一覧)から表示 */
 	void refreshData() {
 		if(targetDiagram==null) return;
-		List<Component> targetComps = new ArrayList<Component>(); 
+		List<Component> targetComps = new ArrayList<Component>();
 		for (Component comp : targetDiagram.getRegisteredComponents()) {
 			if (!(comp instanceof CorbaComponent)) {
 				continue;
@@ -390,7 +389,7 @@ public class ActionOrderView extends ViewPart {
 //			}
 //		}
 //	}
-	
+
 	private class ActionOrder {
 		private List<Component> startupOrder = new ArrayList<Component>();
 		private List<Component> shutdownOrder = new ArrayList<Component>();
@@ -459,26 +458,26 @@ public class ActionOrderView extends ViewPart {
 				actionOrderlistTableViewer.get(index).refresh();
 			}
 		}
-		
+
 		public String getElement(int colIndex, int rowIndex) {
 			switch(colIndex) {
 			case 0:
 				return startupOrder.get(rowIndex).getInstanceNameL();
-			case 1: 
+			case 1:
 				return shutdownOrder.get(rowIndex).getInstanceNameL();
-			case 2: 
+			case 2:
 				return activationOrder.get(rowIndex).getInstanceNameL();
-			case 3: 
+			case 3:
 				return deactivationOrder.get(rowIndex).getInstanceNameL();
 			case 4:
 				return resettingOrder.get(rowIndex).getInstanceNameL();
-			case 5: 
+			case 5:
 				return initializeOrder.get(rowIndex).getInstanceNameL();
-			default: 
+			default:
 				return finalizeOrder.get(rowIndex).getInstanceNameL();
 			}
 		}
-		
+
 		public void swapElement(int tableIndex, String source, String target) {
 			if(tableIndex<0 || source==null || source.length()<=0 || target==null || target.length()<=0) return;
 			List<Component> targetData;
@@ -491,7 +490,7 @@ public class ActionOrderView extends ViewPart {
 			actionOrderlistTableViewer.get(tableIndex).refresh();
 			actionOrderlistTableViewer.get(tableIndex).getTable().setSelection(trgIndex);
 		}
-		
+
 		public void moveBackElement(int tableIndex, String source) {
 			if(tableIndex<0 || source==null || source.length()<=0) return;
 			List<Component> targetData;
@@ -504,7 +503,7 @@ public class ActionOrderView extends ViewPart {
 			actionOrderlistTableViewer.get(tableIndex).refresh();
 			actionOrderlistTableViewer.get(tableIndex).getTable().setSelection(targetData.size()-1);
 		}
-		
+
 		public void upElement(int tableIndex, int rowIndex) {
 			if(tableIndex<0 || rowIndex<=0) return;
 			List<Component> targetData;
@@ -516,7 +515,7 @@ public class ActionOrderView extends ViewPart {
 			actionOrderlistTableViewer.get(tableIndex).refresh();
 			actionOrderlistTableViewer.get(tableIndex).getTable().setSelection(rowIndex-1);
 		}
-		
+
 		public void downElement(int tableIndex, int rowIndex) {
 			if(tableIndex<0 || startupOrder.size()-1<=rowIndex) return;
 			List<Component> targetData;
@@ -528,7 +527,7 @@ public class ActionOrderView extends ViewPart {
 			actionOrderlistTableViewer.get(tableIndex).refresh();
 			actionOrderlistTableViewer.get(tableIndex).getTable().setSelection(rowIndex+1);
 		}
-		
+
 		public void update() {
 			orderTableViewer.setInput(startupOrder);
 			actionOrderlistTableViewer.get(ActionName.ACTION_START_UP.ordinal()).setInput(startupOrder);
@@ -539,7 +538,7 @@ public class ActionOrderView extends ViewPart {
 			actionOrderlistTableViewer.get(ActionName.ACTION_INITIALIZE.ordinal()).setInput(initializeOrder);
 			actionOrderlistTableViewer.get(ActionName.ACTION_FINALIZE.ordinal()).setInput(finalizeOrder);
 		}
-		
+
 		private List<Component> getTargetData(int tableIndex) {
 			List<Component> targetData;
 			switch(tableIndex) {
@@ -553,7 +552,7 @@ public class ActionOrderView extends ViewPart {
 			}
 			return targetData;
 		}
-		
+
 		private int getIndex(String source, List<Component> targetData) {
 			for(int index=0; index<targetData.size(); index++) {
 				Component target = targetData.get(index);

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/configurationview/ConfigurationView.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/configurationview/ConfigurationView.java
@@ -41,10 +41,8 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Item;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
@@ -175,7 +173,7 @@ public class ConfigurationView extends ViewPart {
 	private Button detailConfigurationSetCheckButton;
 
 	private Button sortCheckButton;
-	
+
 	private Button addNamedValueButton;
 	private Button deleteNamedValueButton;
 	private Button detailNamedValueCheckButton;
@@ -391,7 +389,7 @@ public class ConfigurationView extends ViewPart {
 	/**
 	 * 編集後の新しいConfigurationSetを作成する。
 	 * <p>
-	 * 
+	 *
 	 * @param copiedComponent
 	 * @return
 	 */
@@ -719,7 +717,7 @@ public class ConfigurationView extends ViewPart {
 				new TextCellEditor(rightTableViewer.getTable()) });
 		this.rightTableViewerFilter = new DetailTableViewerFilter();
 		this.rightTableViewer.addFilter(this.rightTableViewerFilter);
-		
+
 		rightTable = rightTableViewer.getTable();
 		rightTable.setLinesVisible(true);
 		leftTable.addSelectionListener(new SelectionListener() {
@@ -733,7 +731,7 @@ public class ConfigurationView extends ViewPart {
 				refreshRightData();
 			}
 		});
-		
+
 		gd = new GridData();
 		gd.verticalAlignment = SWT.FILL;
 		gd.horizontalAlignment = SWT.FILL;
@@ -765,7 +763,7 @@ public class ConfigurationView extends ViewPart {
 
 		keyCol.addControlListener(controlAdapter);
 		composite.addControlListener(controlAdapter);
-		
+
 		Composite buttonCompsite = new Composite(composite, SWT.BOTTOM);
 		gl = new GridLayout();
 		gl.numColumns = 4;
@@ -1437,7 +1435,7 @@ public class ConfigurationView extends ViewPart {
 
 		/**
 		 * 詳細モードを設定します。
-		 * 
+		 *
 		 * @param isDetail
 		 *            詳細モードの場合はtrue
 		 */

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/executioncontextview/ExecutionContextView.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/executioncontextview/ExecutionContextView.java
@@ -985,7 +985,6 @@ public class ExecutionContextView extends ViewPart {
 				return;
 			}
 			targetComponent = comp;
-			ExecutionContext targetEc = ctxt;
 			//
 			targetComponent.eAdapters().remove(eAdapter);
 			for (ExecutionContext ec : targetComponent.getExecutionContexts()) {

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/managercontrolview/ManagerControlView.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/managercontrolview/ManagerControlView.java
@@ -4,14 +4,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import jp.go.aist.rtm.systemeditor.nl.Messages;
-import jp.go.aist.rtm.systemeditor.ui.dialog.CreateComponentDialog;
-import jp.go.aist.rtm.systemeditor.ui.dialog.ManagerConfigurationDialog;
-import jp.go.aist.rtm.toolscommon.model.component.Component;
-import jp.go.aist.rtm.toolscommon.model.manager.RTCManager;
-import jp.go.aist.rtm.toolscommon.util.AdapterUtil;
-import jp.go.aist.rtm.toolscommon.util.SDOUtil;
-
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -47,6 +39,13 @@ import org.eclipse.ui.views.properties.TextPropertyDescriptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import jp.go.aist.rtm.systemeditor.ui.dialog.CreateComponentDialog;
+import jp.go.aist.rtm.systemeditor.ui.dialog.ManagerConfigurationDialog;
+import jp.go.aist.rtm.toolscommon.model.component.Component;
+import jp.go.aist.rtm.toolscommon.model.manager.RTCManager;
+import jp.go.aist.rtm.toolscommon.util.AdapterUtil;
+import jp.go.aist.rtm.toolscommon.util.SDOUtil;
+
 /**
  * マネージャ管理ビュー
  */
@@ -70,22 +69,22 @@ public class ManagerControlView extends ViewPart {
 	private Button loadedeModuleButton;
 	private Button rtcInstanceButton;
 	private Button managersButton;
-	
+
 	private Table modulesTable;
 	private TableViewer modulesTableViewer;
 	private TableColumn moduleColumn1;
 	private TableColumn moduleColumn2;
-	
+
 	private Button createButton;
 	private Button configureButton;
 	private Button restartButton;
 	private Button shutdownButton;
-	
+
 	private DispMode mode;
 
 	private RTCManager targetManager;
 	private List<Profile> profileList;
-	private List<RTCManager> managerList; 
+	private List<RTCManager> managerList;
 
 	public ManagerControlView() {
 	}
@@ -351,10 +350,10 @@ public class ManagerControlView extends ViewPart {
 				if (target == null) {
 					return;
 				}
-				
+
 				String managerName = SDOUtil.findValueAsString("instance_name", target.getProfileR().properties);
 				target.shutdownR();
-				
+
 				if(target==targetManager) {
 					targetManager = null;
 				} else {
@@ -441,7 +440,7 @@ public class ManagerControlView extends ViewPart {
 					this.profileList.add(new Profile(module, true));
 				}
 				this.modulesTableViewer.setInput(this.profileList);
-				
+
 			} else if (this.mode == DispMode.RTCInstances) {
 				for (RTC.ComponentProfile component : this.targetManager
 						.getComponentProfilesR()) {
@@ -466,7 +465,7 @@ public class ManagerControlView extends ViewPart {
 			this.profileList = new ArrayList<Profile>();
 		}
 		this.profileList.clear();
-		
+
 		this.profileList.add(new Profile(this.targetManager.getProfileR()));
 		managerList.add(targetManager);
 		for (RTCManager manager : this.targetManager
@@ -522,7 +521,7 @@ public class ManagerControlView extends ViewPart {
 		Profile(RTM.ManagerProfile manager) {
 			this.manager = manager;
 		}
-		
+
 		public boolean hasModuleProfile() {
 			return this.module != null;
 		}
@@ -569,7 +568,7 @@ public class ManagerControlView extends ViewPart {
 		public String getComponent_instance_name() {
 			return this.component.instance_name;
 		}
-		
+
 		/** コンポーネントプロファイル: マネージャ名を取得します */
 		public String getComponent_manager_name() {
 			return SDOUtil.findValueAsString("manager.instance_name",
@@ -598,7 +597,7 @@ public class ManagerControlView extends ViewPart {
 		}
 
 	}
-	
+
 	/** 各種プロファイルのプロパティ表示のためのPropertySource */
 	public static class ProfilePropertySource implements IPropertySource {
 
@@ -660,7 +659,7 @@ public class ManagerControlView extends ViewPart {
 		}
 
 	}
-	
+
 	/** 各種プロファイル一覧表示のLabelProvider */
 	public class ProfileLabelProvider extends LabelProvider implements
 			ITableLabelProvider, ITableColorProvider {

--- a/jp.go.aist.rtm.systemeditor/test/CorbaTest.java
+++ b/jp.go.aist.rtm.systemeditor/test/CorbaTest.java
@@ -82,7 +82,7 @@ public class CorbaTest {
 				break;
 			}
 			LocalObject local = getLocalObject(name);
-		
+
 			if (local == null) {
 				System.out.println("オブジェクトが見つかりません");
 				continue;
@@ -151,7 +151,6 @@ public class CorbaTest {
 	}
 
 	/** コンポーネントアクション */
-	@SuppressWarnings("unchecked")
 	void actionComponent(CorbaComponent c) {
 		c.synchronizeLocalAttribute(null);
 		c.synchronizeLocalReference();
@@ -234,7 +233,7 @@ public class CorbaTest {
 				System.out.print("設定パラメータ[name=value,...]> ");
 				String p = readLine();
 				String[] nvs = p.split(",");
-				List nvlist = new ArrayList();
+				List<NameValue> nvlist = new ArrayList<NameValue>();
 				for (int i = 0; i < nvs.length; i++) {
 					String nva[] = nvs[i].split("=");
 					if (nva.length < 2) {

--- a/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/action/AllDisconnectActionTest.java
+++ b/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/action/AllDisconnectActionTest.java
@@ -19,13 +19,12 @@ public class AllDisconnectActionTest extends TestCase {
 	private Port port3;
 	private StringBuffer buffer;
 	private AllDisconnectAction action;
-	
+
 	private SystemDiagram diagram;
 	private Component component1;
 	private Component component2;
 	private Component component3;
-	
-	@SuppressWarnings("unchecked")
+
 	@Override
 	protected void setUp() throws Exception {
 		port1 = createPort();
@@ -36,7 +35,7 @@ public class AllDisconnectActionTest extends TestCase {
 		port3.setOriginalPortString("2");
 
 		buffer = new StringBuffer();
-		
+
 		diagram = ComponentFactory.eINSTANCE.createSystemDiagram();
 		component1 = ComponentFactory.eINSTANCE.createComponentSpecification();
 		component2 = ComponentFactory.eINSTANCE.createComponentSpecification();
@@ -47,7 +46,7 @@ public class AllDisconnectActionTest extends TestCase {
 		component1.getPorts().add(port1);
 		component2.getPorts().add(port2);
 		component3.getPorts().add(port3);
-		
+
 		action = new AllDisconnectAction();
 		action.setTarget(port1);
 		action.setParent(diagram);
@@ -79,7 +78,7 @@ public class AllDisconnectActionTest extends TestCase {
 		port1.setSynchronizer(ComponentFactory.eINSTANCE.createPortSynchronizer());
 		port2.setSynchronizer(ComponentFactory.eINSTANCE.createPortSynchronizer());
 		port3.setSynchronizer(ComponentFactory.eINSTANCE.createPortSynchronizer());
-		
+
 		setupConnector("1", port1, port2);
 		verifyConnectCount(1, 1, 0);
 		setupConnector("2", port2, port1);
@@ -87,14 +86,14 @@ public class AllDisconnectActionTest extends TestCase {
 	}
 
 	private void setupConnector(String connectorId, Port source, Port target) {
-		PortConnector connector = PortConnectorFactory.createPortConnectorSpecification();	
+		PortConnector connector = PortConnectorFactory.createPortConnectorSpecification();
 		connector.setSource(source);
 		connector.setTarget(target);
-		
+
 		ConnectorProfile conn = ComponentFactory.eINSTANCE.createConnectorProfile();
 		conn.setConnectorId(connectorId);
 		connector.setConnectorProfile(conn);
-		
+
 		connector.createConnectorR();
 	}
 
@@ -103,19 +102,19 @@ public class AllDisconnectActionTest extends TestCase {
 		action.run();
 		assertEquals("disconnect_all ", buffer.toString());
 	}
-	
+
 	public void testOffline() {
 		setupOffline();
 		action.run();
 		verifyConnectCount(0, 0, 0);
 	}
-	
+
 	private void verifyConnectCount(int count, int source, int target) {
 		assertEquals(count, port1.getConnectorProfiles().size());
 		assertEquals(count, port2.getConnectorProfiles().size());
 		assertEquals(count, port3.getConnectorProfiles().size());
 	}
-	
+
 	// TODO: オフライン時の複合コンポーネントのdisconnect allに関しては、connectorIdからPortConnectorSpecificationを探し出す処理がおそらく必要
 	// TODO: 複合コンポーネントを開いたウィンドウに対する手動同期が不完全。（接続関連だけか）
 }

--- a/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/action/DecomposeComponentActionTest.java
+++ b/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/action/DecomposeComponentActionTest.java
@@ -16,7 +16,6 @@ public class DecomposeComponentActionTest extends TestCase {
 	private CorbaComponent component3;
 	private StringBuffer buffer;
 
-	@SuppressWarnings("unchecked")
 	@Override
 	protected void setUp() throws Exception {
 		diagram =  ComponentFactory.eINSTANCE.createSystemDiagram();
@@ -42,7 +41,7 @@ public class DecomposeComponentActionTest extends TestCase {
 		assertEquals(component2, diagram.getComponents().get(1));
 		assertEquals("exit ", buffer.toString());
 	}
-	
+
 	public void testDelete() throws Exception {
 		DeleteCommand command = new DeleteCommand();
 		command.setTarget(component3);

--- a/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/dialog/CreateComponentDialogTest.java
+++ b/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/dialog/CreateComponentDialogTest.java
@@ -1,11 +1,9 @@
 package jp.go.aist.rtm.systemeditor.ui.dialog;
 
-import junit.framework.TestCase;
-
-import org.eclipse.emf.common.util.BasicEList;
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
+
+import junit.framework.TestCase;
 
 public class CreateComponentDialogTest extends TestCase {
 
@@ -18,7 +16,6 @@ public class CreateComponentDialogTest extends TestCase {
 		Shell shell = new Shell(display);
 	    shell.pack();
 	    shell.open();
-	    EList typeList = setupTypeList();
 	    CreateComponentDialog dialog = new CreateComponentDialog(shell);
 //	    dialog.setTypeList(typeList);
 		dialog.open();
@@ -30,14 +27,14 @@ public class CreateComponentDialogTest extends TestCase {
 		display.dispose();
 	}
 
-	private static EList setupTypeList() {
-		BasicEList result = new BasicEList();
-		result.add("PeriodicECSharedComposite");
-		result.add("ConsoleIn");
-		result.add("ConsoleOut");
-		result.add("SequenceInComponent");
-		result.add("SequenceOutComponent");
-		return result;
-	}
+//	private static EList<String> setupTypeList() {
+//		BasicEList<String> result = new BasicEList<String>();
+//		result.add("PeriodicECSharedComposite");
+//		result.add("ConsoleIn");
+//		result.add("ConsoleOut");
+//		result.add("SequenceInComponent");
+//		result.add("SequenceOutComponent");
+//		return result;
+//	}
 
 }

--- a/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/util/CompositeOfflineLoadTest.java
+++ b/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/util/CompositeOfflineLoadTest.java
@@ -1,24 +1,9 @@
 package jp.go.aist.rtm.systemeditor.ui.util;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.datatype.DatatypeFactory;
-
-import jp.go.aist.rtm.nameserviceview.corba.NameServerAccesserTest;
-import jp.go.aist.rtm.repositoryView.model.RepositoryViewItem;
-import jp.go.aist.rtm.repositoryView.model.RepositoryViewLeafItem;
-import jp.go.aist.rtm.systemeditor.factory.SystemEditorWrapperFactory;
-import jp.go.aist.rtm.toolscommon.model.component.ComponentFactory;
-import jp.go.aist.rtm.toolscommon.model.component.ComponentSpecification;
-import jp.go.aist.rtm.toolscommon.model.component.ConnectorProfile;
-import jp.go.aist.rtm.toolscommon.model.component.NameValue;
-import jp.go.aist.rtm.toolscommon.model.component.Port;
-import jp.go.aist.rtm.toolscommon.model.component.SystemDiagram;
-import jp.go.aist.rtm.toolscommon.model.component.SystemDiagramKind;
-import jp.go.aist.rtm.toolscommon.util.RtsProfileHandler;
-import junit.framework.TestCase;
 
 import org.eclipse.emf.common.util.EList;
 import org.openrtp.namespaces.rts.version02.Component;
@@ -36,6 +21,18 @@ import org.openrtp.namespaces.rts.version02.TargetComponent;
 import org.openrtp.namespaces.rts.version02.TargetPort;
 
 import com.sun.org.apache.xerces.internal.jaxp.datatype.DatatypeFactoryImpl;
+
+import jp.go.aist.rtm.nameserviceview.corba.NameServerAccesserTest;
+import jp.go.aist.rtm.systemeditor.factory.SystemEditorWrapperFactory;
+import jp.go.aist.rtm.toolscommon.model.component.ComponentFactory;
+import jp.go.aist.rtm.toolscommon.model.component.ComponentSpecification;
+import jp.go.aist.rtm.toolscommon.model.component.ConnectorProfile;
+import jp.go.aist.rtm.toolscommon.model.component.NameValue;
+import jp.go.aist.rtm.toolscommon.model.component.Port;
+import jp.go.aist.rtm.toolscommon.model.component.SystemDiagram;
+import jp.go.aist.rtm.toolscommon.model.component.SystemDiagramKind;
+import jp.go.aist.rtm.toolscommon.util.RtsProfileHandler;
+import junit.framework.TestCase;
 
 public class CompositeOfflineLoadTest extends TestCase {
 	private ObjectFactory objectFactory;
@@ -58,22 +55,22 @@ public class CompositeOfflineLoadTest extends TestCase {
 		handler.restoreConfigSet(diagram);
 		handler.restoreCompositeComponentPort(diagram);
 		handler.restoreConnection(diagram);
-		
+
 		assertEquals("2009-03-06T10:15:43.349+09:00", diagram.getUpdateDate());
 		assertEquals("2009-03-06T10:15:43.349+09:00", diagram.getCreationDate());
 		assertEquals("RTSystem:d.d:d", diagram.getSystemId());
-		
+
 		assertEquals(2, diagram.getComponents().size());
 		verfifyComponentS1((ComponentSpecification) diagram.getComponents().get(0));
 //		verfifyComponentCameraComponent((ComponentSpecification) diagram.getComponents().get(1));
 //		verfifyComponentImageProcess((ComponentSpecification) diagram.getComponents().get(2));
 		verfifyComponentImageViewer((ComponentSpecification) diagram.getComponents().get(1));
-		
+
 		RtsProfileExt savedProfile = handler.save(diagram);
 		assertEquals(rtsProfile.getUpdateDate(), savedProfile.getUpdateDate());
 		assertEquals(rtsProfile.getCreationDate(), savedProfile.getCreationDate());
 		assertEquals(rtsProfile.getId(), savedProfile.getId());
-		
+
 		verifyComponents(rtsProfile.getComponents(), savedProfile.getComponents());
 		verifyServicePortConnectors(rtsProfile.getServicePortConnectors(), savedProfile.getServicePortConnectors());
 	}
@@ -179,7 +176,6 @@ public class CompositeOfflineLoadTest extends TestCase {
 		assertEquals(p1.getPortName(), p2.getPortName());
 	}
 
-	@SuppressWarnings("unchecked")
 	private void verfifyComponentS1(ComponentSpecification component) {
 		assertTrue(component.isRequired());
 		assertEquals("PeriodicECShared", component.getCompositeTypeL());
@@ -217,51 +213,51 @@ public class CompositeOfflineLoadTest extends TestCase {
 		verifyLocation("RIGHT", 255, 131, component);
 	}
 
-	private void verfifyComponentCameraComponent(
-			ComponentSpecification component) {
-		assertTrue(component.isRequired());
-		assertEquals("None", component.getCompositeTypeL());
-		assertNull(component.getActiveConfigurationSet());
-		assertEquals("CameraComponent_1", component.getInstanceNameL());
-		assertEquals("file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.CameraComponent_1.0.0.xml:1", component.getPathId());
-		assertEquals("RTC:Sample Vender.example.CameraComponent:1.0.0", component.getComponentId());
-		assertEquals(2, component.getPorts().size());
-		verifyPort("CameraComponent_1.ImageData"
-				, "{componentId:RTC:Sample Vender.example.CameraComponent:1.0.0,pathId:file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.CameraComponent_1.0.0.xml:1,instanceName:CameraComponent_1,portName:CameraComponent_1.ImageData}"
-				, (Port) component.getPorts().get(0)
-				, new String[]{});
-		verifyPort("CameraComponent_1.CapPORT"
-				, "{componentId:RTC:Sample Vender.example.CameraComponent:1.0.0,pathId:file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.CameraComponent_1.0.0.xml:1,instanceName:CameraComponent_1,portName:CameraComponent_1.CapPORT}"
-				, (Port) component.getPorts().get(1)
-				, new String[]{"9b4074b4-29b5-4a22-9956-22070915ef25"});
-		assertEquals(0, component.getConfigurationSets().size());
-		verifyLocation("RIGHT", 255, 131, component);
-	}
+//	private void verfifyComponentCameraComponent(
+//			ComponentSpecification component) {
+//		assertTrue(component.isRequired());
+//		assertEquals("None", component.getCompositeTypeL());
+//		assertNull(component.getActiveConfigurationSet());
+//		assertEquals("CameraComponent_1", component.getInstanceNameL());
+//		assertEquals("file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.CameraComponent_1.0.0.xml:1", component.getPathId());
+//		assertEquals("RTC:Sample Vender.example.CameraComponent:1.0.0", component.getComponentId());
+//		assertEquals(2, component.getPorts().size());
+//		verifyPort("CameraComponent_1.ImageData"
+//				, "{componentId:RTC:Sample Vender.example.CameraComponent:1.0.0,pathId:file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.CameraComponent_1.0.0.xml:1,instanceName:CameraComponent_1,portName:CameraComponent_1.ImageData}"
+//				, (Port) component.getPorts().get(0)
+//				, new String[]{});
+//		verifyPort("CameraComponent_1.CapPORT"
+//				, "{componentId:RTC:Sample Vender.example.CameraComponent:1.0.0,pathId:file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.CameraComponent_1.0.0.xml:1,instanceName:CameraComponent_1,portName:CameraComponent_1.CapPORT}"
+//				, (Port) component.getPorts().get(1)
+//				, new String[]{"9b4074b4-29b5-4a22-9956-22070915ef25"});
+//		assertEquals(0, component.getConfigurationSets().size());
+//		verifyLocation("RIGHT", 255, 131, component);
+//	}
 
-	private void verfifyComponentImageProcess(
-			ComponentSpecification component) {
-		assertTrue(component.isRequired());
-		assertEquals("None", component.getCompositeTypeL());
-		assertNull(component.getActiveConfigurationSet());
-		assertEquals("ImageProcess_1", component.getInstanceNameL());
-		assertEquals("file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.ImageProcess_1.0.0.xml:1", component.getPathId());
-		assertEquals("RTC:Sample Vender.example.ImageProcess:1.0.0", component.getComponentId());
-		assertEquals(3, component.getPorts().size());
-		verifyPort("ImageProcess_1.In"
-				, "{componentId:RTC:Sample Vender.example.ImageProcess:1.0.0,pathId:file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.ImageProcess_1.0.0.xml:1,instanceName:ImageProcess_1,portName:ImageProcess_1.In}"
-				, (Port) component.getPorts().get(0)
-				, new String[]{});
-		verifyPort("ImageProcess_1.Out"
-				, "{componentId:RTC:Sample Vender.example.ImageProcess:1.0.0,pathId:file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.ImageProcess_1.0.0.xml:1,instanceName:ImageProcess_1,portName:ImageProcess_1.Out}"
-				, (Port) component.getPorts().get(1)
-				, new String[]{});
-		verifyPort("ImageProcess_1.CapPORT"
-				, "{componentId:RTC:Sample Vender.example.ImageProcess:1.0.0,pathId:file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.ImageProcess_1.0.0.xml:1,instanceName:ImageProcess_1,portName:ImageProcess_1.CapPORT}"
-				, (Port) component.getPorts().get(2)
-				, new String[]{});
-		assertEquals(0, component.getConfigurationSets().size());
-		verifyLocation("RIGHT", 474, 113, component);
-	}
+//	private void verfifyComponentImageProcess(
+//			ComponentSpecification component) {
+//		assertTrue(component.isRequired());
+//		assertEquals("None", component.getCompositeTypeL());
+//		assertNull(component.getActiveConfigurationSet());
+//		assertEquals("ImageProcess_1", component.getInstanceNameL());
+//		assertEquals("file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.ImageProcess_1.0.0.xml:1", component.getPathId());
+//		assertEquals("RTC:Sample Vender.example.ImageProcess:1.0.0", component.getComponentId());
+//		assertEquals(3, component.getPorts().size());
+//		verifyPort("ImageProcess_1.In"
+//				, "{componentId:RTC:Sample Vender.example.ImageProcess:1.0.0,pathId:file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.ImageProcess_1.0.0.xml:1,instanceName:ImageProcess_1,portName:ImageProcess_1.In}"
+//				, (Port) component.getPorts().get(0)
+//				, new String[]{});
+//		verifyPort("ImageProcess_1.Out"
+//				, "{componentId:RTC:Sample Vender.example.ImageProcess:1.0.0,pathId:file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.ImageProcess_1.0.0.xml:1,instanceName:ImageProcess_1,portName:ImageProcess_1.Out}"
+//				, (Port) component.getPorts().get(1)
+//				, new String[]{});
+//		verifyPort("ImageProcess_1.CapPORT"
+//				, "{componentId:RTC:Sample Vender.example.ImageProcess:1.0.0,pathId:file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.ImageProcess_1.0.0.xml:1,instanceName:ImageProcess_1,portName:ImageProcess_1.CapPORT}"
+//				, (Port) component.getPorts().get(2)
+//				, new String[]{});
+//		assertEquals(0, component.getConfigurationSets().size());
+//		verifyLocation("RIGHT", 474, 113, component);
+//	}
 
 	private void verfifyComponentImageViewer(
 			ComponentSpecification component) {
@@ -433,7 +429,7 @@ public class CompositeOfflineLoadTest extends TestCase {
 		location.setY(BigInteger.valueOf(y));
 		return location;
 	}
-	
+
 
 	private ServiceportConnector createServiceportConnector() {
 		ServiceportConnector connector = objectFactory.createServiceportConnectorExt();
@@ -454,66 +450,66 @@ public class CompositeOfflineLoadTest extends TestCase {
 	}
 
 
-	private List<RepositoryViewItem> createRepositoryModel() {
-		List<RepositoryViewItem> repositoryModel = new ArrayList<RepositoryViewItem>();
-		repositoryModel.add(createEofComponentCameraComponent());
-		repositoryModel.add(createEofComponentImageProcess());
-		repositoryModel.add(createEofComponentImageViewer());
-		return repositoryModel;
-	}
+//	private List<RepositoryViewItem> createRepositoryModel() {
+//		List<RepositoryViewItem> repositoryModel = new ArrayList<RepositoryViewItem>();
+//		repositoryModel.add(createEofComponentCameraComponent());
+//		repositoryModel.add(createEofComponentImageProcess());
+//		repositoryModel.add(createEofComponentImageViewer());
+//		return repositoryModel;
+//	}
 
-	private RepositoryViewItem createEofComponentCameraComponent() {
-		RepositoryViewLeafItem item = new RepositoryViewLeafItem("CameraComponent");
-		ComponentSpecification component = ComponentFactory.eINSTANCE.createComponentSpecification();
-		component.setCategoryL("None");
-		component.setInstanceNameL("CameraComponent");
-		component.setPathId("file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.CameraComponent_1.0.0.xml:1");
-		component.setComponentId("RTC:Sample Vender.example.CameraComponent:1.0.0");
-		component.getPorts().add(createEofPort("ImageData", "out"));
-		component.getPorts().add(createEofPort("CapPORT", "service"));		
-		item.setComponent(component);
-		return item;
-	}
+//	private RepositoryViewItem createEofComponentCameraComponent() {
+//		RepositoryViewLeafItem item = new RepositoryViewLeafItem("CameraComponent");
+//		ComponentSpecification component = ComponentFactory.eINSTANCE.createComponentSpecification();
+//		component.setCategoryL("None");
+//		component.setInstanceNameL("CameraComponent");
+//		component.setPathId("file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.CameraComponent_1.0.0.xml:1");
+//		component.setComponentId("RTC:Sample Vender.example.CameraComponent:1.0.0");
+//		component.getPorts().add(createEofPort("ImageData", "out"));
+//		component.getPorts().add(createEofPort("CapPORT", "service"));
+//		item.setComponent(component);
+//		return item;
+//	}
 
-	private RepositoryViewItem createEofComponentImageProcess() {
-		RepositoryViewLeafItem item = new RepositoryViewLeafItem("ImageProcess");
-		ComponentSpecification component = ComponentFactory.eINSTANCE.createComponentSpecification();
-		component.setCategoryL("None");
-		component.setInstanceNameL("ImageProcess");
-		component.setPathId("file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.ImageProcess_1.0.0.xml:1");
-		component.setComponentId("RTC:Sample Vender.example.ImageProcess:1.0.0");
-		component.getPorts().add(createEofPort("In", "in"));
-		component.getPorts().add(createEofPort("Out", "out"));
-		component.getPorts().add(createEofPort("CapPORT", "service"));		
-		item.setComponent(component);
-		return item;
-	}
+//	private RepositoryViewItem createEofComponentImageProcess() {
+//		RepositoryViewLeafItem item = new RepositoryViewLeafItem("ImageProcess");
+//		ComponentSpecification component = ComponentFactory.eINSTANCE.createComponentSpecification();
+//		component.setCategoryL("None");
+//		component.setInstanceNameL("ImageProcess");
+//		component.setPathId("file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.ImageProcess_1.0.0.xml:1");
+//		component.setComponentId("RTC:Sample Vender.example.ImageProcess:1.0.0");
+//		component.getPorts().add(createEofPort("In", "in"));
+//		component.getPorts().add(createEofPort("Out", "out"));
+//		component.getPorts().add(createEofPort("CapPORT", "service"));
+//		item.setComponent(component);
+//		return item;
+//	}
 
-	private RepositoryViewItem createEofComponentImageViewer() {
-		RepositoryViewLeafItem item = new RepositoryViewLeafItem("ImageViewer");
-		ComponentSpecification component = ComponentFactory.eINSTANCE.createComponentSpecification();
-		component.setCategoryL("None");
-		component.setInstanceNameL("ImageViewer");
-		component.setPathId("file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.ImageViewer_1.0.0.xml:1");
-		component.setComponentId("RTC:Sample Vender.example.ImageViewer:1.0.0");
-		component.getPorts().add(createEofPort("ImageDataIn", "in"));
-		component.getPorts().add(createEofPort("CapPORT", "service"));		
-		item.setComponent(component);
-		return item;
-	}
+//	private RepositoryViewItem createEofComponentImageViewer() {
+//		RepositoryViewLeafItem item = new RepositoryViewLeafItem("ImageViewer");
+//		ComponentSpecification component = ComponentFactory.eINSTANCE.createComponentSpecification();
+//		component.setCategoryL("None");
+//		component.setInstanceNameL("ImageViewer");
+//		component.setPathId("file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.ImageViewer_1.0.0.xml:1");
+//		component.setComponentId("RTC:Sample Vender.example.ImageViewer:1.0.0");
+//		component.getPorts().add(createEofPort("ImageDataIn", "in"));
+//		component.getPorts().add(createEofPort("CapPORT", "service"));
+//		item.setComponent(component);
+//		return item;
+//	}
 
-	private Port createEofPort(String portName, String kind) {
-		Port port = createEofPort(kind);
-		port.setSynchronizer(ComponentFactory.eINSTANCE.createPortSynchronizer());
-		port.setNameL(portName);
-		return port;
-	}
+//	private Port createEofPort(String portName, String kind) {
+//		Port port = createEofPort(kind);
+//		port.setSynchronizer(ComponentFactory.eINSTANCE.createPortSynchronizer());
+//		port.setNameL(portName);
+//		return port;
+//	}
 
-	private Port createEofPort(String kind) {
-		if (kind.equals("in")) return ComponentFactory.eINSTANCE.createInPort();
-		if (kind.equals("out")) return ComponentFactory.eINSTANCE.createOutPort();
-		if (kind.equals("service")) return ComponentFactory.eINSTANCE.createServicePort();
-		return null;
-	}
+//	private Port createEofPort(String kind) {
+//		if (kind.equals("in")) return ComponentFactory.eINSTANCE.createInPort();
+//		if (kind.equals("out")) return ComponentFactory.eINSTANCE.createOutPort();
+//		if (kind.equals("service")) return ComponentFactory.eINSTANCE.createServicePort();
+//		return null;
+//	}
 
 }

--- a/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/util/RtsProfileHandlerTest.java
+++ b/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/util/RtsProfileHandlerTest.java
@@ -8,35 +8,6 @@ import java.util.Map;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
-import jp.go.aist.rtm.nameserviceview.corba.NameServerAccesserTest;
-import jp.go.aist.rtm.nameserviceview.model.nameservice.NamingContextNode;
-import jp.go.aist.rtm.nameserviceview.model.nameservice.NamingObjectNode;
-import jp.go.aist.rtm.repositoryView.model.RepositoryViewItem;
-import jp.go.aist.rtm.repositoryView.model.RepositoryViewLeafItem;
-import jp.go.aist.rtm.systemeditor.factory.SystemEditorWrapperFactory;
-import jp.go.aist.rtm.toolscommon.corba.CorbaObjectMock;
-import jp.go.aist.rtm.toolscommon.model.component.ComponentFactory;
-import jp.go.aist.rtm.toolscommon.model.component.ComponentSpecification;
-import jp.go.aist.rtm.toolscommon.model.component.ConnectorProfile;
-import jp.go.aist.rtm.toolscommon.model.component.CorbaComponent;
-import jp.go.aist.rtm.toolscommon.model.component.InPort;
-import jp.go.aist.rtm.toolscommon.model.component.NameValue;
-import jp.go.aist.rtm.toolscommon.model.component.OutPort;
-import jp.go.aist.rtm.toolscommon.model.component.Port;
-import jp.go.aist.rtm.toolscommon.model.component.PortConnector;
-import jp.go.aist.rtm.toolscommon.model.component.PortSynchronizer;
-import jp.go.aist.rtm.toolscommon.model.component.ServicePort;
-import jp.go.aist.rtm.toolscommon.model.component.SystemDiagram;
-import jp.go.aist.rtm.toolscommon.model.component.SystemDiagramKind;
-import jp.go.aist.rtm.toolscommon.model.component.impl.ConfigurationSetImpl;
-import jp.go.aist.rtm.toolscommon.model.component.impl.CorbaComponentImpl;
-import jp.go.aist.rtm.toolscommon.model.component.impl.ExecutionContextImpl;
-import jp.go.aist.rtm.toolscommon.model.component.util.PortConnectorFactory;
-import jp.go.aist.rtm.toolscommon.model.core.Point;
-import jp.go.aist.rtm.toolscommon.model.core.Rectangle;
-import jp.go.aist.rtm.toolscommon.util.RtsProfileHandler;
-import junit.framework.TestCase;
-
 import org.eclipse.emf.common.util.TreeIterator;
 import org.openrtp.namespaces.rts.version02.Activation;
 import org.openrtp.namespaces.rts.version02.Component;
@@ -46,7 +17,6 @@ import org.openrtp.namespaces.rts.version02.Condition;
 import org.openrtp.namespaces.rts.version02.ConditionExt;
 import org.openrtp.namespaces.rts.version02.ConfigurationData;
 import org.openrtp.namespaces.rts.version02.ConfigurationSet;
-import org.openrtp.namespaces.rts.version02.Dataport;
 import org.openrtp.namespaces.rts.version02.DataportConnector;
 import org.openrtp.namespaces.rts.version02.DataportConnectorExt;
 import org.openrtp.namespaces.rts.version02.DataportExt;
@@ -75,9 +45,32 @@ import org.openrtp.namespaces.rts.version02.TargetPort;
 import org.openrtp.namespaces.rts.version02.TargetPortExt;
 import org.openrtp.namespaces.rts.version02.Waittime;
 
-import RTC.ComponentProfile;
-
 import com.sun.org.apache.xerces.internal.jaxp.datatype.DatatypeFactoryImpl;
+
+import RTC.ComponentProfile;
+import jp.go.aist.rtm.nameserviceview.corba.NameServerAccesserTest;
+import jp.go.aist.rtm.nameserviceview.model.nameservice.NamingContextNode;
+import jp.go.aist.rtm.nameserviceview.model.nameservice.NamingObjectNode;
+import jp.go.aist.rtm.systemeditor.factory.SystemEditorWrapperFactory;
+import jp.go.aist.rtm.toolscommon.corba.CorbaObjectMock;
+import jp.go.aist.rtm.toolscommon.model.component.ComponentFactory;
+import jp.go.aist.rtm.toolscommon.model.component.ComponentSpecification;
+import jp.go.aist.rtm.toolscommon.model.component.ConnectorProfile;
+import jp.go.aist.rtm.toolscommon.model.component.CorbaComponent;
+import jp.go.aist.rtm.toolscommon.model.component.NameValue;
+import jp.go.aist.rtm.toolscommon.model.component.Port;
+import jp.go.aist.rtm.toolscommon.model.component.PortConnector;
+import jp.go.aist.rtm.toolscommon.model.component.PortSynchronizer;
+import jp.go.aist.rtm.toolscommon.model.component.SystemDiagram;
+import jp.go.aist.rtm.toolscommon.model.component.SystemDiagramKind;
+import jp.go.aist.rtm.toolscommon.model.component.impl.ConfigurationSetImpl;
+import jp.go.aist.rtm.toolscommon.model.component.impl.CorbaComponentImpl;
+import jp.go.aist.rtm.toolscommon.model.component.impl.ExecutionContextImpl;
+import jp.go.aist.rtm.toolscommon.model.component.util.PortConnectorFactory;
+import jp.go.aist.rtm.toolscommon.model.core.Point;
+import jp.go.aist.rtm.toolscommon.model.core.Rectangle;
+import jp.go.aist.rtm.toolscommon.util.RtsProfileHandler;
+import junit.framework.TestCase;
 
 public class RtsProfileHandlerTest extends TestCase {
 	private RtsProfileHandler handler;
@@ -119,15 +112,15 @@ public class RtsProfileHandlerTest extends TestCase {
 //		diagram.setKind(SystemDiagramKind.ONLINE_LITERAL);
 		handler.setOnline(true);
 		handler.populate(diagram, setupProfile());
-		
+
 		assertEquals("id1", diagram.getSystemId());
 		assertEquals("2009-01-14T18:49:18.892+09:00", diagram.getCreationDate());
 		assertEquals("2009-01-15T18:49:18.892+09:00", diagram.getUpdateDate());
-//		jp.go.aist.rtm.toolscommon.model.component.Property property = 
+//		jp.go.aist.rtm.toolscommon.model.component.Property property =
 //			(jp.go.aist.rtm.toolscommon.model.component.Property) diagram.getProperties().get(0);
 //		assertEquals("property1", property.getName());
 //		assertEquals("value1", property.getValue());
-		
+
 		assertEquals(1, diagram.getComponents().size());
 		jp.go.aist.rtm.toolscommon.model.component.Component component = (jp.go.aist.rtm.toolscommon.model.component.Component) diagram.getComponents().get(0);
 		assertTrue(component instanceof CorbaComponent);
@@ -142,11 +135,11 @@ public class RtsProfileHandlerTest extends TestCase {
 		assertEquals(30, constraint.getWidth());
 		assertEquals(40, constraint.getHeight());
 		assertEquals("RIGHT", component.getOutportDirection());
-//		jp.go.aist.rtm.toolscommon.model.component.Property property = 
+//		jp.go.aist.rtm.toolscommon.model.component.Property property =
 //			(jp.go.aist.rtm.toolscommon.model.component.Property) component.getProperties().get(0);
 //		assertEquals("property2", property.getName());
 //		assertEquals("value2", property.getValue());
-		
+
 		// XMLのロードを行った段階ではポートの情報はセットできない
 		assertTrue(component.getPorts().isEmpty());
 
@@ -170,13 +163,13 @@ public class RtsProfileHandlerTest extends TestCase {
 		RtsProfileExt profile = setupProfile();
 		handler.populate(diagram, profile);
 		diagram.setProfile(profile);
-		
+
 		jp.go.aist.rtm.toolscommon.model.component.Component component = (jp.go.aist.rtm.toolscommon.model.component.Component) diagram.getComponents().get(0);
 		assertTrue(component instanceof ComponentSpecification);
 
 		handler.restoreConfigSet(diagram);
 		handler.restoreCompositeComponentPort(diagram);
-		
+
 		Port port = (Port) component.getPorts().get(0);
 		assertEquals("ConsoleIn0.out", port.getNameL());
 		port = (Port) component.getPorts().get(1);
@@ -204,7 +197,7 @@ public class RtsProfileHandlerTest extends TestCase {
 		Point point = (Point) portConnector.getRoutingConstraint().map().get(1);
 		assertEquals(392, point.getX());
 		assertEquals(110, point.getY());
-		
+
 		port = (Port) component.getPorts().get(1);
 		ConnectorProfile connector2 = (ConnectorProfile) port.getConnectorProfiles().get(0);
 		assertEquals("connector2", connector2.getConnectorId());
@@ -223,7 +216,7 @@ public class RtsProfileHandlerTest extends TestCase {
 		port = (Port) component3.getPorts().get(1);
 		assertEquals(connector2, port.getConnectorProfiles().get(0));
 		assertEquals(port.getOriginalPortString(), connector2.getTargetString());
-		
+
 		jp.go.aist.rtm.toolscommon.model.component.Component component2 = (jp.go.aist.rtm.toolscommon.model.component.Component) component.getComponents().get(0);
 		jp.go.aist.rtm.toolscommon.model.component.ConfigurationSet configSet = (jp.go.aist.rtm.toolscommon.model.component.ConfigurationSet) component2.getConfigurationSets().get(0);
 		assertEquals(component2.getActiveConfigurationSet(), configSet);
@@ -235,7 +228,6 @@ public class RtsProfileHandlerTest extends TestCase {
 
 	// IORの復元を行うテスト
 	// 192.168.1.164にネームサーバとrtcdが起動しているという前提
-	@SuppressWarnings("unchecked")
 	public void _testLoadIOR() throws Exception {
 		NamingContextNode context = NameServerAccesserTest.getNamingContext();
 		TreeIterator allContents = context.eAllContents();
@@ -267,7 +259,7 @@ public class RtsProfileHandlerTest extends TestCase {
 
 	// ベンドポイントを復元するテスト
 	public void testConvertFromBendPointString() throws Exception {
-		Map<Integer, jp.go.aist.rtm.toolscommon.model.core.Point> result 
+		Map<Integer, jp.go.aist.rtm.toolscommon.model.core.Point> result
 			= handler.convertFromBendPointString("{1:(392,110)}");
 		assertEquals(1, result.keySet().size());
 		jp.go.aist.rtm.toolscommon.model.core.Point point = result.get(1);
@@ -276,7 +268,7 @@ public class RtsProfileHandlerTest extends TestCase {
 	}
 
 	public void testConvertFromBendPointString2() throws Exception {
-		Map<Integer, jp.go.aist.rtm.toolscommon.model.core.Point> result 
+		Map<Integer, jp.go.aist.rtm.toolscommon.model.core.Point> result
 			= handler.convertFromBendPointString("{1:(392,110), 2:(23,45)}");
 		assertEquals(2, result.keySet().size());
 		jp.go.aist.rtm.toolscommon.model.core.Point point = result.get(1);
@@ -295,7 +287,7 @@ public class RtsProfileHandlerTest extends TestCase {
 		RtsProfileExt result = handler.save(diagram);
 
 		ComponentExt component = (ComponentExt) result.getComponents().get(1);
-		
+
 		// コンポーネント1のEC
 		ExecutionContextExt executionContext = (ExecutionContextExt) component.getExecutionContexts().get(0);
 		assertEquals("default", executionContext.getId());
@@ -305,7 +297,7 @@ public class RtsProfileHandlerTest extends TestCase {
 		Property property4 = executionContext.getProperties().get(0);
 		assertEquals("property5", property4.getName());
 		assertEquals("value5", property4.getValue());
-		
+
 		assertEquals("default2", component.getExecutionContexts().get(1).getId());
 	}
 
@@ -316,7 +308,7 @@ public class RtsProfileHandlerTest extends TestCase {
 		setupConnectors();
 
 		RtsProfileExt result = handler.save(diagram);
-		
+
 		// プロファイル直下の属性
 		assertEquals("id1", result.getId());
 		assertEquals("abstract1", result.getAbstract());
@@ -332,7 +324,7 @@ public class RtsProfileHandlerTest extends TestCase {
 		Property property1 = result.getProperties().get(0);
 		assertEquals("property1", property1.getName());
 		assertEquals("value1", property1.getValue());
-		
+
 		// コンポーネント１：通常オブジェクト
 		assertEquals(3, result.getComponents().size());
 		ComponentExt component = (ComponentExt) result.getComponents().get(1);
@@ -342,7 +334,7 @@ public class RtsProfileHandlerTest extends TestCase {
 		assertEquals("ConsoleIn0", component.getInstanceName());
 		assertEquals("None", component.getCompositeType());
 		assertTrue(component.isIsRequired());
-		
+
 		// コンポーネント1のデータポート
 		DataportExt dataport = (DataportExt) component.getDataPorts().get(0);
 		assertEquals("out", dataport.getName());
@@ -360,14 +352,14 @@ public class RtsProfileHandlerTest extends TestCase {
 		Property property8 = serviceport.getProperties().get(0);
 		assertEquals("property4", property8.getName());
 		assertEquals("value4", property8.getValue());
-		
+
 		// コンポーネント1のコンフィグセット
 		ConfigurationSet configurationSet = component.getConfigurationSets().get(0);
 		assertEquals("config1", configurationSet.getId());
 		ConfigurationData configurationData = configurationSet.getConfigurationData().get(0);
 		assertEquals("name1", configurationData.getName());
 		assertEquals("value1", configurationData.getData());
-				
+
 		// コンポーネント1の追加属性
 		assertEquals("comment2", component.getComment());
 		assertTrue(component.isVisible());
@@ -383,7 +375,7 @@ public class RtsProfileHandlerTest extends TestCase {
 		Property property6 = component.getProperties().get(1);
 		assertEquals("IOR", property6.getName());
 		assertEquals("newIOR", property6.getValue());
-		
+
 		// コンポーネントグループ
 		ComponentGroup componentGroup = result.getGroups().get(0);
 		assertEquals("groupId1", componentGroup.getGroupId());
@@ -393,7 +385,7 @@ public class RtsProfileHandlerTest extends TestCase {
 		Property property = targetComponent.getProperties().get(0);
 		assertEquals("property8", property.getName());
 		assertEquals("value8", property.getValue());
-		
+
 		// コンポーネント2：複合コンポーネント
 		ComponentExt component2 = (ComponentExt) result.getComponents().get(0);
 		assertEquals("id3", component2.getId());
@@ -416,7 +408,7 @@ public class RtsProfileHandlerTest extends TestCase {
 		TargetComponentExt participant2 = (TargetComponentExt) component2.getParticipants().get(1).getParticipant();
 		assertEquals("id4", participant2.getComponentId());
 		assertEquals("ConsoleOut0", participant2.getInstanceName());
-		
+
 		// DataportConnectors
 		assertEquals(2, result.getDataPortConnectors().size());
 		DataportConnectorExt connector1 = (DataportConnectorExt) result.getDataPortConnectors().get(0);
@@ -452,7 +444,7 @@ public class RtsProfileHandlerTest extends TestCase {
 		assertEquals("id4", targetDataPort.getComponentId());
 		assertEquals("ConsoleOut0", targetDataPort.getInstanceName());
 		assertEquals("in", targetDataPort.getPortName());
-		
+
 		DataportConnectorExt connector1N = (DataportConnectorExt) result.getDataPortConnectors().get(1);
 		assertEquals("connector1N", connector1N.getConnectorId());
 		sourceDataPort = (TargetPortExt) connector1N.getSourceDataPort();
@@ -463,14 +455,14 @@ public class RtsProfileHandlerTest extends TestCase {
 		assertEquals("id2", targetDataPort.getComponentId());
 		assertEquals("ConsoleIn0", targetDataPort.getInstanceName());
 		assertEquals("out2", targetDataPort.getPortName());
-		
+
 		// ServiceportConnectors
 		assertEquals(1, result.getServicePortConnectors().size());
 		ServiceportConnectorExt connector2 = (ServiceportConnectorExt) result.getServicePortConnectors().get(0);
 		assertEquals("connector2", connector2.getConnectorId());
 		assertEquals("conectorName2", connector2.getName());
 		assertEquals("trans1", connector2.getTransMethod());
-		
+
 		// Condition
 		ConditionExt condition = (ConditionExt) result.getStartUp().getTargets().get(0);
 		assertEquals(BigInteger.ONE, condition.getSequence());
@@ -494,7 +486,7 @@ public class RtsProfileHandlerTest extends TestCase {
 		assertEquals(BigInteger.ONE, result.getResetting().getTargets().get(0).getSequence());
 		assertEquals(BigInteger.ONE, result.getInitializing().getTargets().get(0).getSequence());
 		assertEquals(BigInteger.ONE, result.getFinalizing().getTargets().get(0).getSequence());
-		
+
 	}
 
 	private SystemDiagram setupDiagram() {
@@ -556,65 +548,65 @@ public class RtsProfileHandlerTest extends TestCase {
 		return profile;
 	}
 
-	private List<RepositoryViewItem> setupRepositoryModel() {
-		List<RepositoryViewItem> result = new ArrayList<RepositoryViewItem>();
-		result.add(setupRepositoryViewItem1());
-		result.add(setupRepositoryViewItem2());
-		return result;
-	}
+//	private List<RepositoryViewItem> setupRepositoryModel() {
+//		List<RepositoryViewItem> result = new ArrayList<RepositoryViewItem>();
+//		result.add(setupRepositoryViewItem1());
+//		result.add(setupRepositoryViewItem2());
+//		return result;
+//	}
 
-	private RepositoryViewItem setupRepositoryViewItem1() {
-		RepositoryViewLeafItem result = new RepositoryViewLeafItem("name1");
-		result.setComponent(setupComponentSpecification1());
-		return result;
-	}
+//	private RepositoryViewItem setupRepositoryViewItem1() {
+//		RepositoryViewLeafItem result = new RepositoryViewLeafItem("name1");
+//		result.setComponent(setupComponentSpecification1());
+//		return result;
+//	}
 
-	private RepositoryViewItem setupRepositoryViewItem2() {
-		RepositoryViewLeafItem result = new RepositoryViewLeafItem("name2");
-		result.setComponent(setupComponentSpecification2());
-		return result;
-	}
+//	private RepositoryViewItem setupRepositoryViewItem2() {
+//		RepositoryViewLeafItem result = new RepositoryViewLeafItem("name2");
+//		result.setComponent(setupComponentSpecification2());
+//		return result;
+//	}
 
-	private ComponentSpecification setupComponentSpecification1() {
-		ComponentSpecification result = ComponentFactory.eINSTANCE.createComponentSpecification();
-		result.setComponentId("id2");
-		result.setPathId("192.168.1.164/client164.local.tech-arts.co.jp.host_cxt/ConsoleIn0.rtc");
-		result.setInstanceNameL("ConsoleIn0");
-		result.getPorts().add(setupOutport1());
-		result.getPorts().add(createServiceport("client"));
-		return result;
-	}
+//	private ComponentSpecification setupComponentSpecification1() {
+//		ComponentSpecification result = ComponentFactory.eINSTANCE.createComponentSpecification();
+//		result.setComponentId("id2");
+//		result.setPathId("192.168.1.164/client164.local.tech-arts.co.jp.host_cxt/ConsoleIn0.rtc");
+//		result.setInstanceNameL("ConsoleIn0");
+//		result.getPorts().add(setupOutport1());
+//		result.getPorts().add(createServiceport("client"));
+//		return result;
+//	}
 
-	private ServicePort createServiceport(String name) {
-		ServicePort result = ComponentFactory.eINSTANCE.createServicePort();
-		result.setSynchronizer(ComponentFactory.eINSTANCE.createPortSynchronizer());
-		result.setNameL(name);
-		return result;
-	}
+//	private ServicePort createServiceport(String name) {
+//		ServicePort result = ComponentFactory.eINSTANCE.createServicePort();
+//		result.setSynchronizer(ComponentFactory.eINSTANCE.createPortSynchronizer());
+//		result.setNameL(name);
+//		return result;
+//	}
 
-	private ComponentSpecification setupComponentSpecification2() {
-		ComponentSpecification result = ComponentFactory.eINSTANCE.createComponentSpecification();
-		result.setComponentId("id4");
-		result.setPathId("192.168.1.164/client164.local.tech-arts.co.jp.host_cxt/ConsoleOut0.rtc");
-		result.setInstanceNameL("ConsoleOut0");
-		result.getPorts().add(setupInport1());
-		result.getPorts().add(createServiceport("server"));
-		return result;
-	}
+//	private ComponentSpecification setupComponentSpecification2() {
+//		ComponentSpecification result = ComponentFactory.eINSTANCE.createComponentSpecification();
+//		result.setComponentId("id4");
+//		result.setPathId("192.168.1.164/client164.local.tech-arts.co.jp.host_cxt/ConsoleOut0.rtc");
+//		result.setInstanceNameL("ConsoleOut0");
+//		result.getPorts().add(setupInport1());
+//		result.getPorts().add(createServiceport("server"));
+//		return result;
+//	}
 
-	private OutPort setupOutport1() {
-		OutPort result = ComponentFactory.eINSTANCE.createOutPort();
-		result.setSynchronizer(ComponentFactory.eINSTANCE.createPortSynchronizer());
-		result.setNameL("out");
-		return result;
-	}
+//	private OutPort setupOutport1() {
+//		OutPort result = ComponentFactory.eINSTANCE.createOutPort();
+//		result.setSynchronizer(ComponentFactory.eINSTANCE.createPortSynchronizer());
+//		result.setNameL("out");
+//		return result;
+//	}
 
-	private InPort setupInport1() {
-		InPort result = ComponentFactory.eINSTANCE.createInPort();
-		result.setSynchronizer(ComponentFactory.eINSTANCE.createPortSynchronizer());
-		result.setNameL("in");
-		return result;
-	}
+//	private InPort setupInport1() {
+//		InPort result = ComponentFactory.eINSTANCE.createInPort();
+//		result.setSynchronizer(ComponentFactory.eINSTANCE.createPortSynchronizer());
+//		result.setNameL("in");
+//		return result;
+//	}
 
 	private Property createPropery(String name, String value) {
 		Property result = new Property();

--- a/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/views/configurationview/mock/ComponentMock.java
+++ b/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/views/configurationview/mock/ComponentMock.java
@@ -305,7 +305,6 @@ public class ComponentMock implements Component {
 	public void setPathId(String value) {
 	}
 
-	@SuppressWarnings("unchecked")
 	public boolean updateConfigurationSetListR(List list,
 			ConfigurationSet activeConfigurationSet, List originallist) {
 		return false;
@@ -656,7 +655,7 @@ public class ComponentMock implements Component {
 	@Override
 	public void setPrimaryExecutionContext(ExecutionContext value) {
 		// TODO 自動生成されたメソッド・スタブ
-		
+
 	}
 
 	@Override
@@ -668,7 +667,7 @@ public class ComponentMock implements Component {
 	@Override
 	public void setStartUp(String value) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
@@ -680,7 +679,7 @@ public class ComponentMock implements Component {
 	@Override
 	public void setShutDown(String value) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
@@ -692,7 +691,7 @@ public class ComponentMock implements Component {
 	@Override
 	public void setActivation(String value) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
@@ -704,7 +703,7 @@ public class ComponentMock implements Component {
 	@Override
 	public void setDeActivation(String value) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
@@ -716,7 +715,7 @@ public class ComponentMock implements Component {
 	@Override
 	public void setResetting(String value) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
@@ -728,7 +727,7 @@ public class ComponentMock implements Component {
 	@Override
 	public void setInitialize(String value) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
@@ -740,7 +739,7 @@ public class ComponentMock implements Component {
 	@Override
 	public void setFinalize(String value) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 }

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ComponentFactoryImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ComponentFactoryImpl.java
@@ -10,9 +10,28 @@ import java.beans.PropertyChangeListener;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EDataType;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.impl.EFactoryImpl;
+import org.eclipse.emf.ecore.plugin.EcorePlugin;
+import org.omg.CORBA.Any;
+import org.omg.CORBA.TCKind;
+import org.omg.PortableServer.Servant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import RTC.ComponentProfile;
+import RTC.ExecutionContextProfile;
+import RTC.PortProfile;
+import RTC.RTObject;
+import _SDOPackage.Configuration;
+import _SDOPackage.ConfigurationHelper;
+import _SDOPackage.Organization;
+import _SDOPackage.ServiceProfile;
 import jp.go.aist.rtm.toolscommon.corba.CorbaUtil;
-import jp.go.aist.rtm.toolscommon.model.component.*;
-import jp.go.aist.rtm.toolscommon.model.component.util.ICorbaPortEventObserver;
 import jp.go.aist.rtm.toolscommon.model.component.ComponentFactory;
 import jp.go.aist.rtm.toolscommon.model.component.ComponentPackage;
 import jp.go.aist.rtm.toolscommon.model.component.ComponentSpecification;
@@ -38,29 +57,8 @@ import jp.go.aist.rtm.toolscommon.model.component.PortSynchronizer;
 import jp.go.aist.rtm.toolscommon.model.component.ServicePort;
 import jp.go.aist.rtm.toolscommon.model.component.SystemDiagram;
 import jp.go.aist.rtm.toolscommon.model.component.SystemDiagramKind;
+import jp.go.aist.rtm.toolscommon.model.component.util.ICorbaPortEventObserver;
 import jp.go.aist.rtm.toolscommon.model.core.Point;
-
-import org.apache.commons.lang.StringUtils;
-import org.eclipse.emf.ecore.EClass;
-import org.eclipse.emf.ecore.EDataType;
-import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.EPackage;
-import org.eclipse.emf.ecore.impl.EFactoryImpl;
-import org.eclipse.emf.ecore.plugin.EcorePlugin;
-import org.omg.CORBA.Any;
-import org.omg.CORBA.TCKind;
-import org.omg.PortableServer.Servant;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import RTC.ComponentProfile;
-import RTC.ExecutionContextProfile;
-import RTC.PortProfile;
-import RTC.RTObject;
-import _SDOPackage.Configuration;
-import _SDOPackage.ConfigurationHelper;
-import _SDOPackage.Organization;
-import _SDOPackage.ServiceProfile;
 
 /**
  * <!-- begin-user-doc --> An implementation of the model <b>Factory</b>. <!--
@@ -69,7 +67,7 @@ import _SDOPackage.ServiceProfile;
  */
 public class ComponentFactoryImpl extends EFactoryImpl implements
 		ComponentFactory {
-	
+
 	private static final Logger LOGGER = LoggerFactory
 			.getLogger(ComponentFactoryImpl.class);
 
@@ -728,7 +726,7 @@ public class ComponentFactoryImpl extends EFactoryImpl implements
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * 
+	 *
 	 * @generated NOT
 	 */
 	public Configuration createConfigurationFromString(EDataType eDataType,
@@ -739,21 +737,21 @@ public class ComponentFactoryImpl extends EFactoryImpl implements
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * 
+	 *
 	 * @generated NOT
 	 */
 	public Any createAnyFromString(EDataType eDataType, String initialValue) {
 		Any any = null;
 		try {
 			any = CorbaUtil.getOrb().create_any();
-			
+
 			org.omg.CORBA.Object remote = null;
 			try {
 				remote = CorbaUtil.stringToObject(initialValue);
 			} catch (Exception e) {
 				// void
 			}
-			
+
 			if (remote != null) {
 				any.insert_Object(remote);
 			} else {
@@ -772,7 +770,7 @@ public class ComponentFactoryImpl extends EFactoryImpl implements
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * 
+	 *
 	 * @generated NOT
 	 */
 	public String convertAnyToString(EDataType eDataType, Object instanceValue) {

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ComponentPackageImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ComponentPackageImpl.java
@@ -10,6 +10,23 @@ import java.beans.PropertyChangeListener;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EDataType;
+import org.eclipse.emf.ecore.EEnum;
+import org.eclipse.emf.ecore.EOperation;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.impl.EPackageImpl;
+import org.omg.PortableServer.Servant;
+
+import RTC.ComponentProfile;
+import RTC.ExecutionContextProfile;
+import RTC.PortProfile;
+import RTC.RTObject;
+import _SDOPackage.Configuration;
+import _SDOPackage.Organization;
+import _SDOPackage.ServiceProfile;
 import jp.go.aist.rtm.toolscommon.model.component.Component;
 import jp.go.aist.rtm.toolscommon.model.component.ComponentFactory;
 import jp.go.aist.rtm.toolscommon.model.component.ComponentPackage;
@@ -43,25 +60,6 @@ import jp.go.aist.rtm.toolscommon.model.core.CorePackage;
 import jp.go.aist.rtm.toolscommon.model.core.impl.CorePackageImpl;
 import jp.go.aist.rtm.toolscommon.model.manager.ManagerPackage;
 import jp.go.aist.rtm.toolscommon.model.manager.impl.ManagerPackageImpl;
-
-import org.eclipse.emf.ecore.EAttribute;
-import org.eclipse.emf.ecore.EClass;
-import org.eclipse.emf.ecore.EDataType;
-import org.eclipse.emf.ecore.EEnum;
-import org.eclipse.emf.ecore.EOperation;
-import org.eclipse.emf.ecore.EPackage;
-import org.eclipse.emf.ecore.EReference;
-import org.eclipse.emf.ecore.impl.EPackageImpl;
-
-import org.omg.PortableServer.Servant;
-import RTC.ComponentProfile;
-import RTC.ExecutionContextProfile;
-import RTC.ExecutionContextService;
-import RTC.PortProfile;
-import RTC.RTObject;
-import _SDOPackage.Configuration;
-import _SDOPackage.Organization;
-import _SDOPackage.ServiceProfile;
 
 /**
  * <!-- begin-user-doc -->
@@ -385,7 +383,7 @@ public class ComponentPackageImpl extends EPackageImpl implements ComponentPacka
 
 	/**
 	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
-	 * 
+	 *
 	 * <p>This method is used to initialize {@link ComponentPackage#eINSTANCE} when that field is accessed.
 	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
 	 * <!-- begin-user-doc -->
@@ -420,7 +418,7 @@ public class ComponentPackageImpl extends EPackageImpl implements ComponentPacka
 		// Mark meta-data to indicate it can't be changed
 		theComponentPackage.freeze();
 
-  
+
 		// Update the registry and return the package
 		EPackage.Registry.INSTANCE.put(ComponentPackage.eNS_URI, theComponentPackage);
 		return theComponentPackage;

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaExecutionContextImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaExecutionContextImpl.java
@@ -10,13 +10,21 @@ import static jp.go.aist.rtm.toolscommon.model.component.impl.CorbaComponentImpl
 import static jp.go.aist.rtm.toolscommon.model.component.impl.CorbaComponentImpl.synchronizeRemote_EC_ComponentState;
 import static jp.go.aist.rtm.toolscommon.util.RTMixin.eql;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import RTC.ExecutionContextProfile;
+import RTC.ReturnCode_t;
+import _SDOPackage.NameValue;
 import jp.go.aist.rtm.toolscommon.model.component.Component;
-import jp.go.aist.rtm.toolscommon.model.component.ComponentFactory;
 import jp.go.aist.rtm.toolscommon.model.component.ComponentPackage;
 import jp.go.aist.rtm.toolscommon.model.component.CorbaComponent;
 import jp.go.aist.rtm.toolscommon.model.component.CorbaExecutionContext;
@@ -36,17 +44,6 @@ import jp.go.aist.rtm.toolscommon.synchronizationframework.mapping.ManyReference
 import jp.go.aist.rtm.toolscommon.synchronizationframework.mapping.MappingRule;
 import jp.go.aist.rtm.toolscommon.synchronizationframework.mapping.OneReferenceMapping;
 import jp.go.aist.rtm.toolscommon.synchronizationframework.mapping.ReferenceMapping;
-
-import org.eclipse.emf.common.notify.Notification;
-import org.eclipse.emf.common.util.EList;
-import org.eclipse.emf.ecore.EClass;
-import org.eclipse.emf.ecore.impl.ENotificationImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import RTC.ExecutionContextProfile;
-import RTC.ReturnCode_t;
-import _SDOPackage.NameValue;
 
 /**
  * <!-- begin-user-doc -->

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/core/impl/CoreFactoryImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/core/impl/CoreFactoryImpl.java
@@ -6,9 +6,14 @@
  */
 package jp.go.aist.rtm.toolscommon.model.core.impl;
 
-import jp.go.aist.rtm.toolscommon.model.core.*;
-
 import java.util.StringTokenizer;
+
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EDataType;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.impl.EFactoryImpl;
+import org.eclipse.emf.ecore.plugin.EcorePlugin;
 
 import jp.go.aist.rtm.toolscommon.corba.CorbaUtil;
 import jp.go.aist.rtm.toolscommon.model.core.CoreFactory;
@@ -18,13 +23,6 @@ import jp.go.aist.rtm.toolscommon.model.core.Point;
 import jp.go.aist.rtm.toolscommon.model.core.Rectangle;
 import jp.go.aist.rtm.toolscommon.model.core.Visiter;
 import jp.go.aist.rtm.toolscommon.model.core.WrapperObject;
-
-import org.eclipse.emf.ecore.EClass;
-import org.eclipse.emf.ecore.EDataType;
-import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.EPackage;
-import org.eclipse.emf.ecore.impl.EFactoryImpl;
-import org.eclipse.emf.ecore.plugin.EcorePlugin;
 
 /**
  * <!-- begin-user-doc --> An implementation of the model <b>Factory</b>. <!--
@@ -178,7 +176,7 @@ public class CoreFactoryImpl extends EFactoryImpl implements CoreFactory {
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * 
+	 *
 	 * @generated NOT
 	 */
 	public org.omg.CORBA.Object createObjectFromString(EDataType eDataType,
@@ -209,7 +207,7 @@ public class CoreFactoryImpl extends EFactoryImpl implements CoreFactory {
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * 
+	 *
 	 */
 	public String convertPointToString(EDataType eDataType, Object instanceValue) {
 		Point point = ((Point) instanceValue);

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/core/util/CoreAdapterFactory.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/core/util/CoreAdapterFactory.java
@@ -6,19 +6,17 @@
  */
 package jp.go.aist.rtm.toolscommon.model.core.util;
 
-import jp.go.aist.rtm.toolscommon.model.core.*;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.emf.common.notify.Adapter;
+import org.eclipse.emf.common.notify.Notifier;
+import org.eclipse.emf.common.notify.impl.AdapterFactoryImpl;
+import org.eclipse.emf.ecore.EObject;
 
 import jp.go.aist.rtm.toolscommon.model.core.CorbaWrapperObject;
 import jp.go.aist.rtm.toolscommon.model.core.CorePackage;
 import jp.go.aist.rtm.toolscommon.model.core.ModelElement;
 import jp.go.aist.rtm.toolscommon.model.core.WrapperObject;
 import jp.go.aist.rtm.toolscommon.synchronizationframework.LocalObject;
-
-import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.emf.common.notify.Adapter;
-import org.eclipse.emf.common.notify.Notifier;
-import org.eclipse.emf.common.notify.impl.AdapterFactoryImpl;
-import org.eclipse.emf.ecore.EObject;
 
 /**
  * <!-- begin-user-doc -->

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/core/util/CoreSwitch.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/core/util/CoreSwitch.java
@@ -8,17 +8,15 @@ package jp.go.aist.rtm.toolscommon.model.core.util;
 
 import java.util.List;
 
-import jp.go.aist.rtm.toolscommon.model.core.*;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EObject;
 
 import jp.go.aist.rtm.toolscommon.model.core.CorbaWrapperObject;
 import jp.go.aist.rtm.toolscommon.model.core.CorePackage;
 import jp.go.aist.rtm.toolscommon.model.core.ModelElement;
 import jp.go.aist.rtm.toolscommon.model.core.WrapperObject;
 import jp.go.aist.rtm.toolscommon.synchronizationframework.LocalObject;
-
-import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.emf.ecore.EClass;
-import org.eclipse.emf.ecore.EObject;
 
 /**
  * <!-- begin-user-doc --> The <b>Switch</b> for the model's inheritance

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/manager/impl/RTCManagerImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/manager/impl/RTCManagerImpl.java
@@ -6,11 +6,24 @@
  */
 package jp.go.aist.rtm.toolscommon.model.manager.impl;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.common.util.BasicEList;
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
+import org.eclipse.emf.ecore.util.EDataTypeUniqueEList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import RTC.ComponentProfile;
+import RTC.RTObject;
+import RTM.ManagerHelper;
+import RTM.ManagerProfile;
+import RTM.ModuleProfile;
 import jp.go.aist.rtm.toolscommon.model.component.Component;
 import jp.go.aist.rtm.toolscommon.model.component.ComponentFactory;
 import jp.go.aist.rtm.toolscommon.model.component.NameValue;
@@ -28,23 +41,6 @@ import jp.go.aist.rtm.toolscommon.synchronizationframework.mapping.ConstructorPa
 import jp.go.aist.rtm.toolscommon.synchronizationframework.mapping.MappingRule;
 import jp.go.aist.rtm.toolscommon.synchronizationframework.mapping.ReferenceMapping;
 import jp.go.aist.rtm.toolscommon.util.SDOUtil;
-
-import org.eclipse.emf.common.notify.Notification;
-import org.eclipse.emf.common.util.BasicEList;
-import org.eclipse.emf.common.util.EList;
-import org.eclipse.emf.ecore.EClass;
-import org.eclipse.emf.ecore.EReference;
-import org.eclipse.emf.ecore.impl.ENotificationImpl;
-import org.eclipse.emf.ecore.util.EDataTypeUniqueEList;
-import org.eclipse.emf.ecore.util.EObjectResolvingEList;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import RTC.ComponentProfile;
-import RTC.RTObject;
-import RTM.ManagerHelper;
-import RTM.ManagerProfile;
-import RTM.ModuleProfile;
 
 /**
  * <!-- begin-user-doc --> An implementation of the model object '<em><b>RTC Manager</b></em>'.
@@ -567,7 +563,7 @@ public class RTCManagerImpl extends CorbaWrapperObjectImpl implements
 		} else {
 			loadedModuleProfiles.clear();
 		}
-		
+
 		RTM.Manager[] managers = this.getCorbaObjectInterface().get_slave_managers();
 		for(RTM.Manager targetMng : managers) {
 			String managerName = SDOUtil.findValueAsString("instance_name", targetMng.get_profile().properties);

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/manager/validation/RTCManagerValidator.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/manager/validation/RTCManagerValidator.java
@@ -6,11 +6,9 @@
  */
 package jp.go.aist.rtm.toolscommon.model.manager.validation;
 
-import RTC.ComponentProfile;
-import RTM.ManagerProfile;
-
-import RTM.ModuleProfile;
 import org.eclipse.emf.common.util.EList;
+
+import RTM.ManagerProfile;
 
 /**
  * A sample validator interface for {@link jp.go.aist.rtm.toolscommon.model.manager.RTCManager}.

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/util/RtsProfileHandler.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/util/RtsProfileHandler.java
@@ -15,6 +15,23 @@ import java.util.Map;
 
 import javax.xml.datatype.DatatypeFactory;
 
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.emf.common.util.EList;
+import org.openrtp.namespaces.rts.version02.Activation;
+import org.openrtp.namespaces.rts.version02.Condition;
+import org.openrtp.namespaces.rts.version02.Deactivation;
+import org.openrtp.namespaces.rts.version02.Finalize;
+import org.openrtp.namespaces.rts.version02.Initialize;
+import org.openrtp.namespaces.rts.version02.MessageSending;
+import org.openrtp.namespaces.rts.version02.Resetting;
+import org.openrtp.namespaces.rts.version02.Shutdown;
+import org.openrtp.namespaces.rts.version02.Startup;
+import org.openrtp.namespaces.rts.version02.TargetComponent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sun.org.apache.xerces.internal.jaxp.datatype.DatatypeFactoryImpl;
+
 import jp.go.aist.rtm.toolscommon.corba.CorbaUtil;
 import jp.go.aist.rtm.toolscommon.factory.ComponentLoader;
 import jp.go.aist.rtm.toolscommon.model.component.Component;
@@ -35,27 +52,9 @@ import jp.go.aist.rtm.toolscommon.model.core.Point;
 import jp.go.aist.rtm.toolscommon.model.core.Rectangle;
 import jp.go.aist.rtm.toolscommon.profiles.util.XmlHandler;
 
-import org.apache.commons.lang.StringUtils;
-import org.eclipse.emf.common.util.EList;
-import org.openrtp.namespaces.rts.version02.Activation;
-import org.openrtp.namespaces.rts.version02.Condition;
-import org.openrtp.namespaces.rts.version02.Deactivation;
-import org.openrtp.namespaces.rts.version02.Finalize;
-import org.openrtp.namespaces.rts.version02.Initialize;
-import org.openrtp.namespaces.rts.version02.MessageSending;
-import org.openrtp.namespaces.rts.version02.Resetting;
-import org.openrtp.namespaces.rts.version02.Shutdown;
-import org.openrtp.namespaces.rts.version02.Startup;
-import org.openrtp.namespaces.rts.version02.TargetComponent;
-import org.openrtp.namespaces.rts.version02.TargetComponentExt;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.sun.org.apache.xerces.internal.jaxp.datatype.DatatypeFactoryImpl;
-
 /**
  * RTSプロファイルの入出力を司るクラス
- * 
+ *
  */
 public class RtsProfileHandler extends ProfileHandlerBase {
 
@@ -177,7 +176,7 @@ public class RtsProfileHandler extends ProfileHandlerBase {
 
     /**
 	 * ECを復元させる
-	 * 
+	 *
 	 * @param eDiagram
 	 */
 	public void restoreExecutionContext(SystemDiagram eDiagram) {
@@ -252,7 +251,7 @@ public class RtsProfileHandler extends ProfileHandlerBase {
 
 	/**
 	 * RTSプロファイルを保存する
-	 * 
+	 *
 	 * @param eDiagram
 	 * @return
 	 */
@@ -371,8 +370,8 @@ public class RtsProfileHandler extends ProfileHandlerBase {
 			/////
 			org.openrtp.namespaces.rts.version02.Component original = findOriginalComponent(eComp);
 
-			populateExecutionContext(eComp, target, original);			
-			populateComponentLocation(eComp, target);			
+			populateExecutionContext(eComp, target, original);
+			populateComponentLocation(eComp, target);
 			populateComponentProperty(eComp, target, original);
 			populatePorts(eComp, target, original, rtsProfile);
 			populateConfigurationSet(eComp, target);
@@ -415,7 +414,7 @@ public class RtsProfileHandler extends ProfileHandlerBase {
 		targetCond.setSequence(BigInteger.valueOf(Integer.parseInt(strSeq)));
 		targetCond.setTargetComponent(targetComp);
 		return targetCond;
-		
+
 	}
 
 	// Save時にシステムダイアログ内に含まれるデータポートとそれらの接続をRTSプロファイル内にセットする
@@ -453,7 +452,7 @@ public class RtsProfileHandler extends ProfileHandlerBase {
 		String connectorId = eConnProf.getConnectorId();
 		if(savedConnectors.contains(connectorId) ) return;
 		rtsProfile.getDataPortConnectors().add(saveDataPortConnector(ePort, eConnProf));
-		savedConnectors.add(connectorId);		
+		savedConnectors.add(connectorId);
 	}
 
 	// サービスポートコネクタをRTSに追加する
@@ -464,7 +463,7 @@ public class RtsProfileHandler extends ProfileHandlerBase {
 		String connectorId = eConnProf.getConnectorId();
 		if(savedConnectors.contains(connectorId) ) return;
 		rtsProfile.getServicePortConnectors().add(saveServicePortConnector(ePort, eConnProf));
-		savedConnectors.add(connectorId);		
+		savedConnectors.add(connectorId);
 	}
 
 	// Save時にシステムダイアログ内に含まれるデータポート接続をRTSプロファイル内の該当要素に変換する
@@ -817,7 +816,7 @@ public class RtsProfileHandler extends ProfileHandlerBase {
 		target.getLocation().setWidth(BigInteger.valueOf(eComp.getConstraint().getWidth()));
 		target.getLocation().setDirection(eComp.getOutportDirection());
 	}
-	
+
 	// IORを保存する
 	private void populateIOR(
 			List<org.openrtp.namespaces.rts.version02.Property> rtsProperties,
@@ -1042,7 +1041,7 @@ public class RtsProfileHandler extends ProfileHandlerBase {
 			}
 		}
 	}
-	
+
 	private Component getTargetComp(String id, String instName, List<Component> compList) {
 		for(Component target : compList) {
 			if(target.getComponentId().equals(id) && target.getInstanceNameL().equals(instName)) {
@@ -1105,7 +1104,7 @@ public class RtsProfileHandler extends ProfileHandlerBase {
 					if (equalsPathId(eComp, tc)) {
 						eParentComponent.getComponents().add(eComp);
 						return false;
-					}	
+					}
 				}
 			}
 		}
@@ -1257,7 +1256,7 @@ public class RtsProfileHandler extends ProfileHandlerBase {
 					connBase.getSourceServicePort());
 		}
 	}
-	
+
 	private boolean isIOR(String value) {
 		return (value != null && value.startsWith("IOR:"));
 	}


### PR DESCRIPTION
## Identify the Bug
#1 

## Description of the Change
本現象は，RTCを瞬断のように強制終了/起動し，RTSE上でリフレッシュされるまでの間に DnD すると，ドロップの対象(List) が null になってしまう事が原因のようでした．
このため，ドロップ対象の RTCの Listが nullの場合にスキップする処理を追加するとともに，他ビューへのイベント伝達時に，nullが渡させてしまう場合があったため，その部分を修正させて頂きました．
更に併せて，使用していないコード，インポート文の削除，整理を行わせて頂きました．

## Verification 
- [x] Did you succesed the build?  Windows上でEclipse4.7.3を使用
- [x] No warnings for the build?  Windows上でEclipse4.7.3を使用
- [x] Have you passed the unit tests?  ユニットテスト無し
