### PR TITLE
IDLビルド用ファイルのインクルードパスを修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/AIST6/build_ModuleName.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/AIST6/build_ModuleName.xml
@@ -24,15 +24,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="ModuleName" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="ModuleName"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/AIST7/build_ModuleName.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/AIST7/build_ModuleName.xml
@@ -24,15 +24,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="ModuleName" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="ModuleName"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/ConfigSetType/build_foo.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/ConfigSetType/build_foo.xml
@@ -24,15 +24,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="foo" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="foo"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/configset1/build_foo.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/configset1/build_foo.xml
@@ -24,15 +24,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="foo" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="foo"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/configset2/build_foo.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/configset2/build_foo.xml
@@ -24,15 +24,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="foo" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="foo"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/configset3/build_foo.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/configset3/build_foo.xml
@@ -24,15 +24,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="foo" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="foo"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/Multi/ConMulti/build_foo.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/Multi/ConMulti/build_foo.xml
@@ -16,10 +16,10 @@
 	</target>
 	<target name="idlcompile"  depends="mkdir">
 		<exec executable="${java.home}/../bin/idlj">
-			<arg line="-td 'src' -fall 'idl/MyService.idl'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' -fall 'idl/MyService.idl'"/>
 		</exec>
 		<exec executable="${java.home}/../bin/idlj">
-			<arg line="-td 'src' -fall 'idl/DAQService.idl'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' -fall 'idl/DAQService.idl'"/>
 		</exec>
 	</target>
 	<target name="compile" depends="idlcompile">
@@ -32,15 +32,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="foo" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="foo"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/Multi/ProConMulti/build_foo.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/Multi/ProConMulti/build_foo.xml
@@ -16,13 +16,13 @@
 	</target>
 	<target name="idlcompile"  depends="mkdir">
 		<exec executable="${java.home}/../bin/idlj">
-			<arg line="-td 'src' -fall 'idl/MyService.idl'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' -fall 'idl/MyService.idl'"/>
 		</exec>
 		<exec executable="${java.home}/../bin/idlj">
-			<arg line="-td 'src' -fall 'idl/MyService2.idl'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' -fall 'idl/MyService2.idl'"/>
 		</exec>
 		<exec executable="${java.home}/../bin/idlj">
-			<arg line="-td 'src' -fall 'idl/DAQService.idl'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' -fall 'idl/DAQService.idl'"/>
 		</exec>
 	</target>
 	<target name="compile" depends="idlcompile">
@@ -35,15 +35,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="foo" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="foo"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/Multi/ProMulti/build_foo.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/Multi/ProMulti/build_foo.xml
@@ -16,10 +16,10 @@
 	</target>
 	<target name="idlcompile"  depends="mkdir">
 		<exec executable="${java.home}/../bin/idlj">
-			<arg line="-td 'src' -fall 'idl/MyService.idl'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' -fall 'idl/MyService.idl'"/>
 		</exec>
 		<exec executable="${java.home}/../bin/idlj">
-			<arg line="-td 'src' -fall 'idl/DAQService.idl'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' -fall 'idl/DAQService.idl'"/>
 		</exec>
 	</target>
 	<target name="compile" depends="idlcompile">
@@ -32,15 +32,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="foo" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="foo"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/inport1/build_foo.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/inport1/build_foo.xml
@@ -24,15 +24,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="foo" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="foo"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/inport2/build_foo.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/inport2/build_foo.xml
@@ -24,15 +24,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="foo" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="foo"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/name/build_foo.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/name/build_foo.xml
@@ -24,15 +24,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="foo" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="foo"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/outport1/build_foo.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/outport1/build_foo.xml
@@ -24,15 +24,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="foo" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="foo"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/outport2/build_foo.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/outport2/build_foo.xml
@@ -24,15 +24,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="foo" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="foo"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/service1/build_foo.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/service1/build_foo.xml
@@ -16,7 +16,7 @@
 	</target>
 	<target name="idlcompile"  depends="mkdir">
 		<exec executable="${java.home}/../bin/idlj">
-			<arg line="-td 'src' -fall 'idl/MyService.idl'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' -fall 'idl/MyService.idl'"/>
 		</exec>
 	</target>
 	<target name="compile" depends="idlcompile">
@@ -29,15 +29,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="foo" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="foo"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/service2/build_foo.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/service2/build_foo.xml
@@ -16,10 +16,10 @@
 	</target>
 	<target name="idlcompile"  depends="mkdir">
 		<exec executable="${java.home}/../bin/idlj">
-			<arg line="-td 'src' -fall 'idl/MyService.idl'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' -fall 'idl/MyService.idl'"/>
 		</exec>
 		<exec executable="${java.home}/../bin/idlj">
-			<arg line="-td 'src' -fall 'idl/DAQService.idl'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' -fall 'idl/DAQService.idl'"/>
 		</exec>
 	</target>
 	<target name="compile" depends="idlcompile">
@@ -32,15 +32,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="foo" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="foo"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/build/cmake1/build_foo.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/build/cmake1/build_foo.xml
@@ -16,10 +16,10 @@
 	</target>
 	<target name="idlcompile"  depends="mkdir">
 		<exec executable="${java.home}/../bin/idlj">
-			<arg line="-td 'src' -fall 'idl/MyService.idl'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' -fall 'idl/MyService.idl'"/>
 		</exec>
 		<exec executable="${java.home}/../bin/idlj">
-			<arg line="-td 'src' -fall 'idl/DAQService.idl'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' -fall 'idl/DAQService.idl'"/>
 		</exec>
 	</target>
 	<target name="compile" depends="idlcompile">
@@ -32,15 +32,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="foo" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="foo"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/build/cmake2/build_foo.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/build/cmake2/build_foo.xml
@@ -6,28 +6,20 @@
 #
 # $Id$
  -->
-<project name="foo" default="compile">
+<project name="foo" default="generatedoc">
 	<property name="source" value="src" />
 	<property name="dest" value="bin" />
+	<property name="doc" value="doc" />
 	<property environment="env" />
 	<target name="mkdir">
 		<mkdir dir="${dest}" />
 	</target>
 	<target name="idlcompile"  depends="mkdir">
 		<exec executable="${java.home}/../bin/idlj">
-			<arg line="-td 'src' -i 'D:\GlobalAssist\EclipseAISTRep\jp.go.aist.rtm.rtcbuilder.java\resource/100/build/cmake2' -i 'D:\GlobalAssist\EclipseAISTRep\jp.go.aist.rtm.rtcbuilder.java\resource/100/build/cmake2' -fall 'idl/MyServiceChildMulti.idl'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' -fall 'idl/MyService.idl'"/>
 		</exec>
 		<exec executable="${java.home}/../bin/idlj">
-			<arg line="-td 'src' -i 'D:\GlobalAssist\EclipseAISTRep\jp.go.aist.rtm.rtcbuilder.java\resource/100/build/cmake2' -i 'D:\GlobalAssist\EclipseAISTRep\jp.go.aist.rtm.rtcbuilder.java\resource/100/build/cmake2' -fall 'idl/MyServiceParent1.idl'"/>
-		</exec>
-		<exec executable="${java.home}/../bin/idlj">
-			<arg line="-td 'src' -i 'D:\GlobalAssist\EclipseAISTRep\jp.go.aist.rtm.rtcbuilder.java\resource/100/build/cmake2' -i 'D:\GlobalAssist\EclipseAISTRep\jp.go.aist.rtm.rtcbuilder.java\resource/100/build/cmake2' -fall 'idl/MyServiceParent2.idl'"/>
-		</exec>
-		<exec executable="${java.home}/../bin/idlj">
-			<arg line="-td 'src' -i 'D:\GlobalAssist\EclipseAISTRep\jp.go.aist.rtm.rtcbuilder.java\resource/100/build/cmake2' -i 'D:\GlobalAssist\EclipseAISTRep\jp.go.aist.rtm.rtcbuilder.java\resource/100/build/cmake2' -fall 'idl/MyServiceChildWithType.idl'"/>
-		</exec>
-		<exec executable="${java.home}/../bin/idlj">
-			<arg line="-td 'src' -i 'D:\GlobalAssist\EclipseAISTRep\jp.go.aist.rtm.rtcbuilder.java\resource/100/build/cmake2' -i 'D:\GlobalAssist\EclipseAISTRep\jp.go.aist.rtm.rtcbuilder.java\resource/100/build/cmake2' -fall 'idl/MyServiceParentWithType.idl'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' -fall 'idl/DAQService.idl'"/>
 		</exec>
 	</target>
 	<target name="compile" depends="idlcompile">
@@ -38,5 +30,28 @@
 				</fileset>
 			</classpath>
 		</javac>
+	</target>
+	<target name="generatedoc" depends="compile">
+		<javadoc
+                        Locale="ja_JP"
+                        destdir="${doc}"
+                        docencoding="UTF-8"
+			author="true" doctitle="foo"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
+                        >
+			<classpath>
+				<fileset dir="${env.RTM_JAVA_ROOT}/jar">
+					<include name="*.jar"/>
+				</fileset>
+			</classpath>
+			<sourcefiles>
+				<fileset dir="${source}">
+					<include name="**/*.java"/>
+				</fileset>
+                	</sourcefiles>
+                </javadoc>
 	</target>
 </project>

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/module/serviceCon/build_foo.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/module/serviceCon/build_foo.xml
@@ -16,7 +16,7 @@
 	</target>
 	<target name="idlcompile"  depends="mkdir">
 		<exec executable="${java.home}/../bin/idlj">
-			<arg line="-td 'src' -fall 'idl/MyService.idl'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' -fall 'idl/MyService.idl'"/>
 		</exec>
 	</target>
 	<target name="compile" depends="idlcompile">
@@ -29,15 +29,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="foo" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="foo"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/module/serviceM/build_foo.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/module/serviceM/build_foo.xml
@@ -16,7 +16,7 @@
 	</target>
 	<target name="idlcompile"  depends="mkdir">
 		<exec executable="${java.home}/../bin/idlj">
-			<arg line="-td 'src' -fall 'idl/MyService.idl'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' -fall 'idl/MyService.idl'"/>
 		</exec>
 	</target>
 	<target name="compile" depends="idlcompile">
@@ -29,15 +29,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="foo" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="foo"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/module/serviceMC/build_foo.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/module/serviceMC/build_foo.xml
@@ -16,7 +16,7 @@
 	</target>
 	<target name="idlcompile"  depends="mkdir">
 		<exec executable="${java.home}/../bin/idlj">
-			<arg line="-td 'src' -fall 'idl/MyService.idl'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' -fall 'idl/MyService.idl'"/>
 		</exec>
 	</target>
 	<target name="compile" depends="idlcompile">
@@ -29,15 +29,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="foo" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="foo"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder.java/src/jp/go/aist/rtm/rtcbuilder/java/template/java/build.xml.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.java/src/jp/go/aist/rtm/rtcbuilder/java/template/java/build.xml.vsl
@@ -21,21 +21,21 @@
 	<target name="idlcompile"  depends="mkdir">
 #foreach($idlPath in ${rtcParam.providerIdlPathes})
 		<exec executable="${dollarStr}{java.home}/../bin/idlj">
-			<arg line="-td 'src' #foreach($idlSearchPath in ${idlPath.idlSearchPathes})-i '${idlSearchPath}' #end-fall 'idl/${tmpltHelper.getFileName(${idlPath.idlFile})}'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' #foreach($idlSearchPath in ${idlPath.idlSearchPathes})-i '${idlSearchPath}' #end-fall 'idl/${tmpltHelper.getFileName(${idlPath.idlFile})}'"/>
 		</exec>
 #foreach ($idl in ${idlPath.includeIdlParams})
 		<exec executable="${dollarStr}{java.home}/../bin/idlj">
-			<arg line="-td 'src' #foreach($idlSearchPath in ${idlPath.idlSearchPathes})-i '${idlSearchPath}' #end-fall 'idl/${tmpltHelper.getFileName(${idl.idlFile})}'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' #foreach($idlSearchPath in ${idlPath.idlSearchPathes})-i '${idlSearchPath}' #end-fall 'idl/${tmpltHelper.getFileName(${idl.idlFile})}'"/>
 		</exec>
 #end
 #end
 #foreach($idlPath in ${rtcParam.consumerIdlPathes})
 		<exec executable="${dollarStr}{java.home}/../bin/idlj">
-			<arg line="-td 'src' #foreach($idlSearchPath in ${idlPath.idlSearchPathes})-i '${idlSearchPath}' #end-fall 'idl/${tmpltHelper.getFileName(${idlPath.idlFile})}'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' #foreach($idlSearchPath in ${idlPath.idlSearchPathes})-i '${idlSearchPath}' #end-fall 'idl/${tmpltHelper.getFileName(${idlPath.idlFile})}'"/>
 		</exec>
 #foreach ($idl in ${idlPath.includeIdlParams})
 		<exec executable="${dollarStr}{java.home}/../bin/idlj">
-			<arg line="-td 'src' #foreach($idlSearchPath in ${idlPath.idlSearchPathes})-i '${idlSearchPath}' #end-fall 'idl/${tmpltHelper.getFileName(${idl.idlFile})}'"/>
+			<arg line="-td 'src' -i '${env.RTM_JAVA_ROOT}/rtm/idl' #foreach($idlSearchPath in ${idlPath.idlSearchPathes})-i '${idlSearchPath}' #end-fall 'idl/${tmpltHelper.getFileName(${idl.idlFile})}'"/>
 		</exec>
 #end
 #end
@@ -61,15 +61,15 @@
 		</javac>
 	</target>
 	<target name="generatedoc" depends="compile">
-		<javadoc 
+		<javadoc
                         Locale="ja_JP"
                         destdir="${dollarStr}{doc}"
                         docencoding="UTF-8"
-			author="true" doctitle="${rtcParam.name}" 
-			nodeprecated="false" nodeprecatedlist="false" 
-                        noindex="false" nonavbar="false" notree="false" 
-			package="yes" splitindex="true" 
-                        use="true" version="true" charset="UTF-8" 
+			author="true" doctitle="${rtcParam.name}"
+			nodeprecated="false" nodeprecatedlist="false"
+                        noindex="false" nonavbar="false" notree="false"
+			package="yes" splitindex="true"
+                        use="true" version="true" charset="UTF-8"
                         >
 			<classpath>
 				<fileset dir="${dollarStr}{env.RTM_JAVA_ROOT}/jar">

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/generator/param/RtcParam.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/generator/param/RtcParam.java
@@ -52,8 +52,6 @@ public class RtcParam extends AbstractRecordedParam implements Serializable {
 	private RecordedList<DataPortParam> outports = new RecordedList<DataPortParam>();
 	//サービスポート
 	private RecordedList<ServicePortParam> serviceports = new RecordedList<ServicePortParam>();
-//	private List<String> idlSearchPathes = new RecordedList<String>();
-//	private String includeIDLPath = null;
 	//
 	private RecordedList<ServiceClassParam> serviceClassParams = new RecordedList<ServiceClassParam>();
 	//コンフィギュレーション


### PR DESCRIPTION
Identify the Bug
Link to #42

Description of the Change
ご連絡を頂きました内容を基に，build_***.idl内で，${env.RTM_JAVA_ROOT}/rtm/idlをIDLコンパイル時のインクルードパスとして含むように修正させて頂きました．

Verification
Did you succesed the build? Windows上でEclipse4.7.3を使用
No warnings for the build? Windows上でEclipse4.7.3を使用
Have you passed the unit tests? 既存のユニットテストを修正し，修正した内容でコードが生成されることを確認