### PR TITLE
Modified trying to activate child component when activating composite…

### DIFF
--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/factory/CompositeComponentCreator.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/factory/CompositeComponentCreator.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtension;
@@ -15,9 +16,7 @@ import jp.go.aist.rtm.systemeditor.corba.CORBAHelper;
 import jp.go.aist.rtm.systemeditor.extension.CreateCompositeComponentExtension;
 import jp.go.aist.rtm.systemeditor.ui.dialog.NewCompositeComponentDialog;
 import jp.go.aist.rtm.systemeditor.ui.editor.AbstractSystemDiagramEditor;
-import jp.go.aist.rtm.systemeditor.ui.util.TimeoutWrappedJob;
 import jp.go.aist.rtm.systemeditor.ui.util.TimeoutWrapper;
-import jp.go.aist.rtm.toolscommon.manager.ToolsCommonPreferenceManager;
 import jp.go.aist.rtm.toolscommon.model.component.Component;
 import jp.go.aist.rtm.toolscommon.model.component.ComponentFactory;
 import jp.go.aist.rtm.toolscommon.model.component.ConfigurationSet;
@@ -164,42 +163,37 @@ public class CompositeComponentCreator {
 	 * @return 生成された複合RTCのオブジェクト
 	 */
 	public Component create() {
-		int defaultTimeout = ToolsCommonPreferenceManager.getInstance()
-				.getDefaultTimeout(
-						ToolsCommonPreferenceManager.DEFAULT_TIMEOUT_PERIOD);
-		TimeoutWrapper wrapper = new TimeoutWrapper(defaultTimeout);
+		TimeoutWrapper wrapper = TimeoutWrapper.asDefault();
 		//
 		final CreateCompositeComponentExtension creator = findCreator();
 		if (creator == null) {
 			return null;
 		}
 		//
-		wrapper.setJob(new TimeoutWrappedJob() {
+		final Component comp = wrapper.start(new Callable<Component>() {
 			@Override
-			protected Object executeCommand() {
+			public Component call() throws Exception {
 				return creator.createComponent(base);
 			}
 		});
-		final Component comp = (Component) wrapper.start();
 		if (comp == null) {
 			return null;
 		}
 		//
-		wrapper.setJob(new TimeoutWrappedJob() {
+		final Component comp2 = wrapper.start(new Callable<Component>() {
 			@Override
-			protected Object executeCommand() {
+			public Component call() throws Exception {
 				return creator.setCompositeMembers(base, comp);
 			}
 		});
-		if (wrapper.start() == null && comp instanceof CorbaComponent) {
+		if (comp2 == null && comp instanceof CorbaComponent) {
 			final CorbaComponent corbaComp = (CorbaComponent) comp;
-			wrapper.setJob(new TimeoutWrappedJob() {
+			wrapper.start(new Callable<Integer>() {
 				@Override
-				protected Object executeCommand() {
+				public Integer call() throws Exception {
 					return corbaComp.exitR();
 				}
 			});
-			wrapper.start();
 		}
 		return comp;
 	}

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/manager/ComponentIconStore.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/manager/ComponentIconStore.java
@@ -198,18 +198,17 @@ public class ComponentIconStore {
 		if (!path.toFile().exists()) {
 			return null;
 		}
-		BufferedReader reader = new BufferedReader(new InputStreamReader(
-				new FileInputStream(path.toOSString()), "UTF-8"));
 		String xmlString = "";
-		while (true) {
-			String s = reader.readLine();
-			if (s == null) {
-				break;
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+				new FileInputStream(path.toOSString()), "UTF-8")) ) {
+			while (true) {
+				String s = reader.readLine();
+				if (s == null) {
+					break;
+				}
+				xmlString += s;
 			}
-			xmlString += s;
 		}
-		reader.close();
-		
 		IconProfileHandler handler = new IconProfileHandler();
 		ComponentIconStore result = handler.parse(xmlString);
 		return result;

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/action/CombineActionDelegate.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/action/CombineActionDelegate.java
@@ -4,14 +4,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import jp.go.aist.rtm.systemeditor.factory.CompositeComponentCreator;
-import jp.go.aist.rtm.systemeditor.nl.Messages;
-import jp.go.aist.rtm.systemeditor.ui.dialog.NewCompositeComponentDialog;
-import jp.go.aist.rtm.systemeditor.ui.editor.AbstractSystemDiagramEditor;
-import jp.go.aist.rtm.systemeditor.ui.editor.command.CombineCommand;
-import jp.go.aist.rtm.systemeditor.ui.editor.editpart.ComponentEditPart;
-import jp.go.aist.rtm.toolscommon.model.component.Component;
-
 import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.dialogs.IDialogConstants;
@@ -22,13 +14,20 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IEditorActionDelegate;
 import org.eclipse.ui.IEditorPart;
 
+import jp.go.aist.rtm.systemeditor.factory.CompositeComponentCreator;
+import jp.go.aist.rtm.systemeditor.nl.Messages;
+import jp.go.aist.rtm.systemeditor.ui.dialog.NewCompositeComponentDialog;
+import jp.go.aist.rtm.systemeditor.ui.editor.AbstractSystemDiagramEditor;
+import jp.go.aist.rtm.systemeditor.ui.editor.command.CombineCommand;
+import jp.go.aist.rtm.systemeditor.ui.editor.editpart.ComponentEditPart;
+import jp.go.aist.rtm.toolscommon.model.component.Component;
+
 /**
  * 複合コンポーネントを作成するアクション
  */
 public class CombineActionDelegate implements IEditorActionDelegate {
 
-	static final String DIALOG_TITLE_ERROR = Messages
-			.getString("Common.dialog.error_title");
+	static final String DIALOG_TITLE_ERROR = Messages.getString("Common.dialog.error_title");
 
 	private ISelection selection;
 	private AbstractSystemDiagramEditor targetEditor;
@@ -36,7 +35,6 @@ public class CombineActionDelegate implements IEditorActionDelegate {
 
 	/**
 	 * アクションのメインの実行メソッド
-	 * 
 	 */
 	public void run(final IAction action) {
 		if (selectedComponents.size() == 0) {
@@ -48,19 +46,20 @@ public class CombineActionDelegate implements IEditorActionDelegate {
 		creator.setTargetEditor(targetEditor);
 		creator.setComponents(selectedComponents);
 		if (!creator.canCreate()) {
-			MessageDialog.openError(shell, DIALOG_TITLE_ERROR, creator
-					.getMessage());
+			MessageDialog.openError(shell, DIALOG_TITLE_ERROR, creator.getMessage());
 			return;
 		}
 
-		NewCompositeComponentDialog dialog = new NewCompositeComponentDialog(
-				shell, creator, selectedComponents, targetEditor
-						.getSystemDiagram().getComponents());
+		NewCompositeComponentDialog dialog = new NewCompositeComponentDialog(shell, creator, selectedComponents,
+				targetEditor.getSystemDiagram().getComponents());
 		int open = dialog.open();
 		if (open != IDialogConstants.OK_ID) {
 			return;
 		}
 		Component compositeComponent = creator.create();
+		if (compositeComponent == null) {
+			return;
+		}
 
 		// ダイアグラムへの登録はCombineCommandで行う
 		CombineCommand command = new CombineCommand();
@@ -68,8 +67,7 @@ public class CombineActionDelegate implements IEditorActionDelegate {
 		command.setTarget(compositeComponent);
 		targetEditor.deselectAll();
 		if (targetEditor.getAdapter(CommandStack.class) != null) {
-			((CommandStack) targetEditor.getAdapter(CommandStack.class))
-					.execute(command);
+			((CommandStack) targetEditor.getAdapter(CommandStack.class)).execute(command);
 		} else {
 			throw new RuntimeException();
 		}
@@ -88,12 +86,10 @@ public class CombineActionDelegate implements IEditorActionDelegate {
 	private boolean isEnable() {
 		selectedComponents = new ArrayList<Component>();
 		if (selection instanceof IStructuredSelection) {
-			for (Iterator<?> iterator = ((IStructuredSelection) selection)
-					.iterator(); iterator.hasNext();) {
+			for (Iterator<?> iterator = ((IStructuredSelection) selection).iterator(); iterator.hasNext();) {
 				Object part = iterator.next();
 				if (part instanceof ComponentEditPart) {
-					selectedComponents.add(((ComponentEditPart) part)
-							.getModel());
+					selectedComponents.add(((ComponentEditPart) part).getModel());
 				}
 			}
 		}

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/command/CombineCommand.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/command/CombineCommand.java
@@ -3,18 +3,19 @@ package jp.go.aist.rtm.systemeditor.ui.editor.command;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.gef.commands.Command;
+
 import jp.go.aist.rtm.toolscommon.model.component.Component;
 import jp.go.aist.rtm.toolscommon.model.component.ConnectorProfile;
 import jp.go.aist.rtm.toolscommon.model.component.Port;
 import jp.go.aist.rtm.toolscommon.model.component.SystemDiagram;
 
-import org.eclipse.emf.common.util.EList;
-import org.eclipse.gef.commands.Command;
-
 /**
  * システムダイアグラムに複合Rtcを追加するコマンド
  */
 public class CombineCommand extends Command {
+
 	private SystemDiagram parent;
 
 	// 複合RTC
@@ -27,24 +28,21 @@ public class CombineCommand extends Command {
 	public void execute() {
 		// 複合コンポーネントの子ウィンドウにて複合コンポーネントを作成したときの処理
 		adjustParentDiagram(target.getComponents());
-		
+
 		// 子RTCをダイアグラムから消す
 		parent.removeComponents(target.getComponents());
-		
+
 		// 子RTCのポートにつながっていた接続を消す
 		removeConnections(target.getComponents());
-		
+
 		// 複合コンポーネントをダイアグラムに追加する
 		parent.addComponent(target);
 	}
 
-	private void removeConnections(EList<?> components) {
-		for (Object o : components) {
-			Component c = (Component)o;
-			for (Object o2 :c.getPorts()) {
-				Port p = (Port)o2;
-				for (Object o3 :p.getConnectorProfiles()) {
-					ConnectorProfile cp = (ConnectorProfile)o3;
+	private void removeConnections(EList<Component> components) {
+		for (Component c : components) {
+			for (Port p : c.getPorts()) {
+				for (ConnectorProfile cp : p.getConnectorProfiles()) {
 					parent.getConnectorMap().remove(cp.getConnectorId());
 				}
 			}
@@ -53,17 +51,20 @@ public class CombineCommand extends Command {
 
 	private void adjustParentDiagram(List<Component> selectedComponents) {
 		Component parentCompositeComponent = parent.getCompositeComponent();
-		if (parentCompositeComponent == null) return;
-		
+		if (parentCompositeComponent == null) {
+			return;
+		}
 		// サーバに対して、set_membersを呼び出す
 		parentCompositeComponent.setComponentsR(getTargets());
 	}
 
 	private List<Component> getTargets() {
 		List<Component> targets = new ArrayList<Component>();
-		for (Object o : parent.getComponents()) {
-			if (target.getComponents().contains(o)) continue;
-			targets.add((Component)o);
+		for (Component c : parent.getComponents()) {
+			if (target.getComponents().contains(c)) {
+				continue;
+			}
+			targets.add(c);
 		}
 		targets.add(target);
 		return targets;
@@ -72,8 +73,7 @@ public class CombineCommand extends Command {
 	/**
 	 * 親となるシステムダイアグラムを設定する
 	 * 
-	 * @param parent
-	 *            親となるシステムダイアグラム
+	 * @param parent 親となるシステムダイアグラム
 	 */
 	public void setParent(SystemDiagram parent) {
 		this.parent = parent;
@@ -82,8 +82,7 @@ public class CombineCommand extends Command {
 	/**
 	 * 複合コンポーネントを設定する
 	 * 
-	 * @param target
-	 *            複合コンポーネント
+	 * @param target 複合コンポーネント
 	 */
 	public void setTarget(Component target) {
 		this.target = target;
@@ -95,4 +94,5 @@ public class CombineCommand extends Command {
 	 */
 	public void undo() {
 	}
+
 }

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/command/DeleteCommand.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/command/DeleteCommand.java
@@ -1,19 +1,27 @@
 package jp.go.aist.rtm.systemeditor.ui.editor.command;
 
+import java.util.concurrent.Callable;
+
+import org.eclipse.gef.commands.Command;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import jp.go.aist.rtm.systemeditor.nl.Messages;
 import jp.go.aist.rtm.systemeditor.ui.editor.AbstractSystemDiagramEditor;
 import jp.go.aist.rtm.systemeditor.ui.util.ComponentUtil;
 import jp.go.aist.rtm.systemeditor.ui.util.CompositeComponentHelper;
+import jp.go.aist.rtm.systemeditor.ui.util.TimeoutWrapper;
 import jp.go.aist.rtm.toolscommon.model.component.Component;
 import jp.go.aist.rtm.toolscommon.model.component.Port;
 import jp.go.aist.rtm.toolscommon.model.component.SystemDiagram;
-
-import org.eclipse.gef.commands.Command;
 
 /**
  * Rtcを削除する削除コマンド
  */
 public class DeleteCommand extends Command {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(DeleteCommand.class);
+
 	private SystemDiagram parent;
 
 	private Component target;
@@ -23,30 +31,18 @@ public class DeleteCommand extends Command {
 	 * {@inheritDoc}
 	 */
 	public void execute() {
-		if (!CompositeComponentHelper.openConfirm(target, Messages.getString("DeleteCommand.1"))) //$NON-NLS-1$
+		if (!CompositeComponentHelper.openConfirm(target, Messages.getString("DeleteCommand.1"))) {
 			return;
-		
+		}
+
 		disconnectAll();
 
 		// 開いたエディタを閉じる
 		ComponentUtil.closeCompositeComponent(target);
-		
+
 		// 削除実行
 		if (parent.getCompositeComponent() != null) {
-			// 自身が複合RTCの子の場合は複合RTCから外す
-			if (parent.getCompositeComponent().removeComponentR(target)) {
-				// 親エディタに自身を追加する
-				SystemDiagram parentSystemDiagram = parent
-						.getParentSystemDiagram();
-				parentSystemDiagram.addComponent(target);
-				// ネストしている場合はメンバーの再設定が必要
-				if (parentSystemDiagram.getCompositeComponent() != null) {
-					parentSystemDiagram.getCompositeComponent().setComponentsR(
-							parentSystemDiagram.getComponents());
-				}
-				// 画面更新
-				ComponentUtil.findEditor(parentSystemDiagram).refresh();
-			}
+			renestComposite();
 		} else {
 			// ダイアグラムからコンポーネントを削除する
 			parent.removeComponent(target);
@@ -59,13 +55,74 @@ public class DeleteCommand extends Command {
 		}
 	}
 
+	private void renestComposite() {
+		TimeoutWrapper wrapper = TimeoutWrapper.asDefault();
+
+		// 自身が複合RTCの子の場合は複合RTCから外す
+		{
+			Boolean result = wrapper.start(new Callable<Boolean>() {
+				@Override
+				public Boolean call() throws Exception {
+					return parent.getCompositeComponent().removeComponentR(target);
+				}
+			});
+			if (result == null || !result) {
+				LOGGER.error("Fail to remove from parent-composite. composite=<{}>", parent.getCompositeComponent());
+				return;
+			}
+		}
+		// 親エディタに自身を追加する
+		SystemDiagram parentSystemDiagram = parent.getParentSystemDiagram();
+		{
+			Boolean result = wrapper.start(new Callable<Boolean>() {
+				@Override
+				public Boolean call() throws Exception {
+					parentSystemDiagram.addComponent(target);
+					return Boolean.TRUE;
+				}
+			});
+			if (result == null || !result) {
+				LOGGER.error("Fail to add to parent-diagram. diagram=<{}>", parentSystemDiagram);
+				return;
+			}
+		}
+		// ネストしている場合はメンバーの再設定が必要
+		Component parentComposite = parentSystemDiagram.getCompositeComponent();
+		if (parentComposite != null) {
+			Boolean result = wrapper.start(new Callable<Boolean>() {
+				@Override
+				public Boolean call() throws Exception {
+					return parentComposite.setComponentsR(parentSystemDiagram.getComponents());
+				}
+			});
+			if (result == null || !result) {
+				LOGGER.error("Fail to re-set components to parent-composite. composite=<{}>", parentComposite);
+				return;
+			}
+		}
+		// 画面更新
+		ComponentUtil.findEditor(parentSystemDiagram).refresh();
+	}
+
 	/**
 	 * オフラインエディタの場合にだけ、接続をすべて解除する
 	 */
 	private void disconnectAll() {
-		if (target.inOnlineSystemDiagram()) return;
-		for (Object obj: target.getPorts()) {
-			Port port = (Port) obj;
+		if (target.inOnlineSystemDiagram()) {
+			return;
+		}
+		TimeoutWrapper wrapper = TimeoutWrapper.asDefault();
+		for (Port port : target.getPorts()) {
+			Boolean result = wrapper.start(new Callable<Boolean>() {
+				@Override
+				public Boolean call() throws Exception {
+					return port.getSynchronizer().disconnectAll();
+				}
+			});
+			if (result == null || !result) {
+				LOGGER.error("Fail to disconnect-all. port=<{}>", port);
+				return;
+			}
 			port.disconnectAll();
 		}
 	}
@@ -73,8 +130,7 @@ public class DeleteCommand extends Command {
 	/**
 	 * 親のシステムダイアグラムを設定する
 	 * 
-	 * @param parent
-	 *            親のシステムダイアグラム
+	 * @param parent 親のシステムダイアグラム
 	 */
 	public void setParent(SystemDiagram parent) {
 		this.parent = parent;
@@ -83,8 +139,7 @@ public class DeleteCommand extends Command {
 	/**
 	 * 変更対象のコンポーネント
 	 * 
-	 * @param target
-	 *            コンポーネント
+	 * @param target コンポーネント
 	 */
 	public void setTarget(Component target) {
 		this.target = target;
@@ -96,4 +151,5 @@ public class DeleteCommand extends Command {
 	 */
 	public void undo() {
 	}
+
 }

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/util/RTMixin.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/util/RTMixin.java
@@ -1,5 +1,14 @@
 package jp.go.aist.rtm.systemeditor.ui.util;
 
+import java.util.concurrent.Callable;
+
+import org.slf4j.Logger;
+
+import jp.go.aist.rtm.toolscommon.model.component.CorbaComponent;
+import jp.go.aist.rtm.toolscommon.model.component.CorbaExecutionContext;
+import jp.go.aist.rtm.toolscommon.model.core.CorbaWrapperObject;
+import jp.go.aist.rtm.toolscommon.model.manager.RTCManager;
+
 /**
  * staticメソッドのみ定義
  */
@@ -33,6 +42,45 @@ public class RTMixin {
 			return "null";
 		}
 		return o.getClass().getSimpleName() + "@" + Integer.toHexString(o.hashCode());
+	}
+
+	public static <T> T nvl(T t, T defaultValue) {
+		return (t != null) ? t : defaultValue;
+	}
+
+	/** CORBAリクエストの呼び出しをラップしてログ出力 */
+	public static <T> T LOG_R(Logger log, String method, Object target, Callable<T> call) {
+		log.info("RTP->RTM : {}", method);
+		log.info("note right: {}", LOG_TID(target));
+		try {
+			T ret = call.call();
+			log.info("RTP<-RTM : {}", ret);
+			return ret;
+		} catch (Exception e) {
+			log.info("RTP<-RTM : <<exception>> {}", e.getMessage());
+			log.error("ERROR", e);
+			return null;
+		}
+	}
+
+	/** ログ用にターゲットを文字列化 */
+	public static String LOG_TID(Object o) {
+		if (o instanceof CorbaComponent) {
+			CorbaComponent c = (CorbaComponent) o;
+			return String.format("RTC(name=%s):%s", c.getInstanceNameL(), c.getCorbaObjectInterface());
+		} else if (o instanceof CorbaExecutionContext) {
+			CorbaExecutionContext c = (CorbaExecutionContext) o;
+			String owner = (c.getOwner() != null) ? c.getOwner().getInstanceNameL() : "unknown";
+			return String.format("EC(owner=%s):%s", owner, c.getCorbaObjectInterface());
+		} else if (o instanceof RTCManager) {
+			RTCManager c = (RTCManager) o;
+			return String.format("Manager(name=%s):%s", c.getInstanceNameL(), c.getCorbaObjectInterface());
+		} else if (o instanceof CorbaWrapperObject) {
+			CorbaWrapperObject c = (CorbaWrapperObject) o;
+			return String.format("CORBA.Object:%s", c.getCorbaObjectInterface());
+		} else {
+			return to_cid(o);
+		}
 	}
 
 }

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/util/TimeoutWrapper.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/util/TimeoutWrapper.java
@@ -1,39 +1,61 @@
 package jp.go.aist.rtm.systemeditor.ui.util;
 
-import jp.go.aist.rtm.systemeditor.nl.Messages;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.ui.PlatformUI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jp.go.aist.rtm.systemeditor.nl.Messages;
+import jp.go.aist.rtm.toolscommon.manager.ToolsCommonPreferenceManager;
 
 /**
  * 時間のかかる処理を別スレッドで行い、指定された時間内に終わらなければ、エラーメッセージを表示するクラス
- *
  */
 public class TimeoutWrapper {
-	private long milliSecond;
-	private TimeoutWrappedJob job;
 
-	public TimeoutWrapper(long milliSecond) {
+	private static final Logger LOGGER = LoggerFactory.getLogger(TimeoutWrapper.class);
+
+	private long milliSecond;
+
+	private ExecutorService executor;
+
+	public static TimeoutWrapper of(long millisecond) {
+		return new TimeoutWrapper(millisecond);
+	}
+
+	public static TimeoutWrapper asDefault() {
+		int defaultTimeout = ToolsCommonPreferenceManager.getInstance()
+				.getDefaultTimeout(ToolsCommonPreferenceManager.DEFAULT_TIMEOUT_PERIOD);
+		return new TimeoutWrapper(defaultTimeout);
+	}
+
+	private TimeoutWrapper(long milliSecond) {
 		this.milliSecond = milliSecond;
+		this.executor = Executors.newFixedThreadPool(1);
 	}
-	
-	public void setJob(TimeoutWrappedJob job) {
-		this.job = job;
-	}
-	
-	public Object start() {
-		job.setDaemon(true);
-		job.start();
-		synchronized (job) {
-			try {
-				job.wait(milliSecond);
-			} catch (InterruptedException e) {
-			}
+
+	public <T> T start(Callable<T> c) {
+		Future<T> future = this.executor.submit(c);
+		try {
+			T ret = future.get(this.milliSecond, TimeUnit.MILLISECONDS);
+			return ret;
+		} catch (TimeoutException e) {
+			// タイムアウト発生
+			MessageDialog.openError(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
+					Messages.getString("TimeoutWrapper.0"), Messages.getString("TimeoutWrapper.1"));
+			return null;
+		} catch (InterruptedException | ExecutionException e) {
+			LOGGER.error("Fail to get future", e);
+			return null;
 		}
-		if (job.isDone()) return job.getResult();
-		MessageDialog.openError(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell()
-				, Messages.getString("TimeoutWrapper.0"), //$NON-NLS-1$
-				Messages.getString("TimeoutWrapper.1"));
-		return null;
 	}
+
 }

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/executioncontextview/ExecutionContextView.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/executioncontextview/ExecutionContextView.java
@@ -52,10 +52,15 @@ import org.eclipse.ui.ISelectionListener;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.part.ViewPart;
 import org.eclipse.ui.views.properties.IPropertySheetPage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import static jp.go.aist.rtm.systemeditor.ui.util.RTMixin.LOG_R;
 import static jp.go.aist.rtm.systemeditor.ui.util.UIUtil.*;
 
 public class ExecutionContextView extends ViewPart {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ExecutionContextView.class);
 
 	static final int EXEC_BUTTON_WIDTH = 80;
 
@@ -331,7 +336,9 @@ public class ExecutionContextView extends ViewPart {
 
 					@Override
 					public int run() {
-						return ec.startR();
+						return LOG_R(LOGGER, "start()", ec, () -> {
+							return ec.startR();
+						});
 					}
 				};
 				if (!command.isValid()) {
@@ -361,7 +368,9 @@ public class ExecutionContextView extends ViewPart {
 
 					@Override
 					public int run() {
-						return ec.stopR();
+						return LOG_R(LOGGER, "stop()", ec, () -> {
+							return ec.stopR();
+						});
 					}
 				};
 				if (!command.isValid()) {
@@ -393,7 +402,9 @@ public class ExecutionContextView extends ViewPart {
 
 					@Override
 					public int run() {
-						return ec.activateR(comp);
+						return LOG_R(LOGGER, "activate()", comp, () -> {
+							return ec.activateR(comp);
+						});
 					}
 				};
 				if (!command.isValid()) {
@@ -425,7 +436,9 @@ public class ExecutionContextView extends ViewPart {
 
 					@Override
 					public int run() {
-						return ec.deactivateR(comp);
+						return LOG_R(LOGGER, "deactivate()", comp, () -> {
+							return ec.deactivateR(comp);
+						});
 					}
 				};
 				if (!command.isValid()) {
@@ -457,7 +470,9 @@ public class ExecutionContextView extends ViewPart {
 
 					@Override
 					public int run() {
-						return ec.resetR(comp);
+						return LOG_R(LOGGER, "reset()", comp, () -> {
+							return ec.resetR(comp);
+						});
 					}
 				};
 				if (!command.isValid()) {
@@ -488,7 +503,9 @@ public class ExecutionContextView extends ViewPart {
 
 					@Override
 					public int run() {
-						return (ec.removeComponentR(comp)) ? 0 : 1;
+						return LOG_R(LOGGER, "removeComponent()", ec, () -> {
+							return (ec.removeComponentR(comp)) ? 0 : 1;
+						});
 					}
 				};
 				if (!command.isValid()) {
@@ -525,7 +542,9 @@ public class ExecutionContextView extends ViewPart {
 
 					@Override
 					public int run() {
-						return (ec.addComponentR(comp)) ? 0 : 1;
+						return LOG_R(LOGGER, "addComponent()", ec, () -> {
+							return (ec.addComponentR(comp)) ? 0 : 1;
+						});
 					}
 				};
 				if (!command.isValid()) {
@@ -985,6 +1004,7 @@ public class ExecutionContextView extends ViewPart {
 				return;
 			}
 			targetComponent = comp;
+			ExecutionContext targetEc = ctxt;
 			//
 			targetComponent.eAdapters().remove(eAdapter);
 			for (ExecutionContext ec : targetComponent.getExecutionContexts()) {

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/manager/ToolsCommonPreferenceManager.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/manager/ToolsCommonPreferenceManager.java
@@ -58,7 +58,7 @@ public class ToolsCommonPreferenceManager {
 	/**
 	 * デフォルトタイムアウト判定時間
 	 */
-	public static final int defaultTimeoutPeriod = 1000;
+	public static final int defaultTimeoutPeriod = 10000;
 
 	/** 状態通知オブザーバ (デフォルト 有効) */
 	public static final Boolean DEFAULT_STATUS_OBSERVER_HB_ENABLE = true;

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaComponentImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaComponentImpl.java
@@ -16,27 +16,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import org.eclipse.emf.common.notify.Notification;
-import org.eclipse.emf.common.util.EList;
-import org.eclipse.emf.ecore.EClass;
-import org.eclipse.emf.ecore.EStructuralFeature;
-import org.eclipse.emf.ecore.impl.ENotificationImpl;
-import org.eclipse.emf.ecore.util.EDataTypeEList;
-import org.eclipse.emf.ecore.util.EDataTypeUniqueEList;
-import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.ui.views.properties.IPropertySource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import RTC.ComponentProfile;
-import RTC.RTObject;
-import RTC.ReturnCode_t;
-import _SDOPackage.Configuration;
-import _SDOPackage.InternalError;
-import _SDOPackage.InvalidParameter;
-import _SDOPackage.NotAvailable;
-import _SDOPackage.Organization;
-import _SDOPackage.SDO;
 import jp.go.aist.rtm.toolscommon.factory.CorbaWrapperFactory;
 import jp.go.aist.rtm.toolscommon.model.component.Component;
 import jp.go.aist.rtm.toolscommon.model.component.ComponentFactory;
@@ -71,6 +50,29 @@ import jp.go.aist.rtm.toolscommon.synchronizationframework.mapping.MappingRule;
 import jp.go.aist.rtm.toolscommon.synchronizationframework.mapping.ReferenceMapping;
 import jp.go.aist.rtm.toolscommon.ui.propertysource.ComponentPropertySource;
 import jp.go.aist.rtm.toolscommon.util.SDOUtil;
+
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
+import org.eclipse.emf.ecore.util.EDataTypeEList;
+import org.eclipse.emf.ecore.util.EDataTypeUniqueEList;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.ui.views.properties.IPropertySource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import RTC.ComponentProfile;
+import RTC.RTObject;
+import RTC.ReturnCode_t;
+import _SDOPackage.Configuration;
+import _SDOPackage.InternalError;
+import _SDOPackage.InvalidParameter;
+import _SDOPackage.NotAvailable;
+import _SDOPackage.Organization;
+import _SDOPackage.SDO;
 
 /**
  * <!-- begin-user-doc -->
@@ -1172,17 +1174,25 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 	public boolean setComponentsR(List<Component> componentList) {
 		try {
 			Organization org = getSDOOrganization();
-			if (org == null) return false;
-
+			if (org == null) {
+				return false;
+			}
 			List<SDO> list = new ArrayList<SDO>();
 			for (Object obj : componentList) {
 				if (!(obj instanceof CorbaComponent)) {
 					continue;
 				}
 				CorbaComponent comp = (CorbaComponent) obj;
-				list.add(comp.getCorbaObjectInterface());
-				if (!getComponents().contains(comp)) addComponent(comp);
+				RTObject ro = comp.getCorbaObjectInterface();
+				if (list.contains(ro)) {
+					continue; // 重複除外
+				}
+				list.add(ro);
+				if (!getComponents().contains(comp)) {
+					addComponent(comp);
+				}
 			}
+			LOGGER.trace("setComponentsR: members=<{}>", list);
 			return org.set_members(list.toArray(new SDO[0]));
 		} catch (NotAvailable e) {
 			LOGGER.error("Fail to set members (not available)", e);
@@ -1203,8 +1213,9 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 	public boolean addComponentsR(List<Component> componentList) {
 		try {
 			Organization org = getSDOOrganization();
-			if (org == null) return false;
-
+			if (org == null) {
+				return false;
+			}
 			List<SDO> list = new ArrayList<SDO>();
 			EList<Component> components = getComponents();
 			for (Component c : componentList) {
@@ -1212,14 +1223,15 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 					continue;
 				}
 				CorbaComponent comp = (CorbaComponent) c;
+				RTObject ro = comp.getCorbaObjectInterface();
 				// リモートオブジェクトが一致するコンポーネントがなければ、
 				// 自身を追加する(同期処理で子コンポーネントを複製防止)
-				if (this._findChildComponentByRemoteObject(comp
-						.getCorbaObject()) == null) {
-					list.add(comp.getCorbaObjectInterface());
+				if (this._findChildComponentByRemoteObject(ro) == null) {
+					list.add(ro);
 					components.add(comp);
 				}
 			}
+			LOGGER.trace("addComponentsR: members=<{}>", list);
 			return org.add_members(list.toArray(new SDO[0]));
 		} catch (NotAvailable e) {
 			LOGGER.error("Fail to add members (not available)", e);
@@ -1258,10 +1270,19 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 	public boolean removeComponentR(Component component) {
 		try {
 			Organization org = getSDOOrganization();
-			if (org == null) return false;
+			if (org == null) {
+				return false;
+			}
 			CorbaComponent corbaComponent = (CorbaComponent) component;
-			return org.remove_member(corbaComponent.getCorbaObjectInterface()
-					.get_sdo_id());
+			if (corbaComponent == null) {
+				return false;
+			}
+			RTObject ro = corbaComponent.getCorbaObjectInterface();
+			LOGGER.trace("removeComponentR: member=<{}>", ro);
+			if (ro == null) {
+				return false;
+			}
+			return org.remove_member(ro.get_sdo_id());
 		} catch (NotAvailable e) {
 			LOGGER.error("Fail to remove member (not available)", e);
 		} catch (InternalError e) {
@@ -1285,7 +1306,7 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 		}
 		return result;
 	}
-
+	
 	@Override
 	public boolean updateConfigurationSetR(ConfigurationSet configSet, boolean isActive) {
 		boolean result = false;
@@ -1299,7 +1320,7 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 				}
 			}
 			Configuration configuration = getSDOConfiguration();
-			_SDOPackage.ConfigurationSet sdoConfigurationSet =
+			_SDOPackage.ConfigurationSet sdoConfigurationSet = 
 				SDOUtil.createSdoConfigurationSet(configSet);
 			if (!exist) {
 				configuration.add_configuration_set(sdoConfigurationSet);
@@ -1324,7 +1345,7 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 	@Override
 	public String getComponentId() {
 		if (componentId != null) return componentId;
-		return "RTC:" + getVenderL() + ":"
+		return "RTC:" + getVenderL() + ":" 
 		+ getCategoryL() + ":"
 		+ getTypeNameL() + ":"
 		+ getVersionL();
@@ -1548,13 +1569,15 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 	}
 
 	public static void synchronizeRemote_RTCComponentProfile(RTC.RTObject ro) {
-		try {
-			RTC.ComponentProfile prof = ro.get_component_profile();
-			CorbaObjectStore.eINSTANCE.registRTCProfile(ro, prof);
-		} catch (Exception e) {
-			CorbaObjectStore.eINSTANCE.removeRTCProfile(ro);
-			LOGGER.error("Fail to sync RTC.ComponentProfile: rtc={}", ro);
-			LOGGER.error("ERROR:", e);
+		synchronized (CorbaObjectStore.eINSTANCE) {
+			try {
+				RTC.ComponentProfile prof = ro.get_component_profile();
+				CorbaObjectStore.eINSTANCE.registRTCProfile(ro, prof);
+			} catch (Exception e) {
+				CorbaObjectStore.eINSTANCE.removeRTCProfile(ro);
+				LOGGER.error("Fail to sync RTC.ComponentProfile: rtc={}", ro);
+				LOGGER.error("ERROR:", e);
+			}
 		}
 	}
 
@@ -1565,15 +1588,17 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 	}
 
 	public static void synchronizeRemote_RTCPortProfile(RTC.RTObject ro, String name) {
-		// LOGGER.debug("synchronizeRemote_RTCPortProfile: name={} ro={}", name,ro);
-		RTC.PortProfile prof = CorbaObjectStore.eINSTANCE.findRTCPortProfile(ro, name);
-		if (prof != null) {
-			try {
-				RTC.PortProfile pprof = prof.port_ref.get_port_profile();
-				CorbaObjectStore.eINSTANCE.registRTCPortProfile(ro, name, pprof);
-			} catch (Exception e) {
-				LOGGER.error("Fail to sync RTC.PortProfile: name={} rtc={}", name, ro);
-				LOGGER.error("ERROR:", e);
+		synchronized (CorbaObjectStore.eINSTANCE) {
+			// LOGGER.debug("synchronizeRemote_RTCPortProfile: name={} ro={}", name,ro);
+			RTC.PortProfile prof = CorbaObjectStore.eINSTANCE.findRTCPortProfile(ro, name);
+			if (prof != null) {
+				try {
+					RTC.PortProfile pprof = prof.port_ref.get_port_profile();
+					CorbaObjectStore.eINSTANCE.registRTCPortProfile(ro, name, pprof);
+				} catch (Exception e) {
+					LOGGER.error("Fail to sync RTC.PortProfile: name={} rtc={}", name, ro);
+					LOGGER.error("ERROR:", e);
+				}
 			}
 		}
 	}
@@ -1595,45 +1620,43 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 	}
 
 	public static void synchronizeRemote_RTCExecutionContexts(RTC.RTObject ro) {
-		// LOGGER.debug("synchronizeRemote_RTCExecutionContexts: ro={}", ro);
-		boolean update = false;
-		try {
-			// owned context
-			RTC.ExecutionContext[] oec = ro.get_owned_contexts();
-			RTC.ExecutionContext[] oecOld = CorbaObjectStore.eINSTANCE
-					.findOwnedContexts(ro);
-			if (!eql(oec, oecOld)) {
-				CorbaObjectStore.eINSTANCE.registOwnedContexts(ro, oec);
-				update = true;
-			}
-			// participating context
-			RTC.ExecutionContext[] pec = ro.get_participating_contexts();
-			RTC.ExecutionContext[] pecOld = CorbaObjectStore.eINSTANCE
-					.findParticipatingContexts(ro);
-			if (!eql(pec, pecOld)) {
-				CorbaObjectStore.eINSTANCE.registParticipatingContexts(ro, pec);
-				update = true;
-			}
-			//
-			if (update) {
+		synchronized (CorbaObjectStore.eINSTANCE) {
+			// LOGGER.debug("synchronizeRemote_RTCExecutionContexts: ro={}", ro);
+			boolean update = false;
+			try {
+				// owned context
+				RTC.ExecutionContext[] oec = ro.get_owned_contexts();
+				RTC.ExecutionContext[] oecOld = CorbaObjectStore.eINSTANCE.findOwnedContexts(ro);
+				if (!eql(oec, oecOld)) {
+					CorbaObjectStore.eINSTANCE.registOwnedContexts(ro, oec);
+					update = true;
+				}
+				// participating context
+				RTC.ExecutionContext[] pec = ro.get_participating_contexts();
+				RTC.ExecutionContext[] pecOld = CorbaObjectStore.eINSTANCE.findParticipatingContexts(ro);
+				if (!eql(pec, pecOld)) {
+					CorbaObjectStore.eINSTANCE.registParticipatingContexts(ro, pec);
+					update = true;
+				}
+				//
+				if (update) {
+					CorbaObjectStore.eINSTANCE.clearContext(ro);
+					for (RTC.ExecutionContext ec : oec) {
+						int handle = ro.get_context_handle(ec);
+						CorbaObjectStore.eINSTANCE.registContext(ro, Integer.toString(handle), ec);
+					}
+					for (RTC.ExecutionContext ec : pec) {
+						int handle = ro.get_context_handle(ec);
+						CorbaObjectStore.eINSTANCE.registContext(ro, Integer.toString(handle), ec);
+					}
+				}
+			} catch (Exception e) {
+				CorbaObjectStore.eINSTANCE.removeOwnedContexts(ro);
+				CorbaObjectStore.eINSTANCE.removeParticipatingContexts(ro);
 				CorbaObjectStore.eINSTANCE.clearContext(ro);
-				for (RTC.ExecutionContext ec : oec) {
-					int handle = ro.get_context_handle(ec);
-					CorbaObjectStore.eINSTANCE.registContext(ro,
-							Integer.toString(handle), ec);
-				}
-				for (RTC.ExecutionContext ec : pec) {
-					int handle = ro.get_context_handle(ec);
-					CorbaObjectStore.eINSTANCE.registContext(ro,
-							Integer.toString(handle), ec);
-				}
+				LOGGER.error("Fail to sync RTC.ExecutionContext: rtc={}", ro);
+				LOGGER.error("ERROR:", e);
 			}
-		} catch (Exception e) {
-			CorbaObjectStore.eINSTANCE.removeOwnedContexts(ro);
-			CorbaObjectStore.eINSTANCE.removeParticipatingContexts(ro);
-			CorbaObjectStore.eINSTANCE.clearContext(ro);
-			LOGGER.error("Fail to sync RTC.ExecutionContext: rtc={}", ro);
-			LOGGER.error("ERROR:", e);
 		}
 	}
 
@@ -1644,61 +1667,66 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 	}
 
 	public static void synchronizeRemote_EC_ComponentState(RTC.RTObject ro, RTC.ExecutionContext ec) {
-		// LOGGER.debug("synchronizeRemote_EC_ComponentState: ro={}", ro);
-		try {
-			RTC.LifeCycleState state = ec.get_component_state(ro);
-			int stateValue = RTC_STATUS(state);
-			CorbaObjectStore.eINSTANCE.registComponentState(ec, ro, new Integer(stateValue));
-		} catch (Exception e) {
-			CorbaObjectStore.eINSTANCE.removeComponentStateMap(ec);
-			LOGGER.error("Fail to sync RTC status: ec={} rtc={}", ec, ro);
-			LOGGER.error("ERROR:", e);
+		synchronized (CorbaObjectStore.eINSTANCE) {
+			// LOGGER.debug("synchronizeRemote_EC_ComponentState: ro={}", ro);
+			try {
+				RTC.LifeCycleState state = ec.get_component_state(ro);
+				int stateValue = RTC_STATUS(state);
+				CorbaObjectStore.eINSTANCE.registComponentState(ec, ro, new Integer(stateValue));
+			} catch (Exception e) {
+				CorbaObjectStore.eINSTANCE.removeComponentStateMap(ec);
+				LOGGER.error("Fail to sync RTC status: ec={} rtc={}", ec, ro);
+				LOGGER.error("ERROR:", e);
+			}
 		}
 	}
 
 	/** RTC.ExecutionContextの同期(ec_state) (CORBA=>オブジェクトDB) */
 	public static void synchronizeRemote_EC_ECState(RTC.ExecutionContext ec) {
-		// LOGGER.debug("synchronizeRemote_EC_ECState: ec={}", ec);
-		try {
-			int ecStateValue = ExecutionContext.STATE_UNKNOWN;
-			if (ec.is_running()) {
-				ecStateValue = ExecutionContext.STATE_RUNNING;
-			} else {
-				ecStateValue = ExecutionContext.STATE_STOPPED;
+		synchronized (CorbaObjectStore.eINSTANCE) {
+			// LOGGER.debug("synchronizeRemote_EC_ECState: ec={}", ec);
+			try {
+				int ecStateValue = ExecutionContext.STATE_UNKNOWN;
+				if (ec.is_running()) {
+					ecStateValue = ExecutionContext.STATE_RUNNING;
+				} else {
+					ecStateValue = ExecutionContext.STATE_STOPPED;
+				}
+				CorbaObjectStore.eINSTANCE.registECState(ec, ecStateValue);
+			} catch (Exception e) {
+				CorbaObjectStore.eINSTANCE.removeECState(ec);
+				LOGGER.error("Fail to sync EC status: ec={}", ec);
+				LOGGER.error("ERROR:", e);
 			}
-			CorbaObjectStore.eINSTANCE.registECState(ec, ecStateValue);
-		} catch (Exception e) {
-			CorbaObjectStore.eINSTANCE.removeECState(ec);
-			LOGGER.error("Fail to sync EC status: ec={}", ec);
-			LOGGER.error("ERROR:", e);
 		}
 	}
 
 	/** RTC.ExecutionContextの同期(ec_profile) (CORBA=>オブジェクトDB) */
 	public static void synchronizeRemote_EC_ECProfile(RTC.ExecutionContext ec) {
-		// LOGGER.debug("synchronizeRemote_EC_ECProfile: ec={}", ec);
-		try {
-			RTC.ExecutionContextProfile prof;
-			if (ec._is_a(RTC.ExecutionContextServiceHelper.id())) {
-				RTC.ExecutionContextService ecs = RTC.ExecutionContextServiceHelper
-						.narrow(ec);
-				prof = ecs.get_profile();
-			} else {
-				prof = new RTC.ExecutionContextProfile();
-				prof.rate = ec.get_rate();
-				prof.kind = ec.get_kind();
-			}
-			if (prof.owner == null) {
-				RTObject owner = CorbaObjectStore.eINSTANCE.findContextOwner(ec);
-				if (owner != null) {
-					prof.owner = owner;
+		synchronized (CorbaObjectStore.eINSTANCE) {
+			// LOGGER.debug("synchronizeRemote_EC_ECProfile: ec={}", ec);
+			try {
+				RTC.ExecutionContextProfile prof;
+				if (ec._is_a(RTC.ExecutionContextServiceHelper.id())) {
+					RTC.ExecutionContextService ecs = RTC.ExecutionContextServiceHelper.narrow(ec);
+					prof = ecs.get_profile();
+				} else {
+					prof = new RTC.ExecutionContextProfile();
+					prof.rate = ec.get_rate();
+					prof.kind = ec.get_kind();
 				}
+				if (prof.owner == null) {
+					RTObject owner = CorbaObjectStore.eINSTANCE.findContextOwner(ec);
+					if (owner != null) {
+						prof.owner = owner;
+					}
+				}
+				CorbaObjectStore.eINSTANCE.registECProfile(ec, prof);
+			} catch (Exception e) {
+				CorbaObjectStore.eINSTANCE.removeECProfile(ec);
+				LOGGER.error("Fail to sync RTC.ExecutionContextProfile: ec={}", ec);
+				LOGGER.error("ERROR:", e);
 			}
-			CorbaObjectStore.eINSTANCE.registECProfile(ec, prof);
-		} catch (Exception e) {
-			CorbaObjectStore.eINSTANCE.removeECProfile(ec);
-			LOGGER.error("Fail to sync RTC.ExecutionContextProfile: ec={}", ec);
-			LOGGER.error("ERROR:", e);
 		}
 	}
 
@@ -1748,15 +1776,17 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 	}
 
 	public static void synchronizeRemote_ConfigurationSets(RTC.RTObject ro) {
-		// LOGGER.debug("synchronizeRemote_ConfigurationSets: ro={}", ro);
-		try {
-			_SDOPackage.Configuration conf = ro.get_configuration();
-			_SDOPackage.ConfigurationSet[] cs = conf.get_configuration_sets();
-			CorbaObjectStore.eINSTANCE.registConfigSet(ro, cs);
-		} catch (Exception e) {
-			CorbaObjectStore.eINSTANCE.removeConfigSet(ro);
-			LOGGER.error("Fail to sync SDO.ConfigurationSet: rtc={}", ro);
-			LOGGER.error("ERROR:", e);
+		synchronized (CorbaObjectStore.eINSTANCE) {
+			// LOGGER.debug("synchronizeRemote_ConfigurationSets: ro={}", ro);
+			try {
+				_SDOPackage.Configuration conf = ro.get_configuration();
+				_SDOPackage.ConfigurationSet[] cs = conf.get_configuration_sets();
+				CorbaObjectStore.eINSTANCE.registConfigSet(ro, cs);
+			} catch (Exception e) {
+				CorbaObjectStore.eINSTANCE.removeConfigSet(ro);
+				LOGGER.error("Fail to sync SDO.ConfigurationSet: rtc={}", ro);
+				LOGGER.error("ERROR:", e);
+			}
 		}
 	}
 
@@ -1803,16 +1833,17 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 	}
 
 	public static void synchronizeRemote_ActiveConfigurationSet(RTC.RTObject ro) {
-		// LOGGER.debug("synchronizeRemote_ActiveConfigurationSet: ro={}", ro);
-		try {
-			_SDOPackage.Configuration conf = ro.get_configuration();
-			_SDOPackage.ConfigurationSet cs = conf
-					.get_active_configuration_set();
-			CorbaObjectStore.eINSTANCE.registActiveConfigSet(ro, cs);
-		} catch (Exception e) {
-			CorbaObjectStore.eINSTANCE.removeActiveConfigSet(ro);
-			LOGGER.error("Fail to sync active SDO.ConfigurationSet: rtc={}", ro);
-			LOGGER.error("ERROR:", e);
+		synchronized (CorbaObjectStore.eINSTANCE) {
+			// LOGGER.debug("synchronizeRemote_ActiveConfigurationSet: ro={}", ro);
+			try {
+				_SDOPackage.Configuration conf = ro.get_configuration();
+				_SDOPackage.ConfigurationSet cs = conf.get_active_configuration_set();
+				CorbaObjectStore.eINSTANCE.registActiveConfigSet(ro, cs);
+			} catch (Exception e) {
+				CorbaObjectStore.eINSTANCE.removeActiveConfigSet(ro);
+				LOGGER.error("Fail to sync active SDO.ConfigurationSet: rtc={}", ro);
+				LOGGER.error("ERROR:", e);
+			}
 		}
 	}
 
@@ -1856,29 +1887,34 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 	}
 
 	public static void synchronizeRemote_RTCRTObjects(RTC.RTObject ro) {
-		// LOGGER.debug("synchronizeRemote_RTCRTObjects: ro={}", ro);
-		List<RTC.RTObject> list = CorbaObjectStore.eINSTANCE
-				.getCompositeMemberList(ro);
-		try {
-			Organization[] orgs = ro.get_owned_organizations();
-			if (orgs.length == 0) {
-				return;
-			}
-			_SDOPackage.SDO[] sdo_list = orgs[0].get_members();
-			if (sdo_list == null) {
-				return;
-			}
-			list.clear();
-			for (SDO sdo : sdo_list) {
-				RTC.RTObject r = RTC.RTObjectHelper.narrow(sdo);
-				if (r != null) {
-					list.add(r);
+		synchronized (CorbaObjectStore.eINSTANCE) {
+			// LOGGER.debug("synchronizeRemote_RTCRTObjects: ro={}", ro);
+			List<RTC.RTObject> list = CorbaObjectStore.eINSTANCE.getCompositeMemberList(ro);
+			LOGGER.debug("synchronizeRemote_RTCRTObjects: comp.members=<{}>", list);
+			try {
+				Organization[] orgs = ro.get_owned_organizations();
+				LOGGER.debug("synchronizeRemote_RTCRTObjects: organizations=<{}>", java.util.Arrays.asList(orgs));
+				if (orgs.length == 0) {
+					return;
 				}
+				_SDOPackage.SDO[] sdo_list = orgs[0].get_members();
+				LOGGER.debug("synchronizeRemote_RTCRTObjects: members=<{}>", java.util.Arrays.asList(sdo_list));
+				if (sdo_list == null) {
+					return;
+				}
+				list.clear();
+				for (SDO sdo : sdo_list) {
+					RTC.RTObject r = RTC.RTObjectHelper.narrow(sdo);
+					if (r != null) {
+						list.add(r);
+						LOGGER.debug("synchronizeRemote_RTCRTObjects: add member=<{}>", r);
+					}
+				}
+			} catch (Exception e) {
+				CorbaObjectStore.eINSTANCE.removeCompositeMemberList(ro);
+				LOGGER.error("Fail to sync RTC members: rtc={}", ro);
+				LOGGER.error("ERROR:", e);
 			}
-		} catch (Exception e) {
-			CorbaObjectStore.eINSTANCE.removeCompositeMemberList(ro);
-			LOGGER.error("Fail to sync RTC members: rtc={}", ro);
-			LOGGER.error("ERROR:", e);
 		}
 	}
 
@@ -2019,12 +2055,17 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 						}
 						//
 						CorbaExecutionContext cec = (CorbaExecutionContext) component.getPrimaryExecutionContext();
-						if (cec == null
-								|| (!component.getExecutionContexts().contains(cec) && !component.getParticipationContexts()
-										.contains(cec))) {
+						if (cec == null || (!component.getExecutionContexts().contains(cec)
+								&& !component.getParticipationContexts().contains(cec))) {
 							// プライマリEC が未設定/無効な場合は１つ目の ECを割り当てる
-							component.setPrimaryExecutionContext(component.getExecutionContexts().get(0));
-							LOGGER.info("postSynchronizeLocal: set primary ec={}", component.getPrimaryExecutionContext());
+							if (component.getExecutionContexts().isEmpty()) {
+								LOGGER.info("postSynchronizeLocal: set primary ec is empty. ec={}",
+										component.getPrimaryExecutionContext());
+							} else {
+								component.setPrimaryExecutionContext(component.getExecutionContexts().get(0));
+								LOGGER.info("postSynchronizeLocal: set primary ec={}",
+										component.getPrimaryExecutionContext());
+							}
 						}
 					}
 

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaLogObserverImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaLogObserverImpl.java
@@ -96,7 +96,7 @@ public class CorbaLogObserverImpl extends CorbaObserverImpl implements CorbaLogO
 			//
 			activate();
 			try {
-				boolean result = addServiceProfile(rtc.get_configuration());
+				boolean result = addServiceProfile(rtc);
 				if (!result) {
 					deactivate();
 					return false;
@@ -129,7 +129,7 @@ public class CorbaLogObserverImpl extends CorbaObserverImpl implements CorbaLogO
 		//
 		boolean result = false;
 		try {
-			result = removeServiceProfile(rtc.get_configuration());
+			result = removeServiceProfile(rtc);
 		} catch (Exception e) {
 		}
 		deactivate();

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaObserverImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaObserverImpl.java
@@ -240,36 +240,35 @@ public class CorbaObserverImpl extends EObjectImpl implements CorbaObserver {
 		throw new UnsupportedOperationException();
 	}
 
-	protected boolean addServiceProfile(_SDOPackage.Configuration config) {
+	protected boolean addServiceProfile(RTC.RTObject ro) {
 		boolean result;
 		try {
 			serviceProfile.id = UUID.randomUUID().toString();
 			if (serviceProfile.properties == null) {
 				serviceProfile.properties = new _SDOPackage.NameValue[0];
 			}
-			result = config.add_service_profile(serviceProfile);
+			result = ro.get_configuration().add_service_profile(serviceProfile);
 			//
 			if (result) {
-				LOGGER.info("add_service_profile:    id={} type={} ior={} obs={}", serviceProfile.id,
-						serviceProfile.interface_type, serviceProfile.service, this.getClass().getName());
+				LOGGER.info("add_service_profile:    id={} type={} ior={} obs={} rtc=<{}>", serviceProfile.id,
+						serviceProfile.interface_type, serviceProfile.service, this.getClass().getName(), ro);
 			}
 		} catch (Exception e) {
-			LOGGER.error("Fail to add service profile: id={} type={} ior={} obs={}", serviceProfile.id,
-					serviceProfile.interface_type, serviceProfile.service, this.getClass().getName());
+			LOGGER.error("Fail to add service profile: id={} type={} ior={} obs={} rtc=<{}>", serviceProfile.id,
+					serviceProfile.interface_type, serviceProfile.service, this.getClass().getName(), ro);
 			LOGGER.error("ERROR:", e);
 			result = false;
 		}
 		return result;
 	}
 
-	protected boolean removeServiceProfile(_SDOPackage.Configuration config) {
+	protected boolean removeServiceProfile(RTC.RTObject ro) {
 		boolean result;
 		try {
-			result = config.remove_service_profile(serviceProfile.id);
+			result = ro.get_configuration().remove_service_profile(serviceProfile.id);
 			//
-			LOGGER.info("remove_service_profile: id={} type={} ior={} obs={}",
-					serviceProfile.id, serviceProfile.interface_type,
-					serviceProfile.service, this.getClass().getName());
+			LOGGER.info("remove_service_profile: id={} type={} ior={} obs={} rtc=<{}>", serviceProfile.id,
+					serviceProfile.interface_type, serviceProfile.service, this.getClass().getName(), ro);
 		} catch (Exception e) {
 			result = false;
 		}

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaStatusObserverImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaStatusObserverImpl.java
@@ -161,7 +161,7 @@ public class CorbaStatusObserverImpl extends CorbaObserverImpl implements CorbaS
 			//
 			activate();
 			try {
-				boolean result = addServiceProfile(rtc.get_configuration());
+				boolean result = addServiceProfile(rtc);
 				if (!result) {
 					deactivate();
 					return false;
@@ -195,7 +195,7 @@ public class CorbaStatusObserverImpl extends CorbaObserverImpl implements CorbaS
 		//
 		boolean result = false;
 		try {
-			result = removeServiceProfile(rtc.get_configuration());
+			result = removeServiceProfile(rtc);
 		} catch (Exception e) {
 		}
 		deactivate();
@@ -403,8 +403,8 @@ public class CorbaStatusObserverImpl extends CorbaObserverImpl implements CorbaS
 		setProperty("port_profile.receive_event.min_interval", getPropPortRecvMinInterval());
 		//
 		try {
-			removeServiceProfile(rtc.get_configuration());
-			addServiceProfile(rtc.get_configuration());
+			removeServiceProfile(rtc);
+			addServiceProfile(rtc);
 		} catch (Exception e) {
 			LOGGER.error("Fail to reset service profile.", e);
 		}

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/ui/propertysource/CorbaObserverPropertySource.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/ui/propertysource/CorbaObserverPropertySource.java
@@ -52,7 +52,11 @@ public class CorbaObserverPropertySource extends AbstractPropertySource {
 		} else if (INTERFACE_TYPE.equals(id)) {
 			result = observer.getServiceProfile().interface_type;
 		} else if (SERVICE.equals(id)) {
-			result = observer.getServiceProfile().service.toString();
+			if (observer.getServiceProfile().service != null) {
+				result = observer.getServiceProfile().service.toString();
+			} else {
+				result = "null";
+			}
 		}
 		return result;
 	}

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/util/RtcProfileHandler.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/util/RtcProfileHandler.java
@@ -35,7 +35,7 @@ public class RtcProfileHandler {
 	private static final String SPEC_SUFFIX = "RTC";
 	private static final String SPEC_MAJOR_SEPARATOR = ":";
 	// private static final String SPEC_MINOR_SEPARATOR = ".";
-	
+
 	private static final String INTERFACE_DIRECTION_PROVIDED = "Provided";
 	private static final String INTERFACE_DIRECTION_REQUIRED = "Required";
 
@@ -54,22 +54,20 @@ public class RtcProfileHandler {
 	public ComponentSpecification createComponentFromXML(String targetXML) throws Exception {
 		XmlHandler handler = new XmlHandler();
 		RtcProfile profile = handler.restoreFromXmlRtc(targetXML);
-		
+
 		ComponentSpecification component = profile2ComponentEMF(profile, null);
 		return component;
 	}
 
 	public ComponentSpecification createComponent(String targetFile) throws Exception  {
-		
 		//対象ファイルの読み込み
-		BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(targetFile), "UTF-8"));
-		String tmp_str = null;
 		StringBuffer tmp_sb = new StringBuffer();
-	    while((tmp_str = br.readLine()) != null){
-	    	tmp_sb.append(tmp_str + "\r\n");
-	    }
-	    br.close();
-
+		try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(targetFile), "UTF-8")) ) {
+			String tmp_str = null;
+		    while((tmp_str = br.readLine()) != null){
+		    	tmp_sb.append(tmp_str + "\r\n");
+		    }
+		}
 	    ComponentSpecification component = createComponentFromXML(tmp_sb.toString());
 		return component;
 	}
@@ -132,12 +130,12 @@ public class RtcProfileHandler {
 
 		return specification;
 	}
-	
+
 	private boolean checkProfile(RtcProfile module) {
 		if( !module.getBasicInfo().getCategory().startsWith(CATEGORY_COMPOSITE) ) return true;
 		if( module.getDataPorts().size()>0 ) return false;
 		if( module.getServicePorts().size()>0 ) return false;
-			
+
 		return true;
 	}
 


### PR DESCRIPTION
… component.

## Identify the Bug

Link to #11 

## Description of the Change

複合RTC の親をアクティブ化したときに，子をアクティブ化する処理は行っていないのですが，オブザーバ周りやタイムアウト処理関連など，複合RTC に関連した部分を修正させて頂きました．
複合化/複合解除などの操作でタイムアウトが発生するため，リモート処理につきましては，一律でタイムアウト処理を追加するとともに，タイムアウト時間の延長(1sec → 10sec) をしました．(オブザーバ形式になって通知までのタイムラグができたため)

また，ミドルウェア側が処理が重くなっているようで，ミドルウェア起動直後は親RTC 作成にタイムアウトしてしまったりしました．更に，複合解除を行った際に，ミドルウェアが落ちてしまったりしました．

更に，以下の問題につきましても，オブザーバの通知が届いて居ない事が原因のようでしたので，今回の修正で修正されたと思います．
- RTCの参照に到達不能なIPアドレスが含まれる場合にRTSEがフリーズする問題の解消
   ネームツリー上や，ポート接続時に一方のポートへの参照がUnreachableの場合に，RTSEがフリーズする現象が発生する
- ポート接続後システムダイアグラム上で接続されていないように表示される問題の解消
   データポートを接続したのにシステムダイアグラム上でポートの色が変化せず，コネクタも 表示されないことがある．システムダイアグラムで×を押して消して，新たにシステムダイアグラムを表示するとコネクタが正常に接続された状態で表示される現象が発生する


## Verification 
- [x] Did you succesed the build?  Windows上でEclipse4.7.3を使用
- [x] No warnings for the build?  Windows上でEclipse4.7.3を使用
- [ ] Have you passed the unit tests?  ユニットテスト無し
