### PR TITLE
initializeParam() addedl for OutPort in Java RTC code generated by RTC

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder.java/src/jp/go/aist/rtm/rtcbuilder/java/template/java/Java_RTC_Impl.java.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.java/src/jp/go/aist/rtm/rtcbuilder/java/template/java/Java_RTC_Impl.java.vsl
@@ -105,6 +105,7 @@ public class ${rtcParam.name}Impl extends DataFlowComponentBase {
 #end
 #foreach($port in ${rtcParam.outports})  
         m_${port.tmplVarName}_val = new ${javaConv.getDataTypeName(${port.type})}();
+        initializeParam(m_${port.tmplVarName}_val);
         m_${port.tmplVarName} = new DataRef<${javaConv.getDataTypeName(${port.type})}>(m_${port.tmplVarName}_val);
         m_${port.name}Out = new OutPort<${javaConv.getDataTypeName(${port.type})}>("${port.name}", m_${port.tmplVarName});
 #end


### PR DESCRIPTION
Modification for issue #36

RTCB generated code for Java does not include initializeParam() initialization for OutPort.
Velocity template code has been modified.