### PR TITLE
Modified to execute Manager's init function only once.#44

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/AIST2/ModuleNameComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/AIST2/ModuleNameComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/CheckIDL/SampleComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/CheckIDL/SampleComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/ConfigType/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/ConfigType/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset1/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset1/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset2/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset2/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset3/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset3/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset4/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset4/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Content/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Content/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/DataPortIDL/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/DataPortIDL/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Doc/fullLong/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Doc/fullLong/fooComp.cpp
@@ -82,9 +82,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ExecutionCxt/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ExecutionCxt/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Manip/ModuleNameComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Manip/ModuleNameComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ConMulti/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ConMulti/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ProConMulti/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ProConMulti/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ProMulti/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ProMulti/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/confprefix/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/confprefix/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/confsuffix/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/confsuffix/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/dtprefix/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/dtprefix/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/dtsuffix/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/dtsuffix/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/prefix/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/prefix/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/siprefix/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/siprefix/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/sisuffix/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/sisuffix/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/suffix/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/suffix/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/svprefix/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/svprefix/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/svsuffix/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/svsuffix/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/SystemConfig/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/SystemConfig/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/DataPort/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/DataPort/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/ServicePort1/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/ServicePort1/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/ServicePort2/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/ServicePort2/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/attribute/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/attribute/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/inport1/testComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/inport1/testComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/inport2/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/inport2/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/name/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/name/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/operation/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/operation/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/outport1/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/outport1/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/outport2/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/outport2/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/service1/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/service1/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/service2/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/service2/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/DFFSMMM/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/DFFSMMM/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/DataFlow/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/DataFlow/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/FSM/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/FSM/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/cmake1/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/cmake1/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/cmake1/src/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/cmake1/src/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/cmake2/src/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/cmake2/src/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/vc1/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/vc1/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint1/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint1/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint2/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint2/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint3/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint3/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlinherit/inherit1/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlinherit/inherit1/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlinherit/inherit2/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlinherit/inherit2/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceArg/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceArg/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceArgStruct/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceArgStruct/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceCon/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceCon/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceM/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceM/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath1/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath1/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath2/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath2/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath3/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath3/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlstruct/TestModuleComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlstruct/TestModuleComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/IDLType1/ModuleNameComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/IDLType1/ModuleNameComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/SeqString/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/SeqString/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/Struct/ModuleNameComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/Struct/ModuleNameComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/Struct2/ModuleNameComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/Struct2/ModuleNameComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/type/testComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/type/testComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/all/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/all/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/execute/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/execute/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/finalize/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/finalize/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/initialize/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/initialize/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/library/library1/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/library/library1/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/library/library2/fooComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/library/library2/fooComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/DataPortIDL/src/MarkerPositionComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/DataPortIDL/src/MarkerPositionComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePort/ModuleNameComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePort/ModuleNameComp.cpp
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/CXX_Comp.cpp.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/CXX_Comp.cpp.vsl
@@ -76,9 +76,6 @@ int main (int argc, char** argv)
   RTC::Manager* manager;
   manager = RTC::Manager::init(argc, argv);
 
-  // Initialize manager
-  manager->init(argc, argv);
-
   // Set module initialization proceduer
   // This procedure will be invoked in activateManager() function.
   manager->setModuleInitProc(MyModuleInit);


### PR DESCRIPTION
Identify the Bug
Link to #44

Description of the Change
ご連絡を頂きました内容を基に，***Comp.cpp内でManagerのinit関数を１回しか実行しないように修正させて頂きました．

Verification
 Did you succesed the build? Windows上でEclipse2019-03を使用
 No warnings for the build? Windows上でEclipse2019-03を使用
 Have you passed the unit tests? 既存のユニットテストを修正し，修正した内容でコードが生成されることを確認