### PR TITLE
Modified RTSystemEditor Warning. 

### DIFF
--- a/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/model/nameservice/impl/NamingContextNodeImpl.java
+++ b/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/model/nameservice/impl/NamingContextNodeImpl.java
@@ -311,7 +311,6 @@ public class NamingContextNodeImpl extends CorbaNodeImpl implements
 				private NamingContext context;
 				private LocalObject localObject;
 
-				@SuppressWarnings("unchecked")
 				@Override
 				public List getNewRemoteLinkList(Object[] remoteObjects) {
 					context = (NamingContext) remoteObjects[0];
@@ -358,7 +357,6 @@ public class NamingContextNodeImpl extends CorbaNodeImpl implements
 					}
 				}
 
-				@SuppressWarnings("unchecked")
 				@Override
 				public List getOldRemoteLinkList(LocalObject localObject) {
 					this.localObject = localObject;
@@ -374,7 +372,6 @@ public class NamingContextNodeImpl extends CorbaNodeImpl implements
 					return result;
 				}
 
-				@SuppressWarnings("unchecked")
 				@Override
 				public LocalObject getLocalObjectByRemoteLink(
 						LocalObject parent, Object link) {

--- a/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/ui/action/DeleteNodeActionDelegate.java
+++ b/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/ui/action/DeleteNodeActionDelegate.java
@@ -18,7 +18,7 @@ import org.eclipse.ui.IWorkbenchPart;
 
 /**
  * ネームサービスをビューから削除するアクション または ネームサービスからコンテキストを削除するアクション
- * 
+ *
  */
 public class DeleteNodeActionDelegate implements IObjectActionDelegate {
 	private IWorkbenchPart targetPart;
@@ -49,7 +49,6 @@ public class DeleteNodeActionDelegate implements IObjectActionDelegate {
 		}
 	}
 
-	@SuppressWarnings("unchecked")
 	private void runServer() {
 		for (Iterator iter = ((IStructuredSelection) selection).iterator(); iter
 				.hasNext();) {
@@ -58,12 +57,11 @@ public class DeleteNodeActionDelegate implements IObjectActionDelegate {
 		}
 	}
 
-	@SuppressWarnings("unchecked")
 	private void runContext() {
 		boolean confirm = MessageDialog.openConfirm(targetPart.getSite()
 				.getShell(), Messages.getString("DeleteINamingContextActionDelegate.0"), Messages.getString("DeleteINamingContextActionDelegate.1")); //$NON-NLS-1$ //$NON-NLS-2$
 		if (!confirm) return;
-		
+
 		try {
 			for (Iterator iter = selection.iterator(); iter.hasNext();) {
 				CorbaNode binding = (CorbaNode) iter.next();
@@ -96,7 +94,6 @@ public class DeleteNodeActionDelegate implements IObjectActionDelegate {
 		}
 	}
 
-	@SuppressWarnings("unchecked")
 	private SelectedNode getCurrentState() {
 		boolean hasServer = false;
 		boolean hasContext = false;

--- a/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/ui/action/KillZombiesAction.java
+++ b/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/ui/action/KillZombiesAction.java
@@ -33,7 +33,6 @@ public class KillZombiesAction implements IViewActionDelegate {
 
 	public void run(IAction action) {
 		Job job = new Job(KILL_ZOMLIES_TITLE) {
-			@SuppressWarnings("unchecked")
 			protected IStatus run(IProgressMonitor monitor) {
 
 				monitor.beginTask(KILL_ZOMLIES_START, 100);

--- a/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/ui/action/StartManagerAction.java
+++ b/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/ui/action/StartManagerAction.java
@@ -19,7 +19,7 @@ import org.eclipse.ui.IViewPart;
 
 public class StartManagerAction implements IViewActionDelegate {
 	private NameServiceView view;
-	
+
 	private static String SCRIPT_WINDOWS = System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "rtcd-cxx-daemon.bat";
 	private static String SCRIPT_LINUX = "/usr/bin/rtcd";
 
@@ -44,26 +44,25 @@ public class StartManagerAction implements IViewActionDelegate {
 			targetManager.shutdownR();
 		}
 		/////
-		boolean isWindows = false; 
+		boolean isWindows = false;
 		String targetOS = System.getProperty("os.name").toLowerCase();
 		if(targetOS.toLowerCase().startsWith("windows")) {
 			isWindows = true;
 		}
-		
-		String target = "";
+
 		if(isWindows) {
 			try {
 				ProcessBuilder pb = new ProcessBuilder(SCRIPT_WINDOWS);
 				File dir = new File(System.getenv("RTM_ROOT") + "bin");
 				pb.directory(dir);
-				Process process = pb.start();
+				pb.start();
 			} catch (IOException e) {
 				e.printStackTrace();
 			}
 		} else {
 			try {
 				ProcessBuilder pb = new ProcessBuilder(SCRIPT_LINUX, "-d");
-				Process process = pb.start();
+				pb.start();
 			} catch (IOException e) {
 				e.printStackTrace();
 			}
@@ -74,16 +73,16 @@ public class StartManagerAction implements IViewActionDelegate {
 		String target = "";
 		String targetOS = System.getProperty("os.name").toLowerCase();
 		if(targetOS.toLowerCase().startsWith("windows")) {
-			target = SCRIPT_WINDOWS; 
+			target = SCRIPT_WINDOWS;
 		} else {
-			target = SCRIPT_LINUX; 
+			target = SCRIPT_LINUX;
 		}
 		File targetFile = new File(target);
 		if(targetFile.exists()==false) {
 			action.setEnabled(false);
 		}
 	}
-	
+
 	private void getAllItems(Tree tree, List<TreeItem> allItems) {
 	    for(TreeItem item : tree.getItems()) {
 	    	item.setExpanded(true);
@@ -98,5 +97,5 @@ public class StartManagerAction implements IViewActionDelegate {
 	        allItems.add(children[index]);
 	        getAllItems(children[index], allItems);
 	    }
-	}	
+	}
 }

--- a/jp.go.aist.rtm.nameserviceview/test/jp/go/aist/rtm/nameserviceview/corba/NameServerAccesserTest.java
+++ b/jp.go.aist.rtm.nameserviceview/test/jp/go/aist/rtm/nameserviceview/corba/NameServerAccesserTest.java
@@ -54,8 +54,6 @@ import jp.go.aist.rtm.toolscommon.synchronizationframework.mapping.MappingRule;
 
 
 public class NameServerAccesserTest {
-	@SuppressWarnings("unchecked")
-//	@Test
 	public void getFactoryProfiles() throws Exception {
 		NamingContextNode context = getNamingContext();
 		TreeIterator allContents = context.eAllContents();
@@ -76,8 +74,6 @@ public class NameServerAccesserTest {
 			}
 		}
 	}
-	@SuppressWarnings("unchecked")
-//	@Test
 	public void getComponentState() throws Exception {
 		NamingContextNode context = getNamingContext();
 		TreeIterator allContents = context.eAllContents();
@@ -100,7 +96,6 @@ public class NameServerAccesserTest {
 			}
 		}
 	}
-//	@Test
 	public void getConnectCompositeComponents() throws Exception {
 		CorbaComponentImpl consoleIn = findComponent("ConsoleIn0");
 		RTC.PortService[] outPorts = consoleIn.getCorbaObjectInterface().get_ports();
@@ -168,7 +163,6 @@ public class NameServerAccesserTest {
 		any.insert_string(value);
 		return any;
 	}
-	@SuppressWarnings("unchecked")
 	private RTCManagerImpl findManager() throws Exception {
 		NamingContextNode context = getNamingContext();
 		TreeIterator allContents = context.eAllContents();
@@ -183,7 +177,6 @@ public class NameServerAccesserTest {
 		}
 		return null;
 	}
-	@SuppressWarnings("unchecked")
 	private CorbaComponentImpl findComponent(String name) throws Exception{
 		NamingContextNode context = getNamingContext();
 		TreeIterator allContents = context.eAllContents();
@@ -675,7 +668,6 @@ public class NameServerAccesserTest {
 		return mappingRuleList.toArray(new MappingRule[mappingRuleList.size()]);
 	}
 
-	@SuppressWarnings("unchecked")
 	private static MappingRule createMappingRule(String mappingRuleValue) throws Exception {
 		int lastIndexOf = mappingRuleValue.lastIndexOf(".");
 

--- a/jp.go.aist.rtm.repositoryView/src/jp/go/aist/rtm/repositoryView/ui/ArrayContentProvider.java
+++ b/jp.go.aist.rtm.repositoryView/src/jp/go/aist/rtm/repositoryView/ui/ArrayContentProvider.java
@@ -14,7 +14,6 @@ import org.eclipse.jface.viewers.Viewer;
  */
 public class ArrayContentProvider implements ITreeContentProvider {
 
-	@SuppressWarnings("unchecked")
 	public Object[] getChildren(Object parentElement) {
 		if (parentElement instanceof List) {
 			List list = (List)parentElement;
@@ -28,7 +27,7 @@ public class ArrayContentProvider implements ITreeContentProvider {
 
 		return ((RepositoryViewItem)element).getParent();
 	}
-	
+
 	public boolean hasChildren(Object element) {
 	    //(自分内にディレクトリがあるかどうか)
 	    return getChildren(element).length > 0;
@@ -39,11 +38,11 @@ public class ArrayContentProvider implements ITreeContentProvider {
 	}
 
 	public void dispose() {
-		
+
 	}
 
 	public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
-		
+
 	}
 
 }

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/manager/ComponentIconStore.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/manager/ComponentIconStore.java
@@ -182,13 +182,12 @@ public class ComponentIconStore {
 			path.toFile().createNewFile();
 		}
 		String xmlSplit[] = xml.split("\n");
-		BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(
-				new FileOutputStream(path.toOSString()), "UTF-8"));
-		for (String s : xmlSplit) {
-			writer.write(s);
-			writer.newLine();
+		try( BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(path.toOSString()), "UTF-8")) ) {
+			for (String s : xmlSplit) {
+				writer.write(s);
+				writer.newLine();
+			}
 		}
-		writer.close();
 	}
 
 	/** アイコン設定をプロファイル(XML)から読込 */

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/restoration/Main.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/restoration/Main.java
@@ -37,15 +37,15 @@ public class Main {
 	 * XMLファイルの場所は、ファイルパスもしくはURI(Webサーバ等可能)で指定する。
 	 * <p>
 	 * [重要]マッピングルールは、実行ファイル直下に、別途作成したファイル(MAPPING_RULES)に指定する
-	 * 
+	 *
 	 * コンソールからRtcLinkのXMLファイルを読み込み、XMLファイルの内容に沿って以下を行う。
 	 * <LI>１．RtcLinkのXMLに含まれるすべてのRTCにアクセス可能であるか確認する。</LI>
 	 * <LI>２．RtcLinkのXMLに含まれるすべてのコンフィグレーション情報を復元する</LI>
 	 * <LI>３．RtcLinkのXMLに含まれるすべてのコネクションを接続する</LI>
 	 * <LI>４・RtcLinkのXMLに含まれるすべてのRTCに対して、Start要求を送信する。</LI>
-	 * 
+	 *
 	 * ３．では、既に同じコネクションIDが存在すれば、接続は行われない <br>
-	 * 
+	 *
 	 * @param args
 	 */
 	public static void main(String[] args) {
@@ -103,7 +103,7 @@ public class Main {
 
 	/**
 	 * 実行メイン
-	 * 
+	 *
 	 * @param xmlUri
 	 * @param result
 	 */
@@ -159,7 +159,7 @@ public class Main {
 
 	/**
 	 * ファイルからマッピングルールを作成する
-	 * 
+	 *
 	 * @return
 	 * @throws ClassNotFoundException
 	 * @throws NoSuchFieldException
@@ -169,10 +169,7 @@ public class Main {
 
 		List<MappingRule> mappingRule = new ArrayList<MappingRule>();
 
-		try {
-			BufferedReader reader = new BufferedReader(new InputStreamReader(
-					new FileInputStream("./MAPPING_RULES"))); //$NON-NLS-1$
-
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream("./MAPPING_RULES"))) ) { //$NON-NLS-1$
 			while (reader.ready()) {
 				String value = reader.readLine();
 
@@ -192,9 +189,6 @@ public class Main {
 
 				mappingRule.add((MappingRule) field.get(clazz.newInstance()));
 			}
-
-			reader.close();
-
 		} catch (Exception e) {
 			LOGGER.error("Fail to create mapping rules", e);
 			result.setSuccess(false);

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/AbstractSystemDiagramEditor.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/AbstractSystemDiagramEditor.java
@@ -135,7 +135,7 @@ public abstract class AbstractSystemDiagramEditor extends GraphicalEditor {
 		setEditDomain(new DefaultEditDomain(this));
 		getEditDomain().setCommandStack(new ConnectCancelCommandStack());
 	}
-	
+
 	/**
 	 * @return openEditorの引数として渡される（オンラインまたはオフラインの）エディタID
 	 */
@@ -223,7 +223,6 @@ public abstract class AbstractSystemDiagramEditor extends GraphicalEditor {
 	protected void createGraphicalViewer(Composite parent) {
 		GraphicalViewer viewer = new ScrollingGraphicalViewer() {
 
-			@SuppressWarnings("unchecked")
 			@Override
 			public EditPart findObjectAtExcluding(Point pt, Collection exclude,
 					Conditional condition) {
@@ -250,7 +249,6 @@ public abstract class AbstractSystemDiagramEditor extends GraphicalEditor {
 
 		GraphicalViewer viewer = getGraphicalViewer();
 		viewer.setRootEditPart(new ScalableRootEditPart() {
-			@SuppressWarnings("unchecked")
 			@Override
 			public Object getAdapter(Class adapter) {
 				if (adapter == AutoexposeHelper.class) {
@@ -271,7 +269,7 @@ public abstract class AbstractSystemDiagramEditor extends GraphicalEditor {
 						}
 						return handleButtonDown;
 					}
-					
+
 				};
 			}
 		});
@@ -441,9 +439,9 @@ public abstract class AbstractSystemDiagramEditor extends GraphicalEditor {
 
 	/**
 	 * ダイアグラムの整合性をチェックします。
-	 * 
+	 *
 	 * 拡張ポイント: jp.go.aist.rtm.toolscommon.validations
-	 * 
+	 *
 	 * @return 不整合の場合はfalse
 	 */
 	public boolean validateDiagram() {
@@ -503,13 +501,12 @@ public abstract class AbstractSystemDiagramEditor extends GraphicalEditor {
 		return result;
 	}
 
-	@SuppressWarnings("unchecked")
 	protected void save(IFile file, IProgressMonitor progressMonitor)
 			throws CoreException {
-		
+
 		List<AbstractSystemDiagramEditor> editors = new ArrayList<AbstractSystemDiagramEditor>();
 		editors.add(this);
-		
+
 		// 子エディタを取得
 		for (Iterator iterator = systemDiagram.getComponents().iterator(); iterator
 				.hasNext();) {
@@ -648,7 +645,7 @@ public abstract class AbstractSystemDiagramEditor extends GraphicalEditor {
 				return (Component) SynchronizationSupport
 				.findLocalObjectByRemoteObject(
 						new Object[] { obj },
-						systemDiagram);				
+						systemDiagram);
 			}
 		}
 		return findComponentByPathId(
@@ -747,7 +744,7 @@ public abstract class AbstractSystemDiagramEditor extends GraphicalEditor {
 
 	protected FileEditorInput createEditorInput(IEditorInput input) {
 		if (input instanceof FileEditorInput) return (FileEditorInput) input;
-		
+
 		IPath path = ((IPathEditorInput) input).getPath();
 		IFile file = getOutsideIFileLink(path);
 		return new FileEditorInput(file);
@@ -767,9 +764,9 @@ public abstract class AbstractSystemDiagramEditor extends GraphicalEditor {
 		IProject project = ensureProjectOpen();
 
 		IFile fileLink = getFileLinkByRawLocation(path, project);
-		
+
 		if (fileLink != null) return fileLink;
-		
+
 
 		fileLink = project.getFile(formater.format(new Date()) + "__" //$NON-NLS-1$
 				+ path.lastSegment());
@@ -846,7 +843,6 @@ public abstract class AbstractSystemDiagramEditor extends GraphicalEditor {
 		systemDiagram = null;
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public Object getAdapter(Class type) {
 		if (type.equals(IPropertySheetPage.class)) {
@@ -886,7 +882,7 @@ public abstract class AbstractSystemDiagramEditor extends GraphicalEditor {
 
 	/**
 	 * SystemDiagramを取得する
-	 * 
+	 *
 	 * @return
 	 */
 	public SystemDiagram getSystemDiagram() {
@@ -894,7 +890,7 @@ public abstract class AbstractSystemDiagramEditor extends GraphicalEditor {
 	}
 
 	/**
-	 * 
+	 *
 	 */
 	protected final class SystemDiagramPropertyChangeListener implements
 			PropertyChangeListener {
@@ -997,7 +993,7 @@ public abstract class AbstractSystemDiagramEditor extends GraphicalEditor {
 		}
 		AbstractSystemDiagramEditor parent = ComponentUtil.findEditor(getSystemDiagram().getParentSystemDiagram());
 		if (parent != null) parent.refresh();
-		
+
 	}
 
 	public void openError(String title, String message) {

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/ConnectCancelCommandStack.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/ConnectCancelCommandStack.java
@@ -18,12 +18,10 @@ import org.eclipse.gef.commands.CommandStackListener;
  *
  */
 public class ConnectCancelCommandStack extends CommandStack {
-	@SuppressWarnings("unchecked")
 	private Stack undoable = new Stack();
 
 	private int saveLocation = 0;
 
-	@SuppressWarnings("unchecked")
 	private Stack redoable = new Stack();
 
 	/**
@@ -36,7 +34,7 @@ public class ConnectCancelCommandStack extends CommandStack {
 	}
 	/**
 	 * Executes the specified Command if possible. Prior to executing the command, a
-	 * CommandStackEvent for {@link #PRE_EXECUTE} will be fired to event listeners. 
+	 * CommandStackEvent for {@link #PRE_EXECUTE} will be fired to event listeners.
 	 * Similarly, after attempting to execute the command, an event for {@link #POST_EXECUTE}
 	 * will be fired.  If the execution of the command completely normally,  stack listeners
 	 * will receive {@link CommandStackListener#commandStackChanged(EventObject) stackChanged}
@@ -81,7 +79,7 @@ public class ConnectCancelCommandStack extends CommandStack {
 			ReconnectConnectorCommand connectCommand = (ReconnectConnectorCommand) command;
 			if (!connectCommand.getResult()) return;
 		}
-		
+
 		undoable.push(command);
 	}
 
@@ -117,7 +115,7 @@ public class ConnectCancelCommandStack extends CommandStack {
 	public Command getRedoCommand() {
 		return redoable.isEmpty() ? null : (Command)redoable.peek();
 	}
-	
+
 	/**
 	 * Peeks at the top of the <i>undo</i> stack. This is useful for describing to the User
 	 * what will be undone. The returned <code>Command</code> has a label describing it.
@@ -187,7 +185,7 @@ public class ConnectCancelCommandStack extends CommandStack {
 	/**
 	 * Returns true if the stack is dirty. The stack is dirty whenever the last executed or
 	 * redone command is different than the command that was at the top of the undo stack when
-	 * {@link #markSaveLocation()} was last called. 
+	 * {@link #markSaveLocation()} was last called.
 	 * @return <code>true</code> if the stack is dirty
 	 */
 	public boolean isDirty() {

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/editpart/CompositeFilter.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/editpart/CompositeFilter.java
@@ -26,7 +26,6 @@ public class CompositeFilter {
 		return getConnections(null, port);
 	}
 
-	@SuppressWarnings("unchecked")
 	private static Port findPort(List components, String originalString) {
 		for (Object obj: components) {
 			for(Object element : ((Component)obj).getPorts()) {
@@ -54,7 +53,6 @@ public class CompositeFilter {
 		return getConnections(port, null);
 	}
 
-	@SuppressWarnings("unchecked")
 	private static List<PortConnector> getConnections(Port first, Port second) {
 		Port port = first != null ? first : second;
 
@@ -62,7 +60,7 @@ public class CompositeFilter {
 
 		SystemDiagram diagram = getDiagram(port);
 		if (diagram == null) return result;
-		
+
 		List components = diagram.getComponents();
 		if (!(components.contains(port.eContainer())))return result;
 
@@ -72,17 +70,17 @@ public class CompositeFilter {
 			String tmpString = (first != null ? profile.getSourceString() : profile.getTargetString());
 			if (tmpString == null) continue;
 			if (!(tmpString.equals(originalPortString))) continue;
-			
+
 			String anotherString = (first != null ? profile.getTargetString() : profile.getSourceString());
 			Port anotherPort = findPort(components, anotherString);
 			if (anotherPort == null) continue;
-			
+
 			PortConnector connector = findOrCreateConnector(port, anotherPort, profile);
 			if (connector == null) continue;
-			
+
 			connector.setSource(first != null ? port : anotherPort);
 			connector.setTarget(first != null ? anotherPort : port);
-			
+
 			result.add(connector);
 		}
 		return result;

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/editpart/SystemDiagramEditPart.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/editpart/SystemDiagramEditPart.java
@@ -52,7 +52,6 @@ public class SystemDiagramEditPart extends AbstractEditPart {
 				new SystemXYLayoutEditPolicy());
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	/**
 	 * {@inheritDoc}

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/handler/ChangeDirectionCommandHandler.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/handler/ChangeDirectionCommandHandler.java
@@ -53,7 +53,7 @@ public class ChangeDirectionCommandHandler extends AbstractHandler {
 	}
 
 	// コマンド実行本体
-	Object executeInternal(String id, ComponentEditPart... editParts) throws ExecutionException {
+	Object executeInternal(String id, ComponentEditPart... editParts) {
 		LOGGER.debug("ChangeDirectionCommandHandler: command=<{}> comps=<{}>", id, editParts);
 
 		org.eclipse.gef.requests.ChangeBoundsRequest request = new org.eclipse.gef.requests.ChangeBoundsRequest();

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/preference/OfflineEditorPreferencePage.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/preference/OfflineEditorPreferencePage.java
@@ -91,7 +91,7 @@ public class OfflineEditorPreferencePage extends PreferencePage implements
 		dataFlowTypeViewer.setInput(selectedDataFlowType);
 		convertStrings2SingleItems(SystemEditorPreferenceManager.getInstance().getDataFlowTypes(), selectedDataFlowType);
 		dataFlowTypeViewer.refresh();
-		
+
 		//Subscription Type
 		Group subscriptionTypeGroup = createGroup(composite, Messages.getString("OfflineEditorPreferencePage.10")); //$NON-NLS-1$
 		subscriptionTypeViewer = new TableViewer(subscriptionTypeGroup, SWT.BORDER | SWT.FULL_SELECTION);
@@ -100,7 +100,7 @@ public class OfflineEditorPreferencePage extends PreferencePage implements
 		subscriptionTypeViewer.setInput(selectedSubscriptionType);
 		convertStrings2SingleItems(SystemEditorPreferenceManager.getInstance().getSubscriptionTypes(), selectedSubscriptionType);
 		subscriptionTypeViewer.refresh();
-		
+
 		//Push Policy
 		Group pushPolicyGroup = createGroup(composite, Messages.getString("OfflineEditorPreferencePage.11")); //$NON-NLS-1$
 		pushPolicyViewer = new TableViewer(pushPolicyGroup, SWT.BORDER | SWT.FULL_SELECTION);
@@ -109,7 +109,7 @@ public class OfflineEditorPreferencePage extends PreferencePage implements
 		pushPolicyViewer.setInput(selectedPushPolicy);
 		convertStrings2SingleItems(SystemEditorPreferenceManager.getInstance().getPushPolicies(), selectedPushPolicy);
 		pushPolicyViewer.refresh();
-		
+
 		//Buffer Full Policy
 		Group bufferFullPolicyGroup = createGroup(composite, Messages.getString("OfflineEditorPreferencePage.12")); //$NON-NLS-1$
 		bufferFullPolicyViewer = new TableViewer(bufferFullPolicyGroup, SWT.BORDER | SWT.FULL_SELECTION);
@@ -118,7 +118,7 @@ public class OfflineEditorPreferencePage extends PreferencePage implements
 		bufferFullPolicyViewer.setInput(selectedBufferFullPolicy);
 		convertStrings2SingleItems(SystemEditorPreferenceManager.getInstance().getBufferFullPolicies(), selectedBufferFullPolicy);
 		bufferFullPolicyViewer.refresh();
-		
+
 		//Buffer Empty Policy
 		Group bufferEmptyPolicyGroup = createGroup(composite, Messages.getString("OfflineEditorPreferencePage.13")); //$NON-NLS-1$
 		bufferEmptyPolicyViewer = new TableViewer(bufferEmptyPolicyGroup, SWT.BORDER | SWT.FULL_SELECTION);
@@ -130,7 +130,7 @@ public class OfflineEditorPreferencePage extends PreferencePage implements
 
 		return composite;
 	}
-	
+
 	public void init(IWorkbench workbench) {
 	}
 
@@ -163,12 +163,12 @@ public class OfflineEditorPreferencePage extends PreferencePage implements
 
 		return super.performOk();
 	}
-		
+
 	private void setDefault() {
 		String[] prefInterfaceType = SystemEditorPreferenceManager.defaultConnectInterfaceType;
 		convertStrings2SingleItems(prefInterfaceType, selectedInterfaceType);
 		interfaceTypeViewer.refresh();
-		
+
 		String[] prefDataFlowType = SystemEditorPreferenceManager.defaultConnectDataFlowType;
 		convertStrings2SingleItems(prefDataFlowType, selectedDataFlowType);
 		dataFlowTypeViewer.refresh();
@@ -180,27 +180,27 @@ public class OfflineEditorPreferencePage extends PreferencePage implements
 		String[] prefPushPolicies = SystemEditorPreferenceManager.defaultConnectPushPolicy;
 		convertStrings2SingleItems(prefPushPolicies, selectedPushPolicy);
 		pushPolicyViewer.refresh();
-		
+
 		String[] prefBufferFullPolicies = SystemEditorPreferenceManager.defaultConnectBufferFullPolicy;
 		convertStrings2SingleItems(prefBufferFullPolicies, selectedBufferFullPolicy);
 		bufferFullPolicyViewer.refresh();
-		
+
 		String[] prefBufferEmptyPolicies = SystemEditorPreferenceManager.defaultConnectBufferEmptyPolicy;
 		convertStrings2SingleItems(prefBufferEmptyPolicies, selectedBufferEmptyPolicy);
 		bufferEmptyPolicyViewer.refresh();
 	}
-		
+
 	private TableViewer createTableViewer(Composite parent, final TableViewer targetViewer) {
 
 		Table table = targetViewer.getTable();
         table.setLinesVisible(false);
         table.setHeaderVisible(false);
-        
+
         GridData gd = new GridData(GridData.FILL_HORIZONTAL);
 		gd.grabExcessHorizontalSpace = true;
 		gd.heightHint = 50;
 		table.setLayoutData(gd);
-        
+
         targetViewer.setContentProvider(new ArrayContentProvider());
         targetViewer.setLabelProvider(new SingleLabelProvider());
 		TableColumn nameColumn = new TableColumn(targetViewer.getTable(), SWT.NONE);
@@ -236,7 +236,6 @@ public class OfflineEditorPreferencePage extends PreferencePage implements
 		//
 		deleteButton.setText(Messages.getString("Common.button.delete")); //$NON-NLS-1$
 		deleteButton.addSelectionListener(new SelectionAdapter() {
-			@SuppressWarnings("unchecked")
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				int selectionIndex = targetViewer.getTable()
@@ -251,7 +250,7 @@ public class OfflineEditorPreferencePage extends PreferencePage implements
 		});
 		gd = new GridData();
 		deleteButton.setLayoutData(gd);
-		
+
 		return targetViewer;
 	}
 
@@ -264,10 +263,10 @@ public class OfflineEditorPreferencePage extends PreferencePage implements
 		gd.grabExcessHorizontalSpace = true;
 		targetGroup.setLayoutData(gd);
 		targetGroup.setText(title);
-		
+
 		return targetGroup;
 	}
-		
+
 	private void convertSingleItems2Strings(List<SingleLabelItem> sources, List<String> targets) {
 		targets.clear();
 		for( SingleLabelItem target : sources) {
@@ -284,14 +283,14 @@ public class OfflineEditorPreferencePage extends PreferencePage implements
 
 	private class SingleLabelItem {
 		private String labeltext = ""; //$NON-NLS-1$
-	
+
 		public SingleLabelItem(String name) {
 			this.labeltext = name;
 		}
 		public String getLabeltext() {
 			return this.labeltext;
 		}
-	
+
 		public void setLabeltext(String contents) {
 			this.labeltext = contents;
 		}
@@ -348,7 +347,7 @@ public class OfflineEditorPreferencePage extends PreferencePage implements
 
 			SingleLabelItem selectedItem = (SingleLabelItem) ((TableItem) element)
 					.getData();
-			
+
 			selectedItem.setLabeltext((String) value);
 
 			viewer.refresh();

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/compositecomponentview/CompositeComponentView.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/compositecomponentview/CompositeComponentView.java
@@ -163,7 +163,7 @@ public class CompositeComponentView extends ViewPart {
 		typeText.setLayoutData(gd);
 		typeText.setEditable(false);
 		typeText.setBackground(colorRegistry.get(COLOR_WHITE));
-	
+
 		final Composite listComposite = new Composite(composite, SWT.FILL);
 		gl = new GridLayout();
 		gl.marginWidth = 0;
@@ -215,7 +215,7 @@ public class CompositeComponentView extends ViewPart {
 		final TableColumn portCol = new TableColumn(portTable, SWT.NONE);
 		portCol.setText("port");
 		portCol.setWidth(200);
-	
+
 		final Composite execButtonComposite = new Composite(composite, SWT.NONE);
 		gl = new GridLayout();
 		gd = new GridData();
@@ -343,7 +343,6 @@ public class CompositeComponentView extends ViewPart {
 		}
 	}
 
-	@SuppressWarnings("unchecked")
 	private void refreshData() {
 		nameText.setText("");
 		typeText.setText("");
@@ -411,7 +410,7 @@ public class CompositeComponentView extends ViewPart {
 		boolean isTarget = false;
 
 		boolean isModified = false;
-		
+
 		boolean isRequired() {
 			return requiredExportedPorts.contains(toConfigString());
 		}
@@ -529,7 +528,6 @@ public class CompositeComponentView extends ViewPart {
 	}
 
 	private ISelectionListener selectionListener = new ISelectionListener() {
-		@SuppressWarnings("unchecked")
 		public void selectionChanged(IWorkbenchPart part, ISelection selection) {
 			targetComponent = null;
 			targetPort = null;

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/configurationview/configurationwrapper/ConfigurationCondition.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/configurationview/configurationwrapper/ConfigurationCondition.java
@@ -469,7 +469,7 @@ public class ConfigurationCondition {
 	 * @return 小数値
 	 */
 	public Double getDecimalByDigits(int ivalue) {
-		Double d = Double.valueOf((double) ivalue);
+		Double d = Double.valueOf(ivalue);
 		d /= Math.pow(10.0, this.getDigits());
 		return d;
 	}
@@ -523,7 +523,7 @@ public class ConfigurationCondition {
 			return 0;
 		if (dvalue > dmax)
 			return widget.getSliderMaxStep();
-		Double step = (dmax - dmin) / (double) widget.getSliderMaxStep();
+		Double step = (dmax - dmin) / widget.getSliderMaxStep();
 //		int result = (int) ((dvalue - dmin) / step );
 		int result = (int) ((dvalue - dmin) / step + 0.5);
 		return result;
@@ -533,7 +533,7 @@ public class ConfigurationCondition {
 	 * maxStep内のstepをmin〜max内の値に変換します
 	 * @param step ステップ位置
 	 * @param widget Widgetオブジェクト
-	 * @param previousValue 
+	 * @param previousValue
 	 * @return 換算した値
 	 */
 	public String getValueByStep(int step, ConfigurationWidget widget,
@@ -549,7 +549,7 @@ public class ConfigurationCondition {
 		double dmin = Double.valueOf(this.min);
 		double dmax = Double.valueOf(this.max);
 		double dprev = Double.valueOf(previousValue);
-		double dvalue = dmin + (widget.getSliderStep() * (double) step);
+		double dvalue = dmin + (widget.getSliderStep() * step);
 		dvalue = (dvalue > dmax) ? dmax : dvalue;
 		if (isInt()) {
 			if (dvalue > dprev && dvalue < dprev + 1) {

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/configurationview/configurationwrapper/ConfigurationWidget.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/configurationview/configurationwrapper/ConfigurationWidget.java
@@ -64,7 +64,7 @@ public class ConfigurationWidget {
 
 		String s = widgets.trim();
 		if (s.charAt(0) != '{')  return s;
-		
+
 		s = s.substring(1, s.length() - 1).trim();	// { }除去
 
 		String[] tokens = s.split(",");
@@ -253,7 +253,7 @@ public class ConfigurationWidget {
 	public int getSpinIncrement() {
 		double step = 1.0;
 		if (hasCondition() && condition.getDigits() > 0) {
-			step = 1.0 / Math.pow(10.0, (double) condition.getDigits());
+			step = 1.0 / Math.pow(10.0, condition.getDigits());
 		}
 		int inc = (int) (spinStep / step);
 		return (inc == 0) ? 1 : inc;

--- a/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/util/CompositeOfflineLoadTest.java
+++ b/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/util/CompositeOfflineLoadTest.java
@@ -186,26 +186,26 @@ public class CompositeOfflineLoadTest extends TestCase {
 		assertEquals(5, component.getPorts().size());
 		verifyPort("CameraComponent_1.ImageData"
 				, "{componentId:RTC:Sample Vender.example.CameraComponent:1.0.0,pathId:file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.CameraComponent_1.0.0.xml:1,instanceName:CameraComponent_1,portName:CameraComponent_1.ImageData}"
-				, (Port) component.getPorts().get(0)
+				, component.getPorts().get(0)
 				, new String[]{});
 		verifyPort("CameraComponent_1.CapPORT"
 				, "{componentId:RTC:Sample Vender.example.CameraComponent:1.0.0,pathId:file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.CameraComponent_1.0.0.xml:1,instanceName:CameraComponent_1,portName:CameraComponent_1.CapPORT}"
-				, (Port) component.getPorts().get(1)
+				, component.getPorts().get(1)
 				, new String[]{"9b4074b4-29b5-4a22-9956-22070915ef25"});
 		verifyPort("ImageProcess_1.Out"
 				, "{componentId:RTC:Sample Vender.example.ImageProcess:1.0.0,pathId:file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.ImageProcess_1.0.0.xml:1,instanceName:ImageProcess_1,portName:ImageProcess_1.Out}"
-				, (Port) component.getPorts().get(2)
+				, component.getPorts().get(2)
 				, new String[]{});
 		verifyPort("ImageProcess_1.In"
 				, "{componentId:RTC:Sample Vender.example.ImageProcess:1.0.0,pathId:file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.ImageProcess_1.0.0.xml:1,instanceName:ImageProcess_1,portName:ImageProcess_1.In}"
-				, (Port) component.getPorts().get(3)
+				, component.getPorts().get(3)
 				, new String[]{});
 		verifyPort("ImageProcess_1.CapPORT"
 				, "{componentId:RTC:Sample Vender.example.ImageProcess:1.0.0,pathId:file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.ImageProcess_1.0.0.xml:1,instanceName:ImageProcess_1,portName:ImageProcess_1.CapPORT}"
-				, (Port) component.getPorts().get(4)
+				, component.getPorts().get(4)
 				, new String[]{});
 		assertEquals(1, component.getConfigurationSets().size());
-		verifyConfigSet((jp.go.aist.rtm.toolscommon.model.component.ConfigurationSet) component.getConfigurationSets().get(0));
+		verifyConfigSet(component.getConfigurationSets().get(0));
 		EList components = component.getComponents();
 		assertEquals(2, components.size());
 //		assertEquals(diagram.getComponents().get(0), components.get(0));
@@ -270,11 +270,11 @@ public class CompositeOfflineLoadTest extends TestCase {
 		assertEquals(2, component.getPorts().size());
 		verifyPort("ImageViewer_1.ImageDataIn"
 				, "{componentId:RTC:Sample Vender.example.ImageViewer:1.0.0,pathId:file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.ImageViewer_1.0.0.xml:1,instanceName:ImageViewer_1,portName:ImageViewer_1.ImageDataIn}"
-				, (Port) component.getPorts().get(0)
+				, component.getPorts().get(0)
 				, new String[]{});
 		verifyPort("ImageViewer_1.CapPORT"
 				, "{componentId:RTC:Sample Vender.example.ImageViewer:1.0.0,pathId:file://localhost/C:\\RTSystemEditor\\rsmtj\\RTC_Sample Vender.example.ImageViewer_1.0.0.xml:1,instanceName:ImageViewer_1,portName:ImageViewer_1.CapPORT}"
-				, (Port) component.getPorts().get(1)
+				, component.getPorts().get(1)
 				, new String[]{"9b4074b4-29b5-4a22-9956-22070915ef25"});
 		assertEquals(0, component.getConfigurationSets().size());
 		verifyLocation("LEFT", 495, 160, component);
@@ -285,7 +285,7 @@ public class CompositeOfflineLoadTest extends TestCase {
 		assertEquals(originalPortString, port.getOriginalPortString());
 		assertEquals(connectorIds.length, port.getConnectorProfiles().size());
 		for (int i = 0; i < connectorIds.length; i++) {
-			ConnectorProfile connectorProfile = (ConnectorProfile) port.getConnectorProfiles().get(i);
+			ConnectorProfile connectorProfile = port.getConnectorProfiles().get(i);
 			assertEquals(connectorIds[i], connectorProfile.getConnectorId());
 		}
 	}
@@ -293,7 +293,7 @@ public class CompositeOfflineLoadTest extends TestCase {
 	private void verifyConfigSet(jp.go.aist.rtm.toolscommon.model.component.ConfigurationSet configSet) {
 		assertEquals("default", configSet.getId());
 		assertEquals(1, configSet.getConfigurationData().size());
-		NameValue nv = (NameValue) configSet.getConfigurationData().get(0);
+		NameValue nv = configSet.getConfigurationData().get(0);
 		assertEquals("CameraComponent_1.ImageData,CameraComponent_1.CapPORT,ImageProcess_1.In,ImageProcess_1.Out,ImageProcess_1.CapPORT"
 				, nv.getValueAsString());
 		assertEquals("exported_ports", nv.getName());

--- a/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/util/RestoreConnectionTest.java
+++ b/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/util/RestoreConnectionTest.java
@@ -18,12 +18,12 @@ public class RestoreConnectionTest extends TestCase {
 	private Port port1;
 	private Port port2;
 	private Port port3;
-	
+
 	private Component component1;
 	private Component component2;
 	private Component component3;
 	private Component component4;
-	
+
 	private SystemDiagram diagram;
 	private RtsProfileExt profile;
 	private ObjectFactory factory;
@@ -34,14 +34,14 @@ public class RestoreConnectionTest extends TestCase {
 		verifyConnectorCount(port1, 1);
 		verifyConnectorCount(port2, 0);
 		verifyConnectorCount(port3, 1);
-		ConnectorProfile connector1 = (ConnectorProfile) port1.getConnectorProfiles().get(0);
+		ConnectorProfile connector1 = port1.getConnectorProfiles().get(0);
 //		assertEquals(port3, connector1.getTarget());
 		assertEquals(port3.getOriginalPortString(), connector1.getTargetString());
-		ConnectorProfile connector2 = (ConnectorProfile) port3.getConnectorProfiles().get(0);
+		ConnectorProfile connector2 = port3.getConnectorProfiles().get(0);
 //		assertEquals(port1, connector2.getSource());
 		assertEquals(port1.getOriginalPortString(), connector2.getSourceString());
 	}
-	
+
 	private void verifyConnectorCount(Port port, int profileCount) {
 		assertEquals(profileCount, port.getConnectorProfiles().size());
 	}
@@ -51,12 +51,12 @@ public class RestoreConnectionTest extends TestCase {
 		setupPort1();
 		setupPort2();
 		setupPort3();
-		
+
 		setupComponent1();
 		setupComponent2();
 		setupComponent3();
 		setupComponent4();
-		
+
 		setupProfile();
 		setupDiagram();
 	}

--- a/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/util/RtsProfileHandlerTest.java
+++ b/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/util/RtsProfileHandlerTest.java
@@ -122,7 +122,7 @@ public class RtsProfileHandlerTest extends TestCase {
 //		assertEquals("value1", property.getValue());
 
 		assertEquals(1, diagram.getComponents().size());
-		jp.go.aist.rtm.toolscommon.model.component.Component component = (jp.go.aist.rtm.toolscommon.model.component.Component) diagram.getComponents().get(0);
+		jp.go.aist.rtm.toolscommon.model.component.Component component = diagram.getComponents().get(0);
 		assertTrue(component instanceof CorbaComponent);
 		assertEquals("id3", component.getComponentId());
 		assertEquals("192.168.1.164/client164.local.tech-arts.co.jp.host_cxt/Composite0.rtc", component.getPathId());
@@ -146,12 +146,12 @@ public class RtsProfileHandlerTest extends TestCase {
 		// XMLのロードを行った段階ではコンフィグの情報はセットしない
 		assertTrue(component.getConfigurationSets().isEmpty());
 
-		jp.go.aist.rtm.toolscommon.model.component.Component component2 = (jp.go.aist.rtm.toolscommon.model.component.Component) component.getComponents().get(0);
+		jp.go.aist.rtm.toolscommon.model.component.Component component2 = component.getComponents().get(0);
 		assertNull(component2.getCategoryL());
 		assertFalse(component2.isRequired());
 		assertEquals(0, component2.getComponents().size());
 
-		jp.go.aist.rtm.toolscommon.model.component.Component component3 = (jp.go.aist.rtm.toolscommon.model.component.Component) component.getComponents().get(1);
+		jp.go.aist.rtm.toolscommon.model.component.Component component3 = component.getComponents().get(1);
 		assertEquals(0, component3.getComponents().size());
 	}
 
@@ -164,27 +164,27 @@ public class RtsProfileHandlerTest extends TestCase {
 		handler.populate(diagram, profile);
 		diagram.setProfile(profile);
 
-		jp.go.aist.rtm.toolscommon.model.component.Component component = (jp.go.aist.rtm.toolscommon.model.component.Component) diagram.getComponents().get(0);
+		jp.go.aist.rtm.toolscommon.model.component.Component component = diagram.getComponents().get(0);
 		assertTrue(component instanceof ComponentSpecification);
 
 		handler.restoreConfigSet(diagram);
 		handler.restoreCompositeComponentPort(diagram);
 
-		Port port = (Port) component.getPorts().get(0);
+		Port port = component.getPorts().get(0);
 		assertEquals("ConsoleIn0.out", port.getNameL());
-		port = (Port) component.getPorts().get(1);
+		port = component.getPorts().get(1);
 		assertEquals("ConsoleIn0.client", port.getNameL());
 		assertEquals("{componentId:id2,pathId:192.168.1.164/client164.local.tech-arts.co.jp.host_cxt/ConsoleIn0.rtc,instanceName:ConsoleIn0,portName:ConsoleIn0.client}", port.getOriginalPortString());
-		port = (Port) component.getPorts().get(2);
+		port = component.getPorts().get(2);
 		assertEquals("ConsoleOut0.in", port.getNameL());
-		port = (Port) component.getPorts().get(3);
+		port = component.getPorts().get(3);
 		assertEquals("ConsoleOut0.server", port.getNameL());
 
 		handler.restoreConnection(diagram);
-		port = (Port) component.getPorts().get(0);
+		port = component.getPorts().get(0);
 		assertEquals("ConsoleIn0.out", port.getNameL());
 		assertEquals("{componentId:id2,pathId:192.168.1.164/client164.local.tech-arts.co.jp.host_cxt/ConsoleIn0.rtc,instanceName:ConsoleIn0,portName:ConsoleIn0.out}", port.getOriginalPortString());
-		ConnectorProfile connector1 = (ConnectorProfile) port.getConnectorProfiles().get(0);
+		ConnectorProfile connector1 = port.getConnectorProfiles().get(0);
 		assertEquals("connector1", connector1.getConnectorId());
 		assertEquals("conectorName1", connector1.getName());
 		assertEquals("TimedOctetSeq", connector1.getDataType());
@@ -194,34 +194,34 @@ public class RtsProfileHandlerTest extends TestCase {
 		assertNull(connector1.getPushRate());
 		// ベンディングポイントの復元
 		PortConnector portConnector = diagram.getConnectorMap().get("connector1");
-		Point point = (Point) portConnector.getRoutingConstraint().map().get(1);
+		Point point = portConnector.getRoutingConstraint().map().get(1);
 		assertEquals(392, point.getX());
 		assertEquals(110, point.getY());
 
-		port = (Port) component.getPorts().get(1);
-		ConnectorProfile connector2 = (ConnectorProfile) port.getConnectorProfiles().get(0);
+		port = component.getPorts().get(1);
+		ConnectorProfile connector2 = port.getConnectorProfiles().get(0);
 		assertEquals("connector2", connector2.getConnectorId());
 		assertEquals("conectorName2", connector2.getName());
 		// ベンディングポイントの復元
 		portConnector = diagram.getConnectorMap().get("connector2");
 		assertTrue(portConnector.getRoutingConstraint().map().isEmpty());
 
-		port = (Port) component.getPorts().get(1);
+		port = component.getPorts().get(1);
 		assertEquals("ConsoleIn0.client", port.getNameL());
 
-		jp.go.aist.rtm.toolscommon.model.component.Component component3 = (jp.go.aist.rtm.toolscommon.model.component.Component) component.getComponents().get(1);
-		port = (Port) component3.getPorts().get(0);
+		jp.go.aist.rtm.toolscommon.model.component.Component component3 = component.getComponents().get(1);
+		port = component3.getPorts().get(0);
 		assertEquals(connector1, port.getConnectorProfiles().get(0));
 		assertEquals(port.getOriginalPortString(), connector1.getTargetString());
-		port = (Port) component3.getPorts().get(1);
+		port = component3.getPorts().get(1);
 		assertEquals(connector2, port.getConnectorProfiles().get(0));
 		assertEquals(port.getOriginalPortString(), connector2.getTargetString());
 
-		jp.go.aist.rtm.toolscommon.model.component.Component component2 = (jp.go.aist.rtm.toolscommon.model.component.Component) component.getComponents().get(0);
-		jp.go.aist.rtm.toolscommon.model.component.ConfigurationSet configSet = (jp.go.aist.rtm.toolscommon.model.component.ConfigurationSet) component2.getConfigurationSets().get(0);
+		jp.go.aist.rtm.toolscommon.model.component.Component component2 = component.getComponents().get(0);
+		jp.go.aist.rtm.toolscommon.model.component.ConfigurationSet configSet = component2.getConfigurationSets().get(0);
 		assertEquals(component2.getActiveConfigurationSet(), configSet);
 		assertEquals("config1", configSet.getId());
-		NameValue configData = (NameValue) configSet.getConfigurationData().get(0);
+		NameValue configData = configSet.getConfigurationData().get(0);
 		assertEquals("name1", configData.getName());
 		assertEquals("value1", configData.getValueAsString());
 	}

--- a/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/views/configurationview/mock/ComponentMock.java
+++ b/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/views/configurationview/mock/ComponentMock.java
@@ -466,7 +466,7 @@ public class ComponentMock implements Component {
 			if (result.length() > 0) {
 				result += ",";
 			}
-			result += (String) values.get(i);
+			result += values.get(i);
 		}
 		nv.setValue(result);
 		return true;

--- a/jp.go.aist.rtm.toolscommon.profiles/src/jp/go/aist/rtm/toolscommon/profiles/handlers/CommonDocHandler.java
+++ b/jp.go.aist.rtm.toolscommon.profiles/src/jp/go/aist/rtm/toolscommon/profiles/handlers/CommonDocHandler.java
@@ -14,16 +14,16 @@ public class CommonDocHandler extends DefaultBeanWrapper {
 	@SuppressWarnings("unchecked")
 	public Collection<?> keys() {
     	Collection<?> result = super.keys();
-    	
+
     	for( int intIdx=0; intIdx<result.size(); intIdx++) {
     		String target = ((List<String>)result).get(intIdx);
-    		if( ((String)target).equals("doc") ) {
+    		if( target.equals("doc") ) {
     			((List<String>)result).set(intIdx, "rtcDoc::doc");
     		}
     	}
     	return result;
     }
-	
+
     public Object getProperty(Object obj, String name) {
     	if(name.equals("rtcDoc::doc")) {
     		name = "doc";

--- a/jp.go.aist.rtm.toolscommon.profiles/src/jp/go/aist/rtm/toolscommon/profiles/util/XmlHandler.java
+++ b/jp.go.aist.rtm.toolscommon.profiles/src/jp/go/aist/rtm/toolscommon/profiles/util/XmlHandler.java
@@ -93,22 +93,20 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
 public class XmlHandler {
-	
+
 	private static final Logger LOGGER = LoggerFactory
 			.getLogger(XmlHandler.class);
-	
+
 	public RtsProfileExt loadXmlRts(String targetFile) throws Exception {
 		LOGGER.debug("loadXmlRts: targetFile=<{}>", targetFile);
 		StringBuffer stbRet = new StringBuffer();
-		InputStreamReader isr = new InputStreamReader(new FileInputStream(targetFile), "UTF-8");
-		BufferedReader br = new BufferedReader(isr);
-
-		String str = new String();
-		while( (str = br.readLine()) != null ){
-			stbRet.append(str + "\n");
+		try( InputStreamReader isr = new InputStreamReader(new FileInputStream(targetFile), "UTF-8");
+				BufferedReader br = new BufferedReader(isr) ) {
+			String str = new String();
+			while( (str = br.readLine()) != null ){
+				stbRet.append(str + "\n");
+			}
 		}
-		br.close();
-		isr.close();
 		return restoreFromXmlRts(stbRet.toString());
 	}
 
@@ -152,17 +150,16 @@ public class XmlHandler {
 		if( lineSeparator==null || lineSeparator.equals("") ) lineSeparator = "\n";
 		String xmlSplit[] = xmlString.split(lineSeparator);
 
-		BufferedWriter outputFile = new BufferedWriter(
-					new OutputStreamWriter(new FileOutputStream(targetFile), "UTF-8"));
-		for(int intIdx=0;intIdx<xmlSplit.length;intIdx++) {
-			outputFile.write(xmlSplit[intIdx]);
-			outputFile.newLine();
+		try(BufferedWriter outputFile = new BufferedWriter(
+					new OutputStreamWriter(new FileOutputStream(targetFile), "UTF-8")) ) {
+			for(int intIdx=0;intIdx<xmlSplit.length;intIdx++) {
+				outputFile.write(xmlSplit[intIdx]);
+				outputFile.newLine();
+			}
 		}
-		outputFile.close();
-		
 		return true;
 	}
-	
+
 	public String convertToXmlRts(RtsProfile profile) throws Exception {
 	    String xmlString = "";
 		try {
@@ -186,7 +183,7 @@ public class XmlHandler {
 			JAXBContext jc = JAXBContext.newInstance(RtcProfile.class);
 			Unmarshaller unmarshaller = jc.createUnmarshaller();
 
-			SchemaFactory sf = SchemaFactory.newInstance(javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI);  
+			SchemaFactory sf = SchemaFactory.newInstance(javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI);
 			Schema schema = sf.newSchema(new File("schema/RtcProfile_ext.xsd"));
 			unmarshaller.setSchema(schema);
 
@@ -234,11 +231,11 @@ public class XmlHandler {
 	    if( targetClass==null ) {
 	    	throw new Exception(Messages.getString("XmlHandler.30"));
 	    }
-	    
+
 	    if( !xmlParser.version.equals("0.1") ) {
 	    	targetXML = replacePositionValue(targetXML);
 	    }
-	    
+
 		JAXBContext jc = JAXBContext.newInstance(targetClass);
 		Unmarshaller unmarshaller = jc.createUnmarshaller();
 		unmarshaller.setEventHandler(new javax.xml.bind.helpers.DefaultValidationEventHandler());
@@ -254,7 +251,7 @@ public class XmlHandler {
 
 	    return result;
 	}
-	
+
 	public String convertToXmlDeploy(DeployProfile profile) throws Exception {
 	    String xmlString = "";
 		try {
@@ -272,7 +269,7 @@ public class XmlHandler {
 		}
 		return xmlString;
 	}
-	
+
 	public DeployProfile restoreFromXmlDeploy(String targetXML) throws Exception {
 		DeployProfile result = null;
 		JAXBContext jc = JAXBContext.newInstance("org.openrtp.namespaces.deploy");
@@ -286,17 +283,15 @@ public class XmlHandler {
 	}
 
 	public DeployProfile loadXmlDeploy(String targetFile) throws Exception {
-		
-		StringBuffer stbRet = new StringBuffer();
-		InputStreamReader isr = new InputStreamReader(new FileInputStream(targetFile), "UTF-8");
-		BufferedReader br = new BufferedReader(isr);
 
-		String str = new String();
-		while( (str = br.readLine()) != null ){
-			stbRet.append(str + "\n");
+		StringBuffer stbRet = new StringBuffer();
+		try( InputStreamReader isr = new InputStreamReader(new FileInputStream(targetFile), "UTF-8");
+				BufferedReader br = new BufferedReader(isr) ) {
+			String str = new String();
+			while( (str = br.readLine()) != null ){
+				stbRet.append(str + "\n");
+			}
 		}
-		br.close();
-		isr.close();
 		return restoreFromXmlDeploy(stbRet.toString());
 	}
 
@@ -307,17 +302,16 @@ public class XmlHandler {
 		if( lineSeparator==null || lineSeparator.equals("") ) lineSeparator = "\n";
 		String xmlSplit[] = xmlString.split(lineSeparator);
 
-		BufferedWriter outputFile = new BufferedWriter(
-					new OutputStreamWriter(new FileOutputStream(targetFile), "UTF-8"));
-		for(int intIdx=0;intIdx<xmlSplit.length;intIdx++) {
-			outputFile.write(xmlSplit[intIdx]);
-			outputFile.newLine();
+		try( BufferedWriter outputFile = new BufferedWriter(
+					new OutputStreamWriter(new FileOutputStream(targetFile), "UTF-8")) ) {
+			for(int intIdx=0;intIdx<xmlSplit.length;intIdx++) {
+				outputFile.write(xmlSplit[intIdx]);
+				outputFile.newLine();
+			}
 		}
-		outputFile.close();
-		
 		return true;
 	}
-	
+
 	private class RtsXMLParser extends DefaultHandler {
 		private String version = "";
 
@@ -333,9 +327,9 @@ public class XmlHandler {
 			}
 			super.startElement(uri, localName, qName, attributes);
 		}
-		
+
 	}
-	
+
 	private class RtcXMLParser extends DefaultHandler {
 		private String version = "";
 
@@ -351,30 +345,30 @@ public class XmlHandler {
 			}
 			super.startElement(uri, localName, qName, attributes);
 		}
-		
+
 	}
-	
+
 	private String replacePositionValue(String targetXML) {
 		// 旧version02から新version02の差分を吸収するための置換
 		Pattern patternLeft = Pattern.compile("rtcExt:position=\"left\"");
 		Matcher matcherLeft = patternLeft.matcher(targetXML);
 		targetXML = matcherLeft.replaceAll("rtcExt:position=\"LEFT\"");
-		
+
 		Pattern patternRight = Pattern.compile("rtcExt:position=\"right\"");
 		Matcher matcherRight = patternRight.matcher(targetXML);
 		targetXML = matcherRight.replaceAll("rtcExt:position=\"RIGHT\"");
-	
+
 		Pattern patternTop = Pattern.compile("rtcExt:position=\"top\"");
 		Matcher matcherTop = patternTop.matcher(targetXML);
 		targetXML = matcherTop.replaceAll("rtcExt:position=\"TOP\"");
-	
+
 		Pattern patternBottom = Pattern.compile("rtcExt:position=\"bottom\"");
 		Matcher matcherBottom = patternBottom.matcher(targetXML);
 		targetXML = matcherBottom.replaceAll("rtcExt:position=\"BOTTOM\"");
-		
+
 		return targetXML;
 	}
-	
+
 	public static String restoreConstraint(ConstraintType source) throws Exception {
 		if( source==null ) 	throw new Exception(Messages.getString("XmlHandler.38"));
 
@@ -412,28 +406,28 @@ public class XmlHandler {
 		////
 		PropertyIsEqualTo equal = unit.getPropertyIsEqualTo();
 		if( equal!=null ) {
-			if( equal.getLiteral()==null || equal.getLiteral().length()<=0 ) 
+			if( equal.getLiteral()==null || equal.getLiteral().length()<=0 )
 				throw new Exception(Messages.getString("XmlHandler.45"));
 			result.append(equal.getLiteral());
 		}
 		////
 		PropertyIsGreaterThanOrEqualTo greaterEq = unit.getPropertyIsGreaterThanOrEqualTo();
 		if( greaterEq!=null ) {
-			if( greaterEq.getLiteral()==null || greaterEq.getLiteral().length()<=0 ) 
+			if( greaterEq.getLiteral()==null || greaterEq.getLiteral().length()<=0 )
 				throw new Exception(Messages.getString("XmlHandler.46"));
 			result.append("x>=" + greaterEq.getLiteral());
 		}
 		////
 		PropertyIsLessThanOrEqualTo lessEq = unit.getPropertyIsLessThanOrEqualTo();
 		if( lessEq!=null ) {
-			if( lessEq.getLiteral()==null || lessEq.getLiteral().length()<=0 ) 
+			if( lessEq.getLiteral()==null || lessEq.getLiteral().length()<=0 )
 				throw new Exception(Messages.getString("XmlHandler.48"));
 			result.append("x<=" + lessEq.getLiteral());
 		}
 		////
 		PropertyIsGreaterThan greater = unit.getPropertyIsGreaterThan();
 		if( greater!=null ) {
-			if( greater.getLiteral()==null || greater.getLiteral().length()<=0 ) 
+			if( greater.getLiteral()==null || greater.getLiteral().length()<=0 )
 				throw new Exception(Messages.getString("XmlHandler.50"));
 			result.append("x>" + greater.getLiteral());
 		}
@@ -471,7 +465,7 @@ public class XmlHandler {
 		if( and!=null ) {
 			//And条件で３つ以上の要素はない
 			if( and.getConstraint().size() > 2 ) throw new Exception(Messages.getString("XmlHandler.60"));
-			
+
 			ConstraintUnitType former = and.getConstraint().get(0).getConstraintUnitType();
 			ConstraintUnitType latter = and.getConstraint().get(1).getConstraintUnitType();
 
@@ -512,16 +506,16 @@ public class XmlHandler {
 
 		return result.toString();
 	}
-	
+
 	public static ConstraintType convertToXmlConstraint(String source) throws Exception {
 		if(source==null || source.length()==0 ) throw new Exception(Messages.getString("XmlHandler.69"));
 		source = source.replace(" ", "");
-		
+
 		ObjectFactory factory = new ObjectFactory();
 		ConstraintType result = factory.createConstraintType();
-		
+
 		ConstraintUnitType unit = factory.createConstraintUnitType();
-		
+
 		if(source.trim().startsWith("(") && source.trim().endsWith(")")) {
 			String body = source.trim().substring(1,source.trim().length()-1);
 			String[] elem = body.trim().split(",");
@@ -549,7 +543,7 @@ public class XmlHandler {
 			}
 			result.setConstraintHashType(list);
 			return result;
-			
+
 		} else 	if( source.contains(",") ) {
 			String[] elem = source.trim().split(",");
 			if( elem.length<=0 ) throw new Exception(Messages.getString("XmlHandler.82"));
@@ -559,7 +553,7 @@ public class XmlHandler {
 			}
 			result.setConstraintListType(list);
 			return result;
-			
+
 		} else 	if( source.contains("=") || source.contains("<") || source.contains(">") ) {
 			if(source.trim().startsWith("x") || source.trim().endsWith("x")) {
 				String body = "";
@@ -574,7 +568,7 @@ public class XmlHandler {
 					PropertyIsGreaterThanOrEqualTo prop = factory.createPropertyIsGreaterThanOrEqualTo();
 					prop.setLiteral(body);
 					unit.setPropertyIsGreaterThanOrEqualTo(prop);
-					
+
 				} else if( source.trim().startsWith("x>") || source.trim().endsWith("<x") ) {
 					if(source.trim().startsWith("x>")) {
 						body = source.trim().substring("x>".length());
@@ -586,7 +580,7 @@ public class XmlHandler {
 					PropertyIsGreaterThan prop = factory.createPropertyIsGreaterThan();
 					prop.setLiteral(body);
 					unit.setPropertyIsGreaterThan(prop);
-					
+
 				} else if( source.trim().startsWith("x<=") || source.trim().endsWith("=>x") ) {
 					if(source.trim().startsWith("x<=")) {
 						body = source.trim().substring("x<=".length());
@@ -635,7 +629,7 @@ public class XmlHandler {
 				prop.setLowerBoundary(lower);
 				prop.setUpperBoundary(upper);
 				unit.setPropertyIsBetween(prop);
-					
+
 			} else	if( source.trim().contains("x") ) {
 				int index = source.trim().indexOf("x");
 				String former = source.trim().substring(0,index+1);
@@ -644,7 +638,7 @@ public class XmlHandler {
 				prop.getConstraint().add(convertToXmlConstraint(former));
 				prop.getConstraint().add(convertToXmlConstraint(latter));
 				unit.setAnd(prop);
-				
+
 			} else {
 				throw new Exception(Messages.getString("XmlHandler.137"));
 			}
@@ -656,10 +650,10 @@ public class XmlHandler {
 			unit.setPropertyIsEqualTo(equal);
 		}
 		result.setConstraintUnitType(unit);
-		
+
 		return result;
 	}
-	
+
 	private RtsProfileExt convertRtsProfile01to02(Object source) {
 		RtsProfileExt result02 = null;
 		org.openrtp.namespaces.rts.version01.RtsProfile profile01 = (org.openrtp.namespaces.rts.version01.RtsProfile)source;
@@ -800,7 +794,7 @@ public class XmlHandler {
 									if( portProperties01!=null ) {
 										connector02.getProperties().addAll(convertRtsProperty01to02(factory, portProperties01));
 									}
-								}									
+								}
 							}
 						}
 					}
@@ -848,7 +842,7 @@ public class XmlHandler {
 									if( portProperties01!=null ) {
 										connector02.getProperties().addAll(convertRtsProperty01to02(factory, portProperties01));
 									}
-								}									
+								}
 							}
 						}
 					}
@@ -981,14 +975,14 @@ public class XmlHandler {
 		}
 		return cond02;
 	}
-	
+
 	private String getPropertyValue(String targetKey, List<org.openrtp.namespaces.rts.version01.Property> propList) {
 		for(org.openrtp.namespaces.rts.version01.Property prop : propList) {
 			if( prop.getName().equals(targetKey) )
 				return prop.getValue();
 		}
 		return null;
-		
+
 	}
 	//
 	private RtcProfile convertRtcProfile01to02(Object source) {
@@ -1161,7 +1155,7 @@ public class XmlHandler {
 				dataPort02.setSubscriptionType(dataport01.getSubscriprionType());
 				//Doc Profile
 				if( dataport01 instanceof org.openrtp.namespaces.rtc.version01.DataportDoc) {
-					org.openrtp.namespaces.rtc.version01.DocDataport docDataPort01 = ((org.openrtp.namespaces.rtc.version01.DataportDoc)dataport01).getDoc(); 
+					org.openrtp.namespaces.rtc.version01.DocDataport docDataPort01 = ((org.openrtp.namespaces.rtc.version01.DataportDoc)dataport01).getDoc();
 					if( docDataPort01!=null ) {
 						DocDataport docDataPort02 = factory.createDocDataport();
 						docDataPort02.setDescription(docDataPort01.getDescription());
@@ -1197,7 +1191,7 @@ public class XmlHandler {
 				servicePort02.setName(serviceport01.getName());
 				//Doc Profile
 				if( serviceport01 instanceof org.openrtp.namespaces.rtc.version01.ServiceportDoc) {
-					org.openrtp.namespaces.rtc.version01.DocServiceport docServicePort01 = ((org.openrtp.namespaces.rtc.version01.ServiceportDoc)serviceport01).getDoc(); 
+					org.openrtp.namespaces.rtc.version01.DocServiceport docServicePort01 = ((org.openrtp.namespaces.rtc.version01.ServiceportDoc)serviceport01).getDoc();
 					if( docServicePort01!=null ) {
 						DocServiceport docServicePort02 = factory.createDocServiceport();
 						docServicePort02.setDescription(docServicePort01.getDescription());
@@ -1230,7 +1224,7 @@ public class XmlHandler {
 						serviceIF02.setPath(serviceIF01.getPath());
 						//Doc Profile
 						if( serviceIF01 instanceof org.openrtp.namespaces.rtc.version01.ServiceinterfaceDoc) {
-							org.openrtp.namespaces.rtc.version01.DocServiceinterface docServiceIF01 = ((org.openrtp.namespaces.rtc.version01.ServiceinterfaceDoc)serviceIF01).getDoc(); 
+							org.openrtp.namespaces.rtc.version01.DocServiceinterface docServiceIF01 = ((org.openrtp.namespaces.rtc.version01.ServiceinterfaceDoc)serviceIF01).getDoc();
 							if( docServiceIF01!=null ) {
 								DocServiceinterface docServiceIF02 = factory.createDocServiceinterface();
 								docServiceIF02.setDescription(docServiceIF01.getDescription());
@@ -1319,7 +1313,7 @@ public class XmlHandler {
 				result02.setLanguage(lang);
 			}
 		}
-		
+
 		return result02;
 	}
 
@@ -1365,7 +1359,7 @@ public class XmlHandler {
 		}
 		return result;
 	}
-	
+
 	private ActionStatusDoc convertAction01to02(ObjectFactory factory, Actions actions02, org.openrtp.namespaces.rtc.version01.ActionStatus action01) {
 		ActionStatusDoc action02 = null;
 		if( action01!=null ) {
@@ -1382,9 +1376,9 @@ public class XmlHandler {
 				}
 			}
 		}
-		return action02; 
+		return action02;
 	}
-	
+
 	public boolean validateXmlRtcBySchema(String targetString) throws Exception {
 		try {
 		    SAXParserFactory spfactory = SAXParserFactory.newInstance();
@@ -1401,7 +1395,7 @@ public class XmlHandler {
 		    if( targetClass==null ) {
 		    	throw new Exception("XML Parse Error");
 		    }
-			
+
 			JAXBContext jc = JAXBContext.newInstance(targetClass);
 			Unmarshaller unmarshaller = jc.createUnmarshaller();
 
@@ -1416,7 +1410,7 @@ public class XmlHandler {
 		}
 		return true;
 	}
-	
+
 	public boolean validateXmlRtsBySchema(String targetString) throws Exception {
 		try {
 		    SAXParserFactory spfactory = SAXParserFactory.newInstance();
@@ -1433,7 +1427,7 @@ public class XmlHandler {
 		    if( targetClass==null ) {
 		    	throw new Exception("XML Parse Error");
 		    }
-			
+
 			JAXBContext jc = JAXBContext.newInstance(targetClass);
 			Unmarshaller unmarshaller = jc.createUnmarshaller();
 

--- a/jp.go.aist.rtm.toolscommon.profiles/src/jp/go/aist/rtm/toolscommon/profiles/util/YamlHandler.java
+++ b/jp.go.aist.rtm.toolscommon.profiles/src/jp/go/aist/rtm/toolscommon/profiles/util/YamlHandler.java
@@ -26,43 +26,40 @@ public class YamlHandler {
 		}
 		return buffer.toString();
 	}
-	
+
 	private String[] removeClassInfo(String strInput) {
 		String lineSeparator = System.getProperty( "line.separator" );
 		if( lineSeparator==null || lineSeparator.equals("") ) lineSeparator = "\n";
 		String splitStr[] = strInput.split(lineSeparator);
-	
+
 		String strWork = "";
 		for( int intidx=0;intidx<splitStr.length;intidx++ ) {
 			strWork = splitStr[intidx];
 			if(strWork.trim().contains(containClassName)) {
-				int end = strWork.indexOf(containClassName); 
+				int end = strWork.indexOf(containClassName);
 				splitStr[intidx] = strWork.substring(0,end+1);
 			}
 			if(strWork.trim().startsWith(prefixClassName)) {
-				int end = strWork.indexOf(prefixClassName); 
+				int end = strWork.indexOf(prefixClassName);
 				splitStr[intidx] = strWork.substring(0,end+1);
 			}
 		}
 		return splitStr;
 	}
 
-	@SuppressWarnings("unchecked")
 	public RtcProfile restoreFromYamlRtc(InputStream input) throws Exception {
 		Map profileYOrg  = (Map)Yaml.load(input);
 		return mapToRtc(profileYOrg);
 	}
 
-	@SuppressWarnings("unchecked")
 	public RtcProfile restoreFromYamlRtc(String targetYaml) throws Exception {
 		Map profileYOrg  = (Map)Yaml.load(targetYaml);
 		return mapToRtc(profileYOrg);
 	}
 
-	@SuppressWarnings("unchecked")
 	private RtcProfile mapToRtc(Map profileYOrg) throws Exception {
 		RtcProfile result = null;
-		
+
 		if( profileYOrg != null ) {
 			Map profileY  = (Map)profileYOrg.get("rtcProfile");
 			if( profileY != null ) {
@@ -76,7 +73,7 @@ public class YamlHandler {
 				}
 			}
 		}
-		
+
 		return result;
 	}
 }

--- a/jp.go.aist.rtm.toolscommon.profiles/src/jp/go/aist/rtm/toolscommon/profiles/util/YamlSubHandlerVer01.java
+++ b/jp.go.aist.rtm.toolscommon.profiles/src/jp/go/aist/rtm/toolscommon/profiles/util/YamlSubHandlerVer01.java
@@ -168,7 +168,7 @@ public class YamlSubHandlerVer01 {
 					}
 					if( isActionAdded ) profile.setActions(actions);
 				}
-			
+
 				//Data Ports
 				List dataPortListY = (List)profileY.get("dataPorts");
 				if( dataPortListY != null ) {
@@ -216,7 +216,7 @@ public class YamlSubHandlerVer01 {
 									docconfig.setDescription((String)configDocY.get("description"));
 									docconfig.setRange((String)configDocY.get("range"));
 									docconfig.setUnit((String)configDocY.get("unit"));
-									
+
 									config.setDoc(docconfig);
 								}
 								//Properties
@@ -237,7 +237,7 @@ public class YamlSubHandlerVer01 {
 						profile.setConfigurationSet(configset);
 					}
 				}
-					
+
 				//Parameter
 				List paramsInfoY = (List)profileY.get("parameters");
 				if( paramsInfoY != null ) {
@@ -281,7 +281,6 @@ public class YamlSubHandlerVer01 {
 		return profile;
 	}
 
-	@SuppressWarnings("unchecked")
 	private void createTargetEnv(ObjectFactory factory, LanguageExt language, Map langInfoY) {
 		TargetEnvironment env = factory.createTargetEnvironment();
 		env.setOs((String)langInfoY.get("os"));
@@ -297,7 +296,6 @@ public class YamlSubHandlerVer01 {
 		language.getTargets().add(env);
 	}
 
-	@SuppressWarnings("unchecked")
 	private XMLGregorianCalendar createDateTimeFromYaml(Map dateY) {
 		return XMLGregorianCalendarImpl.createDateTime(
 				((Integer)dateY.get("year")).intValue(),
@@ -307,8 +305,7 @@ public class YamlSubHandlerVer01 {
 				((Integer)dateY.get("minute")).intValue(),
 				((Integer)dateY.get("second")).intValue() );
 	}
-	
-	@SuppressWarnings("unchecked")
+
 	private ActionStatusDoc createActionFromYaml(Map actionY) {
 		ObjectFactory factory = new ObjectFactory();
 		ActionStatusDoc actionStatus = factory.createActionStatusDoc();
@@ -330,7 +327,6 @@ public class YamlSubHandlerVer01 {
 		return actionStatus;
 	}
 
-	@SuppressWarnings("unchecked")
 	private DataportExt createDataPortFromYaml(Map yamlMap) {
 		ObjectFactory factory = new ObjectFactory();
 		DataportExt dataport = factory.createDataportExt();
@@ -373,8 +369,7 @@ public class YamlSubHandlerVer01 {
 		//
 		return dataport;
 	}
-	
-	@SuppressWarnings("unchecked")
+
 	private ServiceportExt createServicePortFromYaml(Map yamlMap) {
 		ObjectFactory factory = new ObjectFactory();
 		ServiceportExt serviceport = factory.createServiceportExt();
@@ -403,7 +398,7 @@ public class YamlSubHandlerVer01 {
 				}
 			}
 		}
-		
+
 		//Service Interface
 		List interfacesY = (List)yamlMap.get("serviceInterface");
 		if( interfacesY != null ) {

--- a/jp.go.aist.rtm.toolscommon.profiles/src/jp/go/aist/rtm/toolscommon/profiles/util/YamlSubHandlerVer02.java
+++ b/jp.go.aist.rtm.toolscommon.profiles/src/jp/go/aist/rtm/toolscommon/profiles/util/YamlSubHandlerVer02.java
@@ -200,7 +200,7 @@ public class YamlSubHandlerVer02 {
 					//
 					if( isActionAdded ) profile.setActions(actions);
 				}
-			
+
 				//Data Ports
 				List dataPortListY = (List)profileY.get("dataPorts");
 				if( dataPortListY != null ) {
@@ -251,7 +251,7 @@ public class YamlSubHandlerVer02 {
 									docconfig.setUnit((String)configDocY.get("unit"));
 									docconfig.setRange((String)configDocY.get("range"));
 									docconfig.setConstraint((String)configDocY.get("constraint"));
-									
+
 									config.setDoc(docconfig);
 								}
 								//Ext
@@ -274,7 +274,7 @@ public class YamlSubHandlerVer02 {
 						profile.setConfigurationSet(configset);
 					}
 				}
-					
+
 				//Parameter
 				List paramsInfoY = (List)profileY.get("parameters");
 				if( paramsInfoY != null ) {
@@ -345,7 +345,6 @@ public class YamlSubHandlerVer02 {
 		return profile;
 	}
 
-	@SuppressWarnings("unchecked")
 	private XMLGregorianCalendar createDateTimeFromYaml(Map dateY) {
 		return XMLGregorianCalendarImpl.createDateTime(
 				((Integer)dateY.get("year")).intValue(),
@@ -355,8 +354,7 @@ public class YamlSubHandlerVer02 {
 				((Integer)dateY.get("minute")).intValue(),
 				((Integer)dateY.get("second")).intValue() );
 	}
-	
-	@SuppressWarnings("unchecked")
+
 	private ActionStatusDoc createActionFromYaml(Map actionY) {
 		ObjectFactory factory = new ObjectFactory();
 		ActionStatusDoc actionStatus = factory.createActionStatusDoc();
@@ -378,7 +376,6 @@ public class YamlSubHandlerVer02 {
 		return actionStatus;
 	}
 
-	@SuppressWarnings("unchecked")
 	private DataportExt createDataPortFromYaml(Map yamlMap) throws Exception {
 		ObjectFactory factory = new ObjectFactory();
 		DataportExt dataport = factory.createDataportExt();
@@ -426,8 +423,7 @@ public class YamlSubHandlerVer02 {
 		//
 		return dataport;
 	}
-	
-	@SuppressWarnings("unchecked")
+
 	private ConstraintType convertConstraint(ObjectFactory factory, Map constY) throws Exception {
 		ConstraintType result = null;
 		if( constY!=null ) {
@@ -455,7 +451,7 @@ public class YamlSubHandlerVer02 {
 					unitP.setPropertyIsEqualTo(equalP);
 					equalP.setLiteral(literal);
 					return result;
-					
+
 				} else if( unitY.get("propertyIsGreaterThan")!=null ) {
 					targetY = (Map)unitY.get("propertyIsGreaterThan");
 					literal = (String)targetY.get("literal");
@@ -465,7 +461,7 @@ public class YamlSubHandlerVer02 {
 					unitP.setPropertyIsGreaterThan(greaterP);
 					greaterP.setLiteral(literal);
 					return result;
-					
+
 				} else if( unitY.get("propertyIsGreaterThanOrEqualTo")!=null ) {
 					targetY = (Map)unitY.get("propertyIsGreaterThanOrEqualTo");
 					literal = (String)targetY.get("literal");
@@ -475,7 +471,7 @@ public class YamlSubHandlerVer02 {
 					unitP.setPropertyIsGreaterThanOrEqualTo(greaterEqualP);
 					greaterEqualP.setLiteral(literal);
 					return result;
-					
+
 				} else 	if( unitY.get("propertyIsLessThan")!=null ) {
 					targetY = (Map)unitY.get("propertyIsLessThan");
 					literal = (String)targetY.get("literal");
@@ -485,7 +481,7 @@ public class YamlSubHandlerVer02 {
 					unitP.setPropertyIsLessThan(lessP);
 					lessP.setLiteral(literal);
 					return result;
-					
+
 				} else 	if( unitY.get("propertyIsLessThanOrEqualTo")!=null ) {
 					targetY = (Map)unitY.get("propertyIsLessThanOrEqualTo");
 					literal = (String)targetY.get("literal");
@@ -495,22 +491,22 @@ public class YamlSubHandlerVer02 {
 					unitP.setPropertyIsLessThanOrEqualTo(lessEqualP);
 					lessEqualP.setLiteral(literal);
 					return result;
-					
+
 				} else 	if( unitY.get("propertyIsBetween")!=null ) {
 					targetY = (Map)unitY.get("propertyIsBetween");
 					String lower = (String)targetY.get("lowerBoundary");
-					if( lower==null || lower.length()<=0 )	
+					if( lower==null || lower.length()<=0 )
 						throw new Exception(Messages.getString("YamlSubHandlerVer02.150"));
 					String upper = (String)targetY.get("upperBoundary");
-					if( upper==null || upper.length()<=0 )	
+					if( upper==null || upper.length()<=0 )
 						throw new Exception(Messages.getString("YamlSubHandlerVer02.152"));
-					
+
 					PropertyIsBetween betweenP = factory.createPropertyIsBetween();
 					unitP.setPropertyIsBetween(betweenP);
 					betweenP.setLowerBoundary(lower);
 					betweenP.setUpperBoundary(upper);
 					return result;
-					
+
 				} else 	if( unitY.get("and")!=null ) {
 					targetY = (Map)unitY.get("and");
 					List constraintListY = (List)targetY.get("constraint");
@@ -520,7 +516,7 @@ public class YamlSubHandlerVer02 {
 						andP.getConstraint().add(convertConstraint(factory, (Map)constraintListY.get(index)));
 					}
 					return result;
-					
+
 				} else if( unitY.get("or")!=null ) {
 					targetY = (Map)unitY.get("or");
 					List constraintListY = (List)targetY.get("constraint");
@@ -531,7 +527,7 @@ public class YamlSubHandlerVer02 {
 					}
 					return result;
 				}
-				
+
 			} else if( constY.get("constraintListType")!=null ) {
 				Map listY = (Map)constY.get("constraintListType");
 				ConstraintListType listP = factory.createConstraintListType();
@@ -541,7 +537,7 @@ public class YamlSubHandlerVer02 {
 					listP.getConstraint().add(convertConstraint(factory, (Map)constraintListY.get(index)));
 				}
 				return result;
-				
+
 			} else if( constY.get("constraintHashType")!=null ) {
 				Map hashY = (Map)constY.get("constraintHashType");
 				ConstraintHashType hashP = factory.createConstraintHashType();
@@ -555,7 +551,7 @@ public class YamlSubHandlerVer02 {
 		}
 		return result;
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	private ServiceportExt createServicePortFromYaml(Map yamlMap) {
 		ObjectFactory factory = new ObjectFactory();
@@ -598,7 +594,7 @@ public class YamlSubHandlerVer02 {
 				}
 			}
 		}
-		
+
 		//Service Interface
 		List interfacesY = (List)yamlMap.get("serviceInterface");
 		if( interfacesY != null ) {

--- a/jp.go.aist.rtm.toolscommon.profiles/test/jp/go/aist/rtm/toolscommon/profiles/_test/TestBase.java
+++ b/jp.go.aist.rtm.toolscommon.profiles/test/jp/go/aist/rtm/toolscommon/profiles/_test/TestBase.java
@@ -40,51 +40,46 @@ public class TestBase extends TestCase {
 	}
 	protected String readFile(String fileName, String splitter) {
 		StringBuffer stbRet = new StringBuffer();
-		try{
-			FileReader fr = new FileReader(fileName);
-			BufferedReader br = new BufferedReader(fr);
-	
+		try (FileReader fr = new FileReader(fileName); BufferedReader br = new BufferedReader(fr) ) {
 			String str = new String();
 			while( (str = br.readLine()) != null ){
 				stbRet.append(str + splitter);
 			}
-			br.close();
-			fr.close();
 		} catch (IOException e){
 			e.printStackTrace();
 		}
 		return stbRet.toString();
 	}
-	
+
 	protected RtcProfile createConstraintBase(ConstraintType source) {
 		ObjectFactory factory = new ObjectFactory();
-		
+
 		RtcProfile profile = factory.createRtcProfile();
 		profile.setVersion("0.2");
 		ConfigurationSet configset = factory.createConfigurationSet();
 		Configuration config = factory.createConfiguration();
 		configset.getConfiguration().add(config);
 		profile.setConfigurationSet(configset);
-		
+
 		config.setConstraint(source);
-		
+
 		return profile;
 	}
-	
+
 	protected void checkDetailXml(RtcProfile profile){
 		assertEquals("RTC:SampleVendor:SampleCategory:SampleComponent:1.0.0",profile.getId());
 		assertEquals("0.2", profile.getVersion());
 		//
 		checkDetailCommon(profile);
 	}
-	
+
 	protected void checkDetailYaml01(RtcProfile profile){
 		assertEquals("RTC:SampleVendor.SampleCategory.SampleComponent:1.0.0",profile.getId());
 		assertEquals("0.1", profile.getVersion());
 		//
 		checkDetailCommon(profile);
 	}
-	
+
 	protected void checkDetailCommon(RtcProfile profile){
 		BasicInfoExt basic = (BasicInfoExt)profile.getBasicInfo();
 		assertEquals("SampleComponent", basic.getName());
@@ -204,7 +199,7 @@ public class TestBase extends TestCase {
 		assertEquals("int", config.getType());
 		assertEquals("var1", config.getVariableName());
 		assertEquals("1", config.getDefaultValue());
-		DocConfiguration docconfig = config.getDoc(); 
+		DocConfiguration docconfig = config.getDoc();
 		assertEquals("dataname1", docconfig.getDataname());
 		assertEquals("default1", docconfig.getDefaultValue());
 		assertEquals("config_Desc1", docconfig.getDescription());
@@ -329,9 +324,9 @@ public class TestBase extends TestCase {
 		assertEquals("Java", lang.getKind());
 		assertEquals("library1", lang.getTargets().get(0).getLibraries().get(0).getName());
 	}
-	
+
 	protected void checkDetailVer02(RtcProfile profile){
-		
+
 		assertEquals("RTC:SampleVender:SampleCategory:SampleComponent:1.0.0",profile.getId());
 		assertEquals("0.2", profile.getVersion());
 		//
@@ -345,7 +340,7 @@ public class TestBase extends TestCase {
 		assertEquals("SampleDescription", basic.getDescription());
 		assertEquals(1000.0, basic.getExecutionRate());
 		assertEquals("PeriodicExecutionContext", basic.getExecutionType());
-		assertEquals((long)1, basic.getMaxInstances().longValue());
+		assertEquals(1, basic.getMaxInstances().longValue());
 		assertEquals("SampleVendor", basic.getVendor());
 		assertEquals("1.0.0", basic.getVersion());
 		assertEquals("SampleAbstract", basic.getAbstract());
@@ -459,7 +454,7 @@ public class TestBase extends TestCase {
 //		assertEquals("100", config.getConstraint().getConstraintUnitType().getPropertyIsLessThan().getLiteral());
 		assertEquals("Sample", config.getComment());
 		assertEquals("var1", config.getVariableName());
-		DocConfiguration docconfig = config.getDoc(); 
+		DocConfiguration docconfig = config.getDoc();
 		assertEquals("config_Desc1", docconfig.getDescription());
 		assertEquals("dataname1", docconfig.getDataname());
 		assertEquals("default1", docconfig.getDefaultValue());

--- a/jp.go.aist.rtm.toolscommon.profiles/test/test/XMLHandlerTest.java
+++ b/jp.go.aist.rtm.toolscommon.profiles/test/test/XMLHandlerTest.java
@@ -9,18 +9,22 @@ public class XMLHandlerTest extends TestCase {
 	// /RTSystemEditor/a　bと/RTSystemEditor/a%20bディレクトリが存在するという前提のテスト
 	public void testHasSpace() throws Exception {
 		String fileName = "/RTSystemEditor/a%20b/test.xml";
-		new FileOutputStream(fileName);
+		try(FileOutputStream fos = new FileOutputStream(fileName)) {
+		}
 	}
 	public void testHasSpace2() throws Exception {
 		String fileName = "/RTSystemEditor/a b/test.xml";
-		new FileOutputStream(fileName);
+		try( FileOutputStream fos = new FileOutputStream(fileName) ) {
+		}
 	}
 	public void testHasSpace3() throws Exception {
 		String fileName = "/RTSystemEditor/a%20b/test.xml";
-		new FileOutputStream(URLDecoder.decode(fileName, "UTF-8"));
+		try( FileOutputStream fos = new FileOutputStream(URLDecoder.decode(fileName, "UTF-8")) ) {
+		}
 	}
 	public void testHasSpace4() throws Exception {
 		String fileName = "/RTSystemEditor/a%2520b/test.xml";
-		new FileOutputStream(URLDecoder.decode(fileName, "UTF-8"));
+		try( FileOutputStream fos = new FileOutputStream(URLDecoder.decode(fileName, "UTF-8")) ) {
+		}
 	}
 }

--- a/jp.go.aist.rtm.toolscommon.profiles/test/test/XMLTest.java
+++ b/jp.go.aist.rtm.toolscommon.profiles/test/test/XMLTest.java
@@ -42,7 +42,7 @@ public class XMLTest {
 			e.printStackTrace();
 		}
 	}
-	
+
 //	private static void YAMLinputSample() {
 ////		BufferedInputStream inputFile = null;
 ////		try {
@@ -68,7 +68,7 @@ public class XMLTest {
 ////		test.put("org.openrtp.namespaces.rtc.impl.ActionsImpl", "aaa");
 ////		config.setTransfers(test);
 ////		config.dump(holder);
-//		
+//
 //		System.out.println(yamlText);
 //		String[] yamlSplt = removeClassInfo(yamlText);
 //		if( yamlSplt.length > 0 ) {
@@ -101,11 +101,11 @@ public class XMLTest {
 //		for( int intidx=0;intidx<splitStr.length;intidx++ ) {
 //			strWork = splitStr[intidx];
 //			if(strWork.trim().contains(prefixClass)) {
-//				int end = strWork.indexOf(prefixClass); 
+//				int end = strWork.indexOf(prefixClass);
 //				splitStr[intidx] = strWork.substring(0,end+1);
 //			}
 //			if(strWork.trim().startsWith(prefixClass2)) {
-//				int end = strWork.indexOf(prefixClass2); 
+//				int end = strWork.indexOf(prefixClass2);
 //				splitStr[intidx] = strWork.substring(0,end+1);
 //			}
 //		}
@@ -154,14 +154,14 @@ public class XMLTest {
 			e.printStackTrace();
 		}
 	}
-		
+
 	public static boolean validateXml(String targetString) throws Exception {
 		try {
 			JAXBContext jc = JAXBContext.newInstance("org.openrtp.namespaces.rtc");
 			Unmarshaller unmarshaller = jc.createUnmarshaller();
 
-			SchemaFactory sf = SchemaFactory.newInstance(javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI);  
-			Schema schema = sf.newSchema(new File("schema/RtcProfile_ext.xsd")); 
+			SchemaFactory sf = SchemaFactory.newInstance(javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI);
+			Schema schema = sf.newSchema(new File("schema/RtcProfile_ext.xsd"));
 			unmarshaller.setSchema(schema);
 
 			((JAXBElement<?>)unmarshaller.unmarshal(new StreamSource(new FileReader(targetString)))).getValue();
@@ -186,23 +186,18 @@ public class XMLTest {
 //		}
 //		System.out.println("aaa");
 //	}
-	
+
 	protected static String readFile(String fileName) {
 		StringBuffer stbRet = new StringBuffer();
-		try{
-			FileReader fr = new FileReader(fileName);
-			BufferedReader br = new BufferedReader(fr);
-	
+		try( FileReader fr = new FileReader(fileName); BufferedReader br = new BufferedReader(fr) ) {
 			String str = new String();
 			while( (str = br.readLine()) != null ){
 				stbRet.append(str + "\n");
 			}
-			br.close();
-			fr.close();
 		} catch (IOException e){
 			e.printStackTrace();
 		}
 		return stbRet.toString();
 	}
-	
+
 }

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ComponentImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ComponentImpl.java
@@ -1983,7 +1983,7 @@ public abstract class ComponentImpl extends WrapperObjectImpl implements Compone
 			}
 		}
 	}
-	
+
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -1997,7 +1997,6 @@ public abstract class ComponentImpl extends WrapperObjectImpl implements Compone
 		}
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public void removeDeadChild() {
 		for (Iterator iterate = getComponents().iterator(); iterate.hasNext();) {

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ComponentSpecificationImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ComponentSpecificationImpl.java
@@ -347,13 +347,13 @@ public class ComponentSpecificationImpl extends ComponentImpl implements Compone
 
 	@Override
 	public boolean addComponentsR(List<Component> componentList) {
-		return doAddComponents(componentList);			
+		return doAddComponents(componentList);
 	}
 
 	@Override
 	public boolean setComponentsR(List<Component> componentList) {
 		getComponents().clear();
-		return doAddComponents(componentList);			
+		return doAddComponents(componentList);
 	}
 
 	private boolean doAddComponents(List<Component> componentList) {
@@ -400,7 +400,6 @@ public class ComponentSpecificationImpl extends ComponentImpl implements Compone
 		return true;
 	}
 
-	@SuppressWarnings("unchecked")
 	private void removeByEqual(EList components, Component component) {
 		for (Iterator iterate = components.iterator(); iterate.hasNext();) {
 			if (iterate.next().equals(component)) iterate.remove();
@@ -440,7 +439,6 @@ public class ComponentSpecificationImpl extends ComponentImpl implements Compone
 				Component.COMPOSITETYPE_GROUPING)) ;
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public java.lang.Object getAdapter(Class adapter) {
 		java.lang.Object result = null;
@@ -494,7 +492,6 @@ public class ComponentSpecificationImpl extends ComponentImpl implements Compone
 	private static ReferenceMapping[] getReferenceMappings() {
 		return new ReferenceMapping[] { new ManyReferenceMapping(
 				ComponentPackage.eINSTANCE.getComponent_Ports()) {
-			@SuppressWarnings("unchecked")
 			@Override
 			public void syncronizeLocal(LocalObject localObject) {
 				if (!(localObject instanceof ComponentSpecificationImpl)) {
@@ -504,10 +501,10 @@ public class ComponentSpecificationImpl extends ComponentImpl implements Compone
 				if (!comp.inOnlineSystemDiagram() || !comp.isGroupingCompositeComponent()) {
 					return;
 				}
-				
+
 				// 子コンポーネントの生存確認を行う
 				comp.removeDeadChild();
-				
+
 				// ポートの更新を行う
 				// 新しいポートのリンクリスト
 				List<Port> newPorts = comp._getWrappedPorts();
@@ -543,7 +540,7 @@ public class ComponentSpecificationImpl extends ComponentImpl implements Compone
 	public void synchronizeLocalReference() {
 		if (!inOnlineSystemDiagram()) return;
 		if (!isGroupingCompositeComponent()) return;
-		
+
 		for (ReferenceMapping refMap : getReferenceMappings()) {
 			try {
 				refMap.syncronizeLocal(this);

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ConfigurationSetImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ConfigurationSetImpl.java
@@ -42,7 +42,7 @@ public class ConfigurationSetImpl extends WrapperObjectImpl implements
     /**
      * The default value of the '{@link #getId() <em>Id</em>}' attribute. <!--
      * begin-user-doc --> <!-- end-user-doc -->
-     * 
+     *
      * @see #getId()
      * @generated
      * @ordered
@@ -52,7 +52,7 @@ public class ConfigurationSetImpl extends WrapperObjectImpl implements
     /**
      * The cached value of the '{@link #getId() <em>Id</em>}' attribute. <!--
      * begin-user-doc --> <!-- end-user-doc -->
-     * 
+     *
      * @see #getId()
      * @generated
      * @ordered
@@ -70,7 +70,7 @@ public class ConfigurationSetImpl extends WrapperObjectImpl implements
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
-     * 
+     *
      * @generated NOT
      */
     public ConfigurationSetImpl() {
@@ -230,7 +230,6 @@ public class ConfigurationSetImpl extends WrapperObjectImpl implements
                 p.getConfigurationData().toArray()).isEquals();
     }
 
-    @SuppressWarnings("unchecked")
 	public static ConfigurationSet findConfigurationSetByID(String id,
             EList configurationSets) {
         ConfigurationSet result = null;

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaComponentImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaComponentImpl.java
@@ -16,6 +16,27 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
+import org.eclipse.emf.ecore.util.EDataTypeEList;
+import org.eclipse.emf.ecore.util.EDataTypeUniqueEList;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.ui.views.properties.IPropertySource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import RTC.ComponentProfile;
+import RTC.RTObject;
+import RTC.ReturnCode_t;
+import _SDOPackage.Configuration;
+import _SDOPackage.InternalError;
+import _SDOPackage.InvalidParameter;
+import _SDOPackage.NotAvailable;
+import _SDOPackage.Organization;
+import _SDOPackage.SDO;
 import jp.go.aist.rtm.toolscommon.factory.CorbaWrapperFactory;
 import jp.go.aist.rtm.toolscommon.model.component.Component;
 import jp.go.aist.rtm.toolscommon.model.component.ComponentFactory;
@@ -50,29 +71,6 @@ import jp.go.aist.rtm.toolscommon.synchronizationframework.mapping.MappingRule;
 import jp.go.aist.rtm.toolscommon.synchronizationframework.mapping.ReferenceMapping;
 import jp.go.aist.rtm.toolscommon.ui.propertysource.ComponentPropertySource;
 import jp.go.aist.rtm.toolscommon.util.SDOUtil;
-
-import org.eclipse.emf.common.notify.Notification;
-import org.eclipse.emf.common.util.EList;
-import org.eclipse.emf.ecore.EClass;
-import org.eclipse.emf.ecore.EStructuralFeature;
-import org.eclipse.emf.ecore.InternalEObject;
-import org.eclipse.emf.ecore.impl.ENotificationImpl;
-import org.eclipse.emf.ecore.util.EDataTypeEList;
-import org.eclipse.emf.ecore.util.EDataTypeUniqueEList;
-import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.ui.views.properties.IPropertySource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import RTC.ComponentProfile;
-import RTC.RTObject;
-import RTC.ReturnCode_t;
-import _SDOPackage.Configuration;
-import _SDOPackage.InternalError;
-import _SDOPackage.InvalidParameter;
-import _SDOPackage.NotAvailable;
-import _SDOPackage.Organization;
-import _SDOPackage.SDO;
 
 /**
  * <!-- begin-user-doc -->
@@ -1293,7 +1291,6 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 		return false;
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public java.lang.Object getAdapter(Class adapter) {
 		java.lang.Object result = null;
@@ -1306,7 +1303,7 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 		}
 		return result;
 	}
-	
+
 	@Override
 	public boolean updateConfigurationSetR(ConfigurationSet configSet, boolean isActive) {
 		boolean result = false;
@@ -1320,7 +1317,7 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 				}
 			}
 			Configuration configuration = getSDOConfiguration();
-			_SDOPackage.ConfigurationSet sdoConfigurationSet = 
+			_SDOPackage.ConfigurationSet sdoConfigurationSet =
 				SDOUtil.createSdoConfigurationSet(configSet);
 			if (!exist) {
 				configuration.add_configuration_set(sdoConfigurationSet);
@@ -1345,7 +1342,7 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 	@Override
 	public String getComponentId() {
 		if (componentId != null) return componentId;
-		return "RTC:" + getVenderL() + ":" 
+		return "RTC:" + getVenderL() + ":"
 		+ getCategoryL() + ":"
 		+ getTypeNameL() + ":"
 		+ getVersionL();
@@ -2020,14 +2017,12 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 				},
 				new ManyReferenceMapping(ComponentPackage.eINSTANCE
 						.getComponent_ExecutionContexts()) {
-					@SuppressWarnings("unchecked")
 					@Override
 					public List getNewRemoteLinkList(LocalObject localObject) {
 						CorbaComponent component = (CorbaComponent) localObject;
 						return component.getRTCExecutionContexts();
 					}
 
-					@SuppressWarnings("unchecked")
 					@Override
 					public List getOldRemoteLinkList(LocalObject localObject) {
 						List<org.omg.CORBA.Object> result = new ArrayList<>();
@@ -2077,14 +2072,12 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 				},
 				new ManyReferenceMapping(ComponentPackage.eINSTANCE
 						.getComponent_ParticipationContexts()) {
-					@SuppressWarnings("unchecked")
 					@Override
 					public List getNewRemoteLinkList(LocalObject localObject) {
 						CorbaComponent component = (CorbaComponent) localObject;
 						return component.getRTCParticipationContexts();
 					}
 
-					@SuppressWarnings("unchecked")
 					@Override
 					public List getOldRemoteLinkList(LocalObject localObject) {
 						List<org.omg.CORBA.Object> result = new ArrayList<org.omg.CORBA.Object>();
@@ -2106,7 +2099,6 @@ public class CorbaComponentImpl extends ComponentImpl implements CorbaComponent 
 				},
 				new ManyReferenceMapping(ComponentPackage.eINSTANCE
 						.getComponent_Components()) {
-					@SuppressWarnings("unchecked")
 					@Override
 					public List getNewRemoteLinkList(LocalObject localObject) {
 						CorbaComponent component = (CorbaComponent) localObject;

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaConfigurationSetImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaConfigurationSetImpl.java
@@ -194,7 +194,6 @@ public class CorbaConfigurationSetImpl extends ConfigurationSetImpl implements C
                                     .getCorbaConfigurationSet_SDOConfigurationSet()) }) {
             }, new AttributeMapping[] {new AttributeMapping(ComponentPackage.eINSTANCE
                     .getConfigurationSet_ConfigurationData(), true) {
-                @SuppressWarnings("unchecked")
 				@Override
                 public Object getRemoteAttributeValue(
                         LocalObject localObject, Object[] remoteObjects) {

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ExecutionContextImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ExecutionContextImpl.java
@@ -175,7 +175,7 @@ public class ExecutionContextImpl extends WrapperObjectImpl implements
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
+	 *
 	 * @generated NOT
 	 */
 	public ExecutionContextImpl() {
@@ -577,7 +577,6 @@ public class ExecutionContextImpl extends WrapperObjectImpl implements
 		return result.toString();
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public java.lang.Object getAdapter(Class adapter) {
 		java.lang.Object result = null;

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/InPortImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/InPortImpl.java
@@ -50,7 +50,6 @@ public class InPortImpl extends PortImpl implements InPort {
 		return false;
 	}
 
-	@SuppressWarnings("unchecked")
 	public java.lang.Object getAdapter(Class adapter) {
 		java.lang.Object result = null;
 		if (IPropertySource.class.equals(adapter)) {

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/OutPortImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/OutPortImpl.java
@@ -85,7 +85,6 @@ public class OutPortImpl extends PortImpl implements OutPort {
 		return true;
 	}
 
-	@SuppressWarnings("unchecked")
 	public java.lang.Object getAdapter(Class adapter) {
 		java.lang.Object result = null;
 		if (IPropertySource.class.equals(adapter)) {

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/PortConnectorImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/PortConnectorImpl.java
@@ -171,10 +171,9 @@ public abstract class PortConnectorImpl extends WrapperObjectImpl implements Por
 	/**
 	 * <!-- begin-user-doc --> TODO:コネクタが接続元（先）から削除された場合には、接続先（元）からも削除を行う<!--
 	 * end-user-doc -->
-	 * 
+	 *
 	 * @generated NOT
 	 */
-	@SuppressWarnings("unchecked")
 	public NotificationChain eInverseRemove(InternalEObject otherEnd,
 			int featureID, Class baseClass, NotificationChain msgs) {
 		switch (eDerivedStructuralFeatureID(featureID, baseClass)) {
@@ -375,7 +374,6 @@ public abstract class PortConnectorImpl extends WrapperObjectImpl implements Por
 		throw new UnsupportedOperationException();
 	}
 
-	@SuppressWarnings("unchecked")
 	public java.lang.Object getAdapter(Class adapter) {
 		java.lang.Object result = null;
 		if (IPropertySource.class.equals(adapter)) {
@@ -387,6 +385,6 @@ public abstract class PortConnectorImpl extends WrapperObjectImpl implements Por
 		}
 
 		return result;
-	}	
+	}
 
 } // PortConnectorImpl

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/PortProxy.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/PortProxy.java
@@ -36,21 +36,18 @@ public abstract class PortProxy extends EObjectImpl implements Port {
 		return null;
 	}
 
-	@SuppressWarnings("unchecked")
 	private static class InPortProxy extends PortProxy implements InPort {
 		private InPortProxy(Port substance){
 			super(substance);
 		}
 	}
 
-	@SuppressWarnings("unchecked")
 	private static class OutPortProxy extends PortProxy implements OutPort {
 		private OutPortProxy(Port substance){
 			super(substance);
 		}
 	}
-	
-	@SuppressWarnings("unchecked")
+
 	private static class ServicePortProxy extends PortProxy implements ServicePort {
 		private ServicePortProxy(Port substance){
 			super(substance);
@@ -339,7 +336,7 @@ public abstract class PortProxy extends EObjectImpl implements Port {
 	public List<NameValue> getProperties() {
 		return substance.getProperties();
 	}
-	
+
 	public String getProperty(String name) {
 		return substance.getProperty(name);
 	}

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ServicePortImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ServicePortImpl.java
@@ -50,7 +50,6 @@ public class ServicePortImpl extends PortImpl implements ServicePort {
 		return target instanceof ServicePort;
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public java.lang.Object getAdapter(Class adapter) {
 		java.lang.Object result = null;

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/core/impl/ModelElementImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/core/impl/ModelElementImpl.java
@@ -87,7 +87,6 @@ public class ModelElementImpl extends EObjectImpl implements ModelElement {
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 */
-	@SuppressWarnings("unchecked")
 	public void accept(Visiter visiter) {
 		visiter.visit(this);
 		for (Object obj : eContents()) {

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/synchronizationframework/SynchronizationManager.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/synchronizationframework/SynchronizationManager.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
  * 同期マネージャ
  * <p>
  * マッピングルールのリストを保持する（同期機能のコンテクストともいえる）
- * 
+ *
  */
 public class SynchronizationManager {
 
@@ -25,7 +25,7 @@ public class SynchronizationManager {
 
 	/**
 	 * コンストラクタ
-	 * 
+	 *
 	 * @param mappingRules
 	 *            マッピングルールのリスト
 	 */
@@ -35,7 +35,7 @@ public class SynchronizationManager {
 
 	/**
 	 * リモートオブジェクトツリーから、ローカルオブジェクトツリーを作成する。
-	 * 
+	 *
 	 * @param remoteObject
 	 *            リモートオブジェクトルート
 	 * @return 作成したローカルオブジェクト
@@ -46,14 +46,14 @@ public class SynchronizationManager {
 
 	/**
 	 * 親のローカルオブジェクト、リモートオブジェクトルートおよびリモートオブジェクトのリンクから、ローカルオブジェクトツリーを作成する
-	 * 
+	 *
 	 * @param parent
 	 *            親のローカルオブジェクト
 	 * @param remoteObject
 	 *            リモートオブジェクトルート
 	 * @param link
 	 *            リモートオブジェクトのリンク
-	 * @param needSynchronize 同期が必要か          
+	 * @param needSynchronize 同期が必要か
 	 * @return 作成したローカルオブジェクト
 	 */
 	public LocalObject createLocalObject(LocalObject parent,
@@ -87,7 +87,7 @@ public class SynchronizationManager {
 		boolean ping = true;
 		for (MappingRule temp : mappingRules) {
 			try {
-				if (temp.getClassMapping().getConstructorParamMappings().length == remoteObjects.length 
+				if (temp.getClassMapping().getConstructorParamMappings().length == remoteObjects.length
 						&& canTarget(ping, temp.getClassMapping().needsPing())
 						&& temp.getClassMapping().isTarget(parent,remoteObjects, link)) {
 					if (temp.getClassMapping().allowZombie()) return temp;
@@ -109,7 +109,7 @@ public class SynchronizationManager {
 
 	/**
 	 * 同期サポートを作成する
-	 * 
+	 *
 	 * @param localObject
 	 *            ローカルオブジェクト
 	 * @param remoteObject
@@ -125,11 +125,10 @@ public class SynchronizationManager {
 
 	/**
 	 * 包含参照をたどり、すべてのローカルオブジェクトに対して、同期サポートを復元する
-	 * 
+	 *
 	 * @param eobj
 	 *            EObject
 	 */
-	@SuppressWarnings("unchecked")
 	public void assignSynchonizationSupport(EObject eobj) {
 		if (eobj instanceof LocalObject) {
 			LocalObject localObject = (LocalObject) eobj;

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/synchronizationframework/SynchronizationSupport.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/synchronizationframework/SynchronizationSupport.java
@@ -36,7 +36,7 @@ public class SynchronizationSupport {
 
 	/**
 	 * コンストラクタ
-	 * 
+	 *
 	 * @param localObject
 	 *            ローカルオブジェクト
 	 * @param mappingRule
@@ -54,7 +54,7 @@ public class SynchronizationSupport {
 
 	/**
 	 * 同期マネージャを取得する
-	 * 
+	 *
 	 * @return 同期マネージャ
 	 */
 	public SynchronizationManager getSynchronizationManager() {
@@ -160,7 +160,7 @@ public class SynchronizationSupport {
 
 	/**
 	 * オブジェクトに対して接続できるか確認する
-	 * 
+	 *
 	 * @param remoteObject
 	 * @return 接続できるかどうか
 	 */
@@ -177,7 +177,7 @@ public class SynchronizationSupport {
 
 	/**
 	 * オブジェクトに対して接続できるか確認する
-	 * 
+	 *
 	 * @param remoteObject
 	 * @return 接続できるかどうか
 	 */
@@ -195,12 +195,11 @@ public class SynchronizationSupport {
 
 	/**
 	 * オブジェクトグラフ内から、ローカルをリモートオブジェクトによって検索します。
-	 * 
+	 *
 	 * @param remoteObjects
 	 * @param graphPart
 	 * @return
 	 */
-	@SuppressWarnings("unchecked")
 	public static LocalObject findLocalObjectByRemoteObject(
 			Object[] remoteObjects, EObject graphPart) {
 		EObject graphRoot = EcoreUtil.getRootContainer(graphPart);
@@ -213,7 +212,7 @@ public class SynchronizationSupport {
 
 		return null;
 	}
-	
+
 	private static LocalObject findLocalObject(Object obj, Object[] remoteObjects){
 		if (!(obj instanceof LocalObject)) return null;
 		LocalObject result = (LocalObject) obj;
@@ -230,7 +229,6 @@ public class SynchronizationSupport {
 		}
 		return result;
 	}
-	@SuppressWarnings("unchecked")
 	public static Collection<LocalObject> findLocalObjectByRemoteObjects(
 			Object[] remoteObjects, LocalObject graphPart) {
 		Collection<LocalObject> result = new ArrayList<LocalObject>();
@@ -258,7 +256,7 @@ public class SynchronizationSupport {
 
 	/**
 	 * リモートオブジェクトを取得する
-	 * 
+	 *
 	 * @return リモートオブジェクト
 	 */
 	public Object[] getRemoteObjects() {

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/synchronizationframework/mapping/ClassMapping.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/synchronizationframework/mapping/ClassMapping.java
@@ -8,7 +8,6 @@ import jp.go.aist.rtm.toolscommon.synchronizationframework.LocalObject;
  * ConstructorParamMappingsにマップ可能なリモートオブジェクトと対応する
  */
 public class ClassMapping {
-	@SuppressWarnings("unchecked")
 	private Class localClass;
 
 	private ConstructorParamMapping[] constructorParamMappings;
@@ -17,15 +16,14 @@ public class ClassMapping {
 
 	/**
 	 * コンストラクタ
-	 * 
+	 *
 	 * @param localClass
 	 *            ローカルオブジェクトのクラス
 	 * @param remoteClass
 	 *            リモートオブジェクトのクラス
 	 * @param allowZombie ゾンビ（リモートオブジェクトが死んだ状態）でも存在させるか
-	 * 			
+	 *
 	 */
-	@SuppressWarnings("unchecked")
 	public ClassMapping(Class localClass,
 			ConstructorParamMapping[] constructorParamMappings,boolean allowZombie) {
 		this.localClass = localClass;
@@ -35,13 +33,12 @@ public class ClassMapping {
 
 	/**
 	 * コンストラクタ
-	 * 
+	 *
 	 * @param localClass
 	 *            ローカルオブジェクトのクラス
 	 * @param remoteClass
 	 *            リモートオブジェクトのクラス
 	 */
-	@SuppressWarnings("unchecked")
 	public ClassMapping(Class localClass,
 			ConstructorParamMapping[] constructorParamMappings) {
 		this(localClass,constructorParamMappings,false);
@@ -52,7 +49,7 @@ public class ClassMapping {
 	 * <p>
 	 * リモートオブジェクトと親ローカルオブジェクト、およびリンクから、 このクラスマッピングが関連づいたマッピングであるかどうか判断する。<br>
 	 * CORBAオブジェクトの場合、narrowして比較する必要があるため、オーバーライドすること。
-	 * 
+	 *
 	 * @param parent
 	 *            親のローカルオブジェクト
 	 * @param remoteObjects
@@ -60,7 +57,6 @@ public class ClassMapping {
 	 *            関連をあらわすリンク(リモートオブジェクト自体であることが多い)
 	 * @return
 	 */
-	@SuppressWarnings("unchecked")
 	public boolean isTarget(LocalObject parent, Object[] remoteObjects,
 			java.lang.Object link) {
 		for (int i = 0; i < remoteObjects.length; i++) {
@@ -74,7 +70,7 @@ public class ClassMapping {
 
 	/**
 	 * リモートオブジェクトから、ローカルオブジェクトを作成する。
-	 * 
+	 *
 	 * @param parent
 	 *            親のローカルオブジェクト
 	 * @param remoteObjects
@@ -102,7 +98,7 @@ public class ClassMapping {
 
 	/**
 	 * ローカルオブジェクトのクラス
-	 * 
+	 *
 	 * @return ローカルオブジェクトのクラス
 	 */
 	public Class<?> getLocalClass() {
@@ -111,7 +107,7 @@ public class ClassMapping {
 
 	/**
 	 * narrowする
-	 * 
+	 *
 	 * @param remoteObjects
 	 * @return
 	 */
@@ -121,7 +117,7 @@ public class ClassMapping {
 
 	/**
 	 * ConstructorParamMappingを取得する
-	 * 
+	 *
 	 * @return
 	 */
 	public ConstructorParamMapping[] getConstructorParamMappings() {

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/synchronizationframework/mapping/ManyReferenceMapping.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/synchronizationframework/mapping/ManyReferenceMapping.java
@@ -15,15 +15,13 @@ import org.eclipse.emf.ecore.EReference;
  */
 public abstract class ManyReferenceMapping extends ReferenceMapping {
 	private static class LinkHolder {
-		@SuppressWarnings("unchecked")
 		private List deleteRemoteLinkList;
-		@SuppressWarnings("unchecked")
 		private List addRemoteLinkList;
 	}
 
 	/**
 	 * コンストラクタ
-	 * 
+	 *
 	 * @param localFeature
 	 *            ローカルオブジェクトのフィーチャ
 	 */
@@ -33,7 +31,7 @@ public abstract class ManyReferenceMapping extends ReferenceMapping {
 
 	/**
 	 * コンストラクタ
-	 * 
+	 *
 	 * @param localFeature
 	 *            ローカルオブジェクトのフィーチャ
 	 * @param allowZombie
@@ -98,7 +96,6 @@ public abstract class ManyReferenceMapping extends ReferenceMapping {
 		return holder;
 	}
 
-	@SuppressWarnings("unchecked")
 	private int findExistLisk(LocalObject localObject, Object newLink,
 			List deleteRemoteLinkList) {
 		for (int i = 0; i < deleteRemoteLinkList.size(); i++) {
@@ -121,17 +118,15 @@ public abstract class ManyReferenceMapping extends ReferenceMapping {
 
 	/**
 	 * 最新のリモートオブジェクトのリンクを返すように、オーバーライドされることが意図される
-	 * 
+	 *
 	 * @param parentRemoteObjects
 	 *            リモートオブジェクト
 	 * @return 最新のリモートオブジェクトのリンク
 	 */
-	@SuppressWarnings("unchecked")
 	protected List getNewRemoteLinkList(Object[] parentRemoteObjects) {
 		return null;
 	};
 
-	@SuppressWarnings("unchecked")
 	protected List getNewRemoteLinkList(LocalObject localObject) {
 		return getNewRemoteLinkList(getRemoteObjects(localObject));
 	}
@@ -141,7 +136,7 @@ public abstract class ManyReferenceMapping extends ReferenceMapping {
 	 * <p>
 	 * 必要に応じて、オーバーライドすること デフォルト実装は、ローカルオブジェクトに対して、リモートオブジェクトが１つである場合の実装。 // *
 	 * 関連オブジェクトなどの複数のリモートオブジェクトが存在する場合には、オーバーライドしなければならない。
-	 * 
+	 *
 	 * @param localObject
 	 *            ローカルオブジェクト
 	 * @return 現在使用している、リモートオブジェクトのリンク
@@ -166,14 +161,13 @@ public abstract class ManyReferenceMapping extends ReferenceMapping {
 
 	/**
 	 * リモートオブジェクトのリンクから、ローカルオブジェクトを取得する
-	 * 
+	 *
 	 * @param parent
 	 *            親のローカルオブジェクト
 	 * @param link
 	 *            リモートオブジェクトのリンク
 	 * @return ローカルオブジェクト
 	 */
-	@SuppressWarnings("unchecked")
 	public LocalObject getLocalObjectByRemoteLink(LocalObject parent,
 			java.lang.Object link) {
 		LocalObject result = null;
@@ -207,7 +201,7 @@ public abstract class ManyReferenceMapping extends ReferenceMapping {
 
 	/**
 	 * 同期後の事後処理を定義します。
-	 * 
+	 *
 	 * @param lo
 	 *            同期対象のローカルオブジェクト
 	 * @param updated
@@ -221,7 +215,7 @@ public abstract class ManyReferenceMapping extends ReferenceMapping {
 
 	/**
 	 * 同期後の事後処理を定義します。
-	 * 
+	 *
 	 * @param lo
 	 *            同期対象のローカルオブジェクト
 	 */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/ui/views/propertysheetview/OpenView.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/ui/views/propertysheetview/OpenView.java
@@ -15,12 +15,11 @@ import org.eclipse.ui.PlatformUI;
 
 /**
  * 選択されたノードに適したビューに切り替えるためのクラス
- * 
+ *
  */
 public class OpenView {
 	private static final String EXTENTION_POINT_NAME = "openViews";
 
-	@SuppressWarnings("unchecked")
 	private static Map<Class, Map<String, String>> viewMap;
 
 	public static String getViewId(Object obj) {
@@ -34,7 +33,6 @@ public class OpenView {
 	 *            選択されたオブジェクト用のビューが複数ある場合の識別子
 	 * @return 選択されたオブジェクトの情報を表示させるビューのID
 	 */
-	@SuppressWarnings("unchecked")
 	public static String getViewId(Object obj, String kind) {
 		if (viewMap == null) {
 			buildViewMap();
@@ -71,7 +69,6 @@ public class OpenView {
 		return null;
 	}
 
-	@SuppressWarnings("unchecked")
 	private static void buildViewMap() {
 		// 拡張ポイントがNULLとなったときは、「-clean」オプションで起動，
 		// もしくはworkspaceを切り替えて起動を行うことで対処する　2009.01.24

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/ui/views/propertysheetview/PropertySheetContentProvider.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/ui/views/propertysheetview/PropertySheetContentProvider.java
@@ -37,7 +37,6 @@ public class PropertySheetContentProvider extends AdapterImpl implements
 		addListener(oldInput, newInput);
 	}
 
-	@SuppressWarnings("unchecked")
 	private void addListener(Object oldInput, Object newInput) {
 		final PropertySheetContentProvider provider = this;
 

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/ui/views/propertysheetview/RTCManagerWrapper.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/ui/views/propertysheetview/RTCManagerWrapper.java
@@ -31,7 +31,7 @@ public class RTCManagerWrapper {
 
 	/**
 	 * コンストラクタ
-	 * 
+	 *
 	 * @param manager
 	 *            ドメインモデル
 	 */
@@ -41,7 +41,7 @@ public class RTCManagerWrapper {
 
 	/**
 	 * マネージャを取得する
-	 * 
+	 *
 	 * @return マネージャのオブジェクト
 	 */
 	public EObject getManager() {
@@ -50,7 +50,7 @@ public class RTCManagerWrapper {
 
 	/**
 	 * マネージャを設定する
-	 * 
+	 *
 	 * @param manager
 	 *            マネージャのオブジェクト
 	 */
@@ -60,7 +60,7 @@ public class RTCManagerWrapper {
 
 	/**
 	 * 起動中コンポーネント名一覧の子オブジェクトを取得します。
-	 * 
+	 *
 	 * @return コンポーネント名一覧の子オブジェクト
 	 */
 	public Child getComponentsChild() {
@@ -69,7 +69,7 @@ public class RTCManagerWrapper {
 
 	/**
 	 * ロード可能モジュール名一覧の子オブジェクトを取得します。
-	 * 
+	 *
 	 * @return ロード可能モジュール名一覧の子オブジェクト
 	 */
 	public Child getLoadableModulesChild() {
@@ -78,7 +78,7 @@ public class RTCManagerWrapper {
 
 	/**
 	 * ロード済みモジュール名一覧の子オブジェクトを取得します。
-	 * 
+	 *
 	 * @return ロード済みモジュール名一覧の子オブジェクト
 	 */
 	public Child getLoadedModulesChild() {
@@ -98,7 +98,7 @@ public class RTCManagerWrapper {
 
 		/**
 		 * プロパティを追加します。
-		 * 
+		 *
 		 * @param id
 		 *            プロパティID
 		 * @param name
@@ -199,7 +199,7 @@ public class RTCManagerWrapper {
 
 		/**
 		 * この子オブジェクトの表示名を返します。
-		 * 
+		 *
 		 * @return 子オブジェクトの表示名(Components/Loadable Modules/Loaded Modules)
 		 */
 		public String getLabel() {
@@ -215,10 +215,9 @@ public class RTCManagerWrapper {
 
 		/**
 		 * この子オブジェクトのプロパティ・ソースを返します。
-		 * 
+		 *
 		 * @return プロパティ・ソース
 		 */
-		@SuppressWarnings("unchecked")
 		public IPropertySource getPropertySource() {
 			if (this.source != null) {
 				return this.source;

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/ui/views/propertysheetview/RtcPropertySheetPage.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/ui/views/propertysheetview/RtcPropertySheetPage.java
@@ -144,7 +144,7 @@ public class RtcPropertySheetPage implements IPropertySheetPage,
 
 	/**
 	 * 委譲
-	 * 
+	 *
 	 * @param selection
 	 */
 	public void handleEntrySelection(ISelection selection) {
@@ -153,7 +153,7 @@ public class RtcPropertySheetPage implements IPropertySheetPage,
 
 	/**
 	 * 委譲
-	 * 
+	 *
 	 * @param pageSite
 	 */
 	public void init(IPageSite pageSite) {
@@ -162,7 +162,7 @@ public class RtcPropertySheetPage implements IPropertySheetPage,
 
 	/**
 	 * 委譲
-	 * 
+	 *
 	 * @param menuManager
 	 * @param toolBarManager
 	 * @param statusLineManager
@@ -179,9 +179,9 @@ public class RtcPropertySheetPage implements IPropertySheetPage,
 	public void refresh() {
 		// defaultDelegate.refresh();
 	}
-	
+
 	private EObject prevComponent;
-	
+
 	/**
 	 * Rtcの場合だけ、特殊なページを表示するようにする
 	 * また、このページでは、RTC以外オブジェクトを触っても、それがIPropertySouceを持っていない場合には（Propertyiesページを表示できない場合には）RTCを表示し続ける。（これは、selectionChangedを無視することで実現している）
@@ -294,7 +294,6 @@ public class RtcPropertySheetPage implements IPropertySheetPage,
 		}
 	}
 
-	@SuppressWarnings("unchecked")
 	private EObject getDisplayObject(Object firstElement) {
 		for (Class displayClass : PropertysheetpageExtentionpoint
 				.getDisplayclassList()) {
@@ -308,7 +307,7 @@ public class RtcPropertySheetPage implements IPropertySheetPage,
 
 	/**
 	 * 委譲
-	 * 
+	 *
 	 * @param actionBars
 	 */
 	public void setActionBars(IActionBars actionBars) {
@@ -323,7 +322,7 @@ public class RtcPropertySheetPage implements IPropertySheetPage,
 
 	/**
 	 * 委譲
-	 * 
+	 *
 	 * @param newProvider
 	 */
 	public void setPropertySourceProvider(IPropertySourceProvider newProvider) {
@@ -331,7 +330,7 @@ public class RtcPropertySheetPage implements IPropertySheetPage,
 
 	/**
 	 * 委譲
-	 * 
+	 *
 	 * @param entry
 	 */
 	public void setRootEntry(IPropertySheetEntry entry) {

--- a/jp.go.aist.rtm.toolscommon/test/jp/go/aist/rtm/toolscommon/component/ComponentTest.java
+++ b/jp.go.aist.rtm.toolscommon/test/jp/go/aist/rtm/toolscommon/component/ComponentTest.java
@@ -33,7 +33,6 @@ public class ComponentTest {
 		assertEquals("ConsoleIn0.out", exportedPorts.get(0));
 		assertEquals("MyServiceConsumer0.service", exportedPorts.get(1));
 	}
-	@SuppressWarnings("unchecked")
 	private ConfigurationSet createConfigutationSet() {
 		ConfigurationSet result = ComponentFactory.eINSTANCE.createConfigurationSet();
 		result.getConfigurationData().add(createNameValue());

--- a/jp.go.aist.rtm.toolscommon/test/jp/go/aist/rtm/toolscommon/component/OfflineCompositeTest.java
+++ b/jp.go.aist.rtm.toolscommon/test/jp/go/aist/rtm/toolscommon/component/OfflineCompositeTest.java
@@ -17,7 +17,6 @@ import org.junit.Test;
 public class OfflineCompositeTest {
 	private SystemDiagram diagram;
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void createComposite() throws Exception {
 		diagram = ComponentFactory.eINSTANCE.createSystemDiagram();
@@ -27,29 +26,29 @@ public class OfflineCompositeTest {
 
 		Component s1 = createCompositeComponentSpecification();
 		s1.addComponentsR(diagram.getComponents());
-		
+
 		assertEquals(2, s1.getComponents().size());
 		assertEquals(2, s1.getExportedPorts().size());
 		assertEquals("ImageProcess.CapPORT", s1.getExportedPorts().get(0));
 		assertEquals("CameraComponent.CapPORT", s1.getExportedPorts().get(1));
 		assertEquals(2, s1.getPorts().size());
-		
+
 		assertEquals(2, diagram.getComponents().size());
-		
+
 		diagram.getComponents().add(s1);
 		diagram.getComponents().add(createComponent("ImageViewer"));
-		
+
 		assertEquals(4, diagram.getComponents().size());
-		
+
 		assertEquals(getPort(0,0).getOriginalPortString()
 				, getPort(2, 0).getOriginalPortString());
-		
+
 		PortConnector connector = createConnector();
 		connector.createConnectorR();
-		
+
 		assertEquals(getPort(0,0).getOriginalPortString()
 				, connector.getConnectorProfile().getSourceString());
-		
+
 		verifyConnectCount(1, getPort(0,0));
 		verifyConnectCount(0, getPort(1,0));
 		verifyConnectCount(1, getPort(2,0));
@@ -58,14 +57,13 @@ public class OfflineCompositeTest {
 	}
 
 	private Port getPort(int componentIndex, int portIndex) {
-		Component component = (Component) diagram.getComponents().get(componentIndex);
-		return (Port) component.getPorts().get(portIndex);
+		Component component = diagram.getComponents().get(componentIndex);
+		return component.getPorts().get(portIndex);
 	}
 	private void verifyConnectCount(int count, Port port) {
 		assertEquals(count, port.getConnectorProfiles().size());
 	}
 
-	@SuppressWarnings("unchecked")
 	private Component createComponent(String instanceName) {
 		Component component = ComponentFactory.eINSTANCE.createComponentSpecification();
 		component.setInstanceNameL(instanceName);
@@ -79,8 +77,7 @@ public class OfflineCompositeTest {
 		port.setNameL("CapPORT");
 		return port;
 	}
-	
-	@SuppressWarnings("unchecked")
+
 	private Component createCompositeComponentSpecification() {
 		Component component = ComponentFactory.eINSTANCE.createComponentSpecification();
 		component.setInstanceNameL("s1");
@@ -90,7 +87,6 @@ public class OfflineCompositeTest {
 		return component;
 	}
 
-	@SuppressWarnings("unchecked")
 	private ConfigurationSet createConfigurationSet() {
 		ConfigurationSet configSet = ComponentFactory.eINSTANCE.createConfigurationSet();
 		configSet.setId("default");
@@ -108,8 +104,8 @@ public class OfflineCompositeTest {
 
 	private PortConnector createConnector() {
 		PortConnector connector = PortConnectorFactory.createPortConnectorSpecification();
-		connector.setSource((Port) ((Component)diagram.getComponents().get(2)).getPorts().get(0));
-		connector.setTarget((Port) ((Component)diagram.getComponents().get(3)).getPorts().get(0));
+		connector.setSource((diagram.getComponents().get(2)).getPorts().get(0));
+		connector.setTarget((diagram.getComponents().get(3)).getPorts().get(0));
 		connector.setConnectorProfile(createConnectorProfile());
 		return connector;
 	}

--- a/jp.go.aist.rtm.toolscommon/test/jp/go/aist/rtm/toolscommon/model/component/util/ComponentCommonUtilTest.java
+++ b/jp.go.aist.rtm.toolscommon/test/jp/go/aist/rtm/toolscommon/model/component/util/ComponentCommonUtilTest.java
@@ -15,7 +15,6 @@ import org.junit.Test;
 
 public class ComponentCommonUtilTest {
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void getConnectedPorts_Corba() throws Exception {
 		RTC.mock.PortServiceImpl c_in1 = _createRtcPortService("in1");
@@ -68,7 +67,6 @@ public class ComponentCommonUtilTest {
 //		assertEquals("in2", result.get(0).getPortProfile().getNameL());
 //	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void getRequiredExportedPortsString_Corba() throws Exception {
 		RTC.mock.PortServiceImpl c_in1 = _createRtcPortService("in1");
@@ -173,7 +171,6 @@ public class ComponentCommonUtilTest {
 
 	private static int CONNECTOR_PROFILE_SEQ = 1;
 
-	@SuppressWarnings("unchecked")
 	private void _connectCorbaPorts(Port source, Port target) {
 		RTC.ConnectorProfile conn_prof = new RTC.ConnectorProfile();
 		conn_prof.connector_id = "conn-" + CONNECTOR_PROFILE_SEQ++;


### PR DESCRIPTION
## Identify the Bug

Link to #14

## Description of the Change

RTSystemEditorに関して，以下の警告を修正
- try-with-resource の使用
- 不要なインポート文の削除
- 使用していない変数の削除
- 不要なキャストの削除
- 不要なアノテーションの削除

対象プラグインは以下のとおり．
- jp.go.aist.rtm.nameserviceview
- jp.go.aist.rtm.repositoryView
- jp.go.aist.rtm.systemeditor
- jp.go.aist.rtm.toolscommon
- jp.go.aist.rtm.toolscommon.profiles

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse4.7.3を使用
- [x] No warnings for the build?  Windows上でEclipse4.7.3を使用
- [x] Have you passed the unit tests?  ユニットテスト無し
