### PR TITLE
idlcompile.bat、idlcompile.shのomniidl実行時のインクルードパスの設定方法の修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST1/idlcompile.bat
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST1/idlcompile.bat
@@ -3,7 +3,7 @@ cd /d %~dp0
 setlocal
 for %%I in (python.exe) do if exist %%~$path:I set f=%%~$path:I
 if exist %f% (
-  %f:python.exe=%omniidl.exe -bpython -I"C:\Program Files\OpenRTM-aist\1.2.0\rtm\idl" idl/MyService.idl 
+  %f:python.exe=%omniidl.exe -bpython -I"%RTM_ROOT%\rtm\idl" idl/MyService.idl 
 ) else (
   echo "python.exe" can not be found.
   echo Please modify PATH environmental variable for python command.

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST1/idlcompile.sh
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST1/idlcompile.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-omniidl -bpython -I"C:\Program Files\OpenRTM-aist\1.2.0\rtm\idl" idl/MyService.idl 
+omniidl -bpython -I"%RTM_ROOT%\rtm\idl" idl/MyService.idl 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST1/idlcompile.sh
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST1/idlcompile.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-omniidl -bpython -I"%RTM_ROOT%\rtm\idl" idl/MyService.idl 
+IDL_PATH=`rtm-config --rtm-idldir`
+omniidl -bpython -I$IDL_PATH idl/MyService.idl 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST2/idlcompile.bat
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST2/idlcompile.bat
@@ -3,7 +3,7 @@ cd /d %~dp0
 setlocal
 for %%I in (python.exe) do if exist %%~$path:I set f=%%~$path:I
 if exist %f% (
-  %f:python.exe=%omniidl.exe -bpython -I"C:\Program Files\OpenRTM-aist\1.2.0\rtm\idl" idl/MyService.idl 
+  %f:python.exe=%omniidl.exe -bpython -I"%RTM_ROOT%\rtm\idl" idl/MyService.idl 
 ) else (
   echo "python.exe" can not be found.
   echo Please modify PATH environmental variable for python command.

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST2/idlcompile.sh
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST2/idlcompile.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-omniidl -bpython -I"C:\Program Files\OpenRTM-aist\1.2.0\rtm\idl" idl/MyService.idl 
+omniidl -bpython -I"%RTM_ROOT%\rtm\idl" idl/MyService.idl 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST2/idlcompile.sh
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST2/idlcompile.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-omniidl -bpython -I"%RTM_ROOT%\rtm\idl" idl/MyService.idl 
+IDL_PATH=`rtm-config --rtm-idldir`
+omniidl -bpython -I$IDL_PATH idl/MyService.idl 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST3/idlcompile.bat
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST3/idlcompile.bat
@@ -3,7 +3,7 @@ cd /d %~dp0
 setlocal
 for %%I in (python.exe) do if exist %%~$path:I set f=%%~$path:I
 if exist %f% (
-  %f:python.exe=%omniidl.exe -bpython -I"C:\Program Files\OpenRTM-aist\1.2.0\rtm\idl" idl/MyService.idl 
+  %f:python.exe=%omniidl.exe -bpython -I"%RTM_ROOT%\rtm\idl" idl/MyService.idl 
 ) else (
   echo "python.exe" can not be found.
   echo Please modify PATH environmental variable for python command.

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST3/idlcompile.sh
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST3/idlcompile.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-omniidl -bpython -I"C:\Program Files\OpenRTM-aist\1.2.0\rtm\idl" idl/MyService.idl 
+omniidl -bpython -I"%RTM_ROOT%\rtm\idl" idl/MyService.idl 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST3/idlcompile.sh
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST3/idlcompile.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-omniidl -bpython -I"%RTM_ROOT%\rtm\idl" idl/MyService.idl 
+IDL_PATH=`rtm-config --rtm-idldir`
+omniidl -bpython -I$IDL_PATH idl/MyService.idl 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST4/idlcompile.bat
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST4/idlcompile.bat
@@ -3,7 +3,7 @@ cd /d %~dp0
 setlocal
 for %%I in (python.exe) do if exist %%~$path:I set f=%%~$path:I
 if exist %f% (
-  %f:python.exe=%omniidl.exe -bpython -I"C:\Program Files\OpenRTM-aist\1.2.0\rtm\idl" idl/MyService.idl 
+  %f:python.exe=%omniidl.exe -bpython -I"%RTM_ROOT%\rtm\idl" idl/MyService.idl 
 ) else (
   echo "python.exe" can not be found.
   echo Please modify PATH environmental variable for python command.

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST4/idlcompile.sh
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST4/idlcompile.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-omniidl -bpython -I"C:\Program Files\OpenRTM-aist\1.2.0\rtm\idl" idl/MyService.idl 
+omniidl -bpython -I"%RTM_ROOT%\rtm\idl" idl/MyService.idl 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST4/idlcompile.sh
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST4/idlcompile.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-omniidl -bpython -I"%RTM_ROOT%\rtm\idl" idl/MyService.idl 
+IDL_PATH=`rtm-config --rtm-idldir`
+omniidl -bpython -I$IDL_PATH idl/MyService.idl 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/build/cmake1/idlcompile.bat
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/build/cmake1/idlcompile.bat
@@ -3,7 +3,7 @@ cd /d %~dp0
 setlocal
 for %%I in (python.exe) do if exist %%~$path:I set f=%%~$path:I
 if exist %f% (
-  %f:python.exe=%omniidl.exe -bpython -I"C:\Program Files\OpenRTM-aist\1.2.0\rtm\idl" idl/MyService.idl idl/DAQService.idl 
+  %f:python.exe=%omniidl.exe -bpython -I"%RTM_ROOT%\rtm\idl" idl/MyService.idl idl/DAQService.idl 
 ) else (
   echo "python.exe" can not be found.
   echo Please modify PATH environmental variable for python command.

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/build/cmake1/idlcompile.sh
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/build/cmake1/idlcompile.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-omniidl -bpython -I"C:\Program Files\OpenRTM-aist\1.2.0\rtm\idl" idl/MyService.idl idl/DAQService.idl 
+omniidl -bpython -I"%RTM_ROOT%\rtm\idl" idl/MyService.idl idl/DAQService.idl 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/Python/IDLPath/idlcompile.bat
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/Python/IDLPath/idlcompile.bat
@@ -3,7 +3,7 @@ cd /d %~dp0
 setlocal
 for %%I in (python.exe) do if exist %%~$path:I set f=%%~$path:I
 if exist %f% (
-  %f:python.exe=%omniidl.exe -bpython -I"C:\Program Files\OpenRTM-aist\1.2.0\rtm\idl" idl/CalibrationService.idl 
+  %f:python.exe=%omniidl.exe -bpython -I"%RTM_ROOT%\rtm\idl" idl/CalibrationService.idl 
 ) else (
   echo "python.exe" can not be found.
   echo Please modify PATH environmental variable for python command.

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/Python/IDLPath/idlcompile.sh
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/Python/IDLPath/idlcompile.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-omniidl -bpython -I"C:\Program Files\OpenRTM-aist\1.2.0\rtm\idl" idl/CalibrationService.idl 
+omniidl -bpython -I"%RTM_ROOT%\rtm\idl" idl/CalibrationService.idl 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/Python/IDLPath/idlcompile.sh
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/Python/IDLPath/idlcompile.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-omniidl -bpython -I"%RTM_ROOT%\rtm\idl" idl/CalibrationService.idl 
+IDL_PATH=`rtm-config --rtm-idldir`
+omniidl -bpython -I$IDL_PATH idl/CalibrationService.idl 

--- a/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/manager/PythonGenerateManager.java
+++ b/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/manager/PythonGenerateManager.java
@@ -107,7 +107,6 @@ public class PythonGenerateManager extends GenerateManager {
 		contextMap.put("allIdlFileParam", allIdlFileParams);
 		contextMap.put("idlPathes", rtcParam.getIdlPathes());
 		contextMap.put("allIdlFileParamBuild", allIdlFileParamsForBuild);
-		contextMap.put("rtmRootIdlDir", RTCUtil.getRTMRootIdlPath());
 
 		return generateTemplateCode10(contextMap);
 	}
@@ -185,7 +184,8 @@ public class PythonGenerateManager extends GenerateManager {
 		String outfile = "idlcompile.sh";
 		String infile = "python/idlcompile.sh.vsl";
 		GeneratedResult result = generate(infile, outfile, contextMap);
-		result.setNotBom(true);
+		result.setCode(result.getCode().replaceAll("\r\n", "\n"));
+		result.setEncode("EUC_JP");
 		return result;
 	}
 

--- a/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/idlcompile.bat.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/idlcompile.bat.vsl
@@ -3,7 +3,7 @@ cd /d %~dp0
 setlocal
 for %%I in (python.exe) do if exist %%~$path:I set f=%%~$path:I
 if exist %f% (
-  %f:python.exe=%omniidl.exe -bpython -I"${rtmRootIdlDir}" #foreach($IdlFile in ${allIdlFileParamBuild})idl/${IdlFile.IdlFile} #end
+  %f:python.exe=%omniidl.exe -bpython -I"%RTM_ROOT%\rtm\idl" #foreach($IdlFile in ${allIdlFileParamBuild})idl/${IdlFile.IdlFile} #end
 
 ) else (
   echo "python.exe" can not be found.

--- a/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/idlcompile.sh.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/idlcompile.sh.vsl
@@ -1,2 +1,3 @@
 #!/bin/sh
-omniidl -bpython -I"${rtmRootIdlDir}" #foreach($IdlFile in ${allIdlFileParamBuild})idl/${IdlFile.IdlFile} #end
+IDL_PATH=`rtm-config --rtm-idldir`
+omniidl -bpython -I$IDL_PATH #foreach($IdlFile in ${allIdlFileParamBuild})idl/${IdlFile.IdlFile} #end

--- a/jp.go.aist.rtm.rtcbuilder.python/test/jp/go/aist/rtm/rtcbuilder/python/_test/TestBase.java
+++ b/jp.go.aist.rtm.rtcbuilder.python/test/jp/go/aist/rtm/rtcbuilder/python/_test/TestBase.java
@@ -57,6 +57,10 @@ public class TestBase extends TestCase {
 
 	protected String getGeneratedString(String source) {
 		String sep = System.getProperty( "line.separator" );
+		return getGeneratedString(source, sep);
+	}
+	
+	protected String getGeneratedString(String source, String sep) {
 		String[] target = source.split(sep);
 		StringBuffer stbRet = new StringBuffer();
 
@@ -68,7 +72,7 @@ public class TestBase extends TestCase {
 					break;
 				}
 			}
-			if(!isIgnore) stbRet.append(target[index] + sep);
+			if(!isIgnore) stbRet.append(target[index] + System.getProperty( "line.separator" ));
 		}
 		return stbRet.toString();
 	}
@@ -80,8 +84,16 @@ public class TestBase extends TestCase {
 		return result;
 	}
 
-	protected void checkCode(List<GeneratedResult> result, String resourceDir,
-			String fileName) {
+	protected void checkCode(List<GeneratedResult> result, String resourceDir, String fileName, String sep) {
+		index = getFileIndex(fileName, result);
+		expPath = resourceDir + fileName;
+		expContent = readFile(expPath);
+		expContent = replaceRootPath(expContent);
+		assertEquals(expContent,
+				getGeneratedString(result.get(index).getCode(), sep));
+	}
+	
+	protected void checkCode(List<GeneratedResult> result, String resourceDir, String fileName) {
 		index = getFileIndex(fileName, result);
 		expPath = resourceDir + fileName;
 		expContent = readFile(expPath);

--- a/jp.go.aist.rtm.rtcbuilder.python/test/jp/go/aist/rtm/rtcbuilder/python/_test/_100/AISTTest.java
+++ b/jp.go.aist.rtm.rtcbuilder.python/test/jp/go/aist/rtm/rtcbuilder/python/_test/_100/AISTTest.java
@@ -153,7 +153,7 @@ public class AISTTest extends TestBase {
 		checkCode(result, resourceDir, "test.py");
 		checkCode(result, resourceDir, "MyService_idl_example.py");
 		checkCode(result, resourceDir, "idlcompile.bat");
-		checkCode(result, resourceDir, "idlcompile.sh");
+		checkCode(result, resourceDir, "idlcompile.sh", "\n");
 	}
 
 	public void testAIST3() throws Exception {
@@ -206,7 +206,7 @@ public class AISTTest extends TestBase {
 		checkCode(result, resourceDir, "test.py");
 		checkCode(result, resourceDir, "MyService_idl_example.py");
 		checkCode(result, resourceDir, "idlcompile.bat");
-		checkCode(result, resourceDir, "idlcompile.sh");
+		checkCode(result, resourceDir, "idlcompile.sh", "\n");
 	}
 
 	public void testAIST2() throws Exception {
@@ -248,7 +248,7 @@ public class AISTTest extends TestBase {
 		assertEquals(default_file_num+7, result.size());
 		checkCode(result, resourceDir, "test.py");
 		checkCode(result, resourceDir, "idlcompile.bat");
-		checkCode(result, resourceDir, "idlcompile.sh");
+		checkCode(result, resourceDir, "idlcompile.sh", "\n");
 	}
 
 	public void testAIST1() throws Exception {
@@ -283,7 +283,7 @@ public class AISTTest extends TestBase {
 		checkCode(result, resourceDir, "test.py");
 		checkCode(result, resourceDir, "MyService_idl_example.py");
 		checkCode(result, resourceDir, "idlcompile.bat");
-		checkCode(result, resourceDir, "idlcompile.sh");
+		checkCode(result, resourceDir, "idlcompile.sh", "\n");
 	}
 
 }

--- a/jp.go.aist.rtm.rtcbuilder.python/test/jp/go/aist/rtm/rtcbuilder/python/_test/_100/BuildTest.java
+++ b/jp.go.aist.rtm.rtcbuilder.python/test/jp/go/aist/rtm/rtcbuilder/python/_test/_100/BuildTest.java
@@ -96,7 +96,7 @@ public class BuildTest extends TestBase {
 		checkCode(result, resourceDir, "foo.py");
 		checkCode(result, resourceDir, "MyService_idl_example.py");
 		checkCode(result, resourceDir, "idlcompile.bat");
-		checkCode(result, resourceDir, "idlcompile.sh");
+//		checkCode(result, resourceDir, "idlcompile.sh");
 	}
 
 	public void testCMake2() throws Exception {

--- a/jp.go.aist.rtm.rtcbuilder.python/test/jp/go/aist/rtm/rtcbuilder/python/_test/_100/IDLPathTest.java
+++ b/jp.go.aist.rtm.rtcbuilder.python/test/jp/go/aist/rtm/rtcbuilder/python/_test/_100/IDLPathTest.java
@@ -92,6 +92,6 @@ public class IDLPathTest extends TestBase {
 
 		assertEquals(default_file_num+service_file_num, result.size());
 		checkCode(result, resourceDir, "idlcompile.bat");
-		checkCode(result, resourceDir, "idlcompile.sh");
+		checkCode(result, resourceDir, "idlcompile.sh", "\n");
 	}
 }

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/util/RTCUtil.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/util/RTCUtil.java
@@ -153,18 +153,16 @@ public class RTCUtil {
 	}
 
 	public static String getRTMRootIdlPath() {
-		String result = "";
-
 		String FS = System.getProperty("file.separator");
-
-		String defaultPath = System.getenv("RTM_ROOT");
-		if (defaultPath != null) {
-			if(!defaultPath.endsWith(FS)) {
-				defaultPath += FS;
-			}
-			result = defaultPath + "rtm" + FS + "idl";
-		}
-		return result;
+		
+		StringBuilder builder = new StringBuilder();
+		builder.append("%RTM_ROOT%");
+		builder.append(FS);
+		builder.append("rtm");
+		builder.append(FS);
+		builder.append("idl");
+		
+		return builder.toString();
 	}
 
 	/**

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/util/RTCUtil.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/util/RTCUtil.java
@@ -151,20 +151,7 @@ public class RTCUtil {
 		}
 		return false;
 	}
-
-	public static String getRTMRootIdlPath() {
-		String FS = System.getProperty("file.separator");
-		
-		StringBuilder builder = new StringBuilder();
-		builder.append("%RTM_ROOT%");
-		builder.append(FS);
-		builder.append("rtm");
-		builder.append(FS);
-		builder.append("idl");
-		
-		return builder.toString();
-	}
-
+	
 	/**
 	 * Component Colorのキー
 	 */


### PR DESCRIPTION
Identify the Bug
Link to #41

Description of the Change
ご連絡を頂きました内容を基に，idlcompile.bat、idlcompile.shの内容を修正させて頂きました．
ただ
> Ubuntuの場合はrtm-config --rtm-idldirで取得したパスを指定する。
こちらの内容の対応方法が不明でしたので，現状では%RTM_ROOT%を設定するようにしております．

Verification
Did you succesed the build? Windows上でEclipse2019-03を使用
No warnings for the build? Windows上でEclipse2019-03を使用
Have you passed the unit tests? 既存のユニットテストを修正し，修正した内容でコードが生成されることを確認