### PR TITLE
テストコードをコンパイル・実行するCMakeを追加

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/generator/param/RtcParam.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/generator/param/RtcParam.java
@@ -998,4 +998,17 @@ public class RtcParam extends AbstractRecordedParam implements Serializable {
 		}
 		return null;
 	}
+	
+	public boolean isStaticFSM() {
+		PropertyParam fsm = getProperty(IRtcBuilderConstants.PROP_TYPE_FSM);
+		if(fsm!=null) {
+			if(Boolean.valueOf(fsm.getValue())) {
+				PropertyParam fsmType = getProperty(IRtcBuilderConstants.PROP_TYPE_FSMTYTPE);
+				if(fsmType.getValue().equals(IRtcBuilderConstants.FSMTYTPE_STATIC)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
 }

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/generator/param/RtcParam.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/generator/param/RtcParam.java
@@ -564,6 +564,15 @@ public class RtcParam extends AbstractRecordedParam implements Serializable {
 		return consumerIdlPathes;
 	}
 	
+	public List<IdlFileParam> getConsumerIdlPathesAdded() {
+		List<IdlFileParam> result = new ArrayList<IdlFileParam>();
+		for(IdlFileParam target : consumerIdlPathes) {
+			if(target.checkDefault()) continue;
+			result.add(target);
+		}
+		return result;
+	}
+	
 	public boolean checkWithoutDefaultPathes() {
 		if(0<providerIdlPathes.size()) {
 			for(IdlFileParam e : providerIdlPathes) {

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/manager/CMakeGenerateManager.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/manager/CMakeGenerateManager.java
@@ -100,6 +100,20 @@ public class CMakeGenerateManager extends GenerateManager {
 		result.add(gr);
 		gr = generateUtilIn(contextMap);
 		result.add(gr);
+		
+		//test cmake
+		RtcParam rtcParam = (RtcParam) contextMap.get("rtcParam");
+		boolean isStaticFSM = rtcParam.isStaticFSM();
+		if(rtcParam.isChoreonoid()==false && isStaticFSM==false) {
+			gr = generateTestCMakeLists(contextMap);
+			result.add(gr);
+			gr = generateTestIncludeCMakeLists(contextMap);
+			result.add(gr);
+			gr = generateTestIncModuleCMakeLists(contextMap);
+			result.add(gr);
+			gr = generateTestSrcCMakeLists(contextMap);
+			result.add(gr);
+		}
 
 		//doc
 		gr = generateDocCMakeLists(contextMap);
@@ -292,7 +306,40 @@ public class CMakeGenerateManager extends GenerateManager {
 		result.setNotBom(true);
 		return result;
 	}
-
+	/////
+	public GeneratedResult generateTestCMakeLists(Map<String, Object> contextMap) {
+		String outfile = "test/CMakeLists.txt";
+		String infile = "cmake/test/CMakeLists.txt.vsl";
+		GeneratedResult result = generate(infile, outfile, contextMap);
+		result.setNotBom(true);
+		return result;
+	}
+	
+	public GeneratedResult generateTestIncludeCMakeLists(Map<String, Object> contextMap) {
+		String outfile = "test/include/CMakeLists.txt";
+		String infile = "cmake/test/include/IncludeCMakeLists.txt.vsl";
+		GeneratedResult result = generate(infile, outfile, contextMap);
+		result.setNotBom(true);
+		return result;
+	}
+	
+	public GeneratedResult generateTestIncModuleCMakeLists(Map<String, Object> contextMap) {
+		RtcParam rtcParam = (RtcParam) contextMap.get("rtcParam");
+		String outfile = "test/include/" + rtcParam.getName() + "Test/CMakeLists.txt";
+		String infile = "cmake/test/include/IncModuleCMakeLists.txt.vsl";
+		GeneratedResult result = generate(infile, outfile, contextMap);
+		result.setNotBom(true);
+		return result;
+	}
+	
+	public GeneratedResult generateTestSrcCMakeLists(Map<String, Object> contextMap) {
+		String outfile = "test/src/CMakeLists.txt";
+		String infile = "cmake/test/src/SrcCMakeLists.txt.vsl";
+		GeneratedResult result = generate(infile, outfile, contextMap);
+		result.setNotBom(true);
+		return result;
+	}
+	/////
 	public GeneratedResult generate(String infile, String outfile,
 			Map<String, Object> contextMap) {
 		try {

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/manager/CXXGenerateManager.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/manager/CXXGenerateManager.java
@@ -72,17 +72,7 @@ public class CXXGenerateManager extends GenerateManager {
 		List<GeneratedResult> result = new ArrayList<GeneratedResult>();
 		RtcParam rtcParam = (RtcParam) contextMap.get("rtcParam");
 
-		boolean isStaticFSM = false;
-		PropertyParam fsm = rtcParam.getProperty(IRtcBuilderConstants.PROP_TYPE_FSM);
-		if(fsm!=null) {
-			if(Boolean.valueOf(fsm.getValue())) {
-				PropertyParam fsmType = rtcParam.getProperty(IRtcBuilderConstants.PROP_TYPE_FSMTYTPE);
-				if(fsmType.getValue().equals(IRtcBuilderConstants.FSMTYTPE_STATIC)) {
-					isStaticFSM = true;
-				}
-			}
-		}
-		
+		boolean isStaticFSM = rtcParam.isStaticFSM();
 		if(isStaticFSM) {
 			StateParam stateParam = rtcParam.getFsmParam();
 			contextMap.put("fsmParam", stateParam);

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/TemplateHelper.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/TemplateHelper.java
@@ -1,17 +1,58 @@
 package jp.go.aist.rtm.rtcbuilder.template;
 
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DEFAULT_SVC_IMPL_SUFFIX;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DEFAULT_SVC_SKEL_SUFFIX;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DEFAULT_SVC_STUB_SUFFIX;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_AUTHOR_OFFSET;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_CONSTRAINT_OFFSET;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_CONSTRAINT_PREFIX;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_CYCLE_OFFSET;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_CYCLE_PREFIX;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_DEFAULT_OFFSET;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_DEFAULT_PREFIX;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_DEFAULT_WIDTH;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_DESC_OFFSET;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_DESC_PREFIX;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_INTERFACE_DETAIL_OFFSET;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_INTERFACE_DETAIL_PREFIX;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_INTERFACE_OFFSET;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_INTERFACE_PREFIX;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_NUMBER_OFFSET;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_NUMBER_PREFIX;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_POST_OFFSET;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_PRE_OFFSET;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_RANGE_OFFSET;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_RANGE_PREFIX;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_README_ACTIVITY_OFFSET;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_README_ACTIVITY_PREFIX;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_README_COPYRIGHT_PREFIX;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_README_INTERFACE_OFFSET;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_README_INTERFACE_PREFIX;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_README_MODULE_OFFSET;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_README_MODULE_PREFIX;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_README_PORT_DETAIL_OFFSET;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_README_PORT_DETAIL_PREFIX;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_README_PORT_OFFSET;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_README_PORT_PREFIX;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_README_PREFIX;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_SEMANTICS_OFFSET;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_SEMANTICS_PREFIX;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_UNIT_OFFSET;
+import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.DOC_UNIT_PREFIX;
+import static jp.go.aist.rtm.rtcbuilder.util.StringUtil.splitString;
+
 import java.io.File;
 
 import jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants;
 import jp.go.aist.rtm.rtcbuilder.fsm.StateParam;
 import jp.go.aist.rtm.rtcbuilder.generator.param.ConfigParameterParam;
 import jp.go.aist.rtm.rtcbuilder.generator.param.ConfigSetParam;
+import jp.go.aist.rtm.rtcbuilder.generator.param.DataPortParam;
 import jp.go.aist.rtm.rtcbuilder.generator.param.PropertyParam;
 import jp.go.aist.rtm.rtcbuilder.generator.param.RtcParam;
+import jp.go.aist.rtm.rtcbuilder.generator.param.ServicePortParam;
 import jp.go.aist.rtm.rtcbuilder.generator.param.idl.IdlFileParam;
 import jp.go.aist.rtm.rtcbuilder.util.RTCUtil;
-import static jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants.*;
-import static jp.go.aist.rtm.rtcbuilder.util.StringUtil.*;
 
 /**
  * テンプレートを出力する際に使用されるヘルパー
@@ -372,5 +413,29 @@ public class TemplateHelper {
 		StateParam state = param.getFsmParam();
 		if(state==null) return "";
 		return state.getName();
+	}
+	
+	public String getConnectorString(RtcParam param) {
+		StringBuilder builder = new StringBuilder();
+		
+		for(DataPortParam port : param.getRawInports() ) {
+			if(port.getType().length()==0) continue;
+			if(0<builder.length()) builder.append(",");
+			builder.append("${PROJECT_NAME}0.").append(port.getName());
+			builder.append("?port=${PROJECT_NAME}Test0.").append(port.getName());
+		}
+		for(DataPortParam port : param.getOutports() ) {
+			if(port.getType().length()==0) continue;
+			if(0<builder.length()) builder.append(",");
+			builder.append("${PROJECT_NAME}0.").append(port.getName());
+			builder.append("?port=${PROJECT_NAME}Test0.").append(port.getName());
+		}
+		//
+		for(ServicePortParam port : param.getServicePorts() ) {
+			if(0<builder.length()) builder.append(",");
+			builder.append("${PROJECT_NAME}0.").append(port.getName());
+			builder.append("?port=${PROJECT_NAME}Test0.").append(port.getName());
+		}
+		return builder.toString();
 	}
 }

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/CMakeLists.txt.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/CMakeLists.txt.vsl
@@ -87,7 +87,7 @@ ADD_CUSTOM_TARGET (${dol}{PROJECT_NAME}_uninstall "${dol}{CMAKE_COMMAND}" -P
 
 ${sharp}option(BUILD_EXAMPLES "Build and install examples" OFF)
 option(BUILD_DOCUMENTATION "Build the documentation" OFF)
-${sharp}option(BUILD_TESTS "Build the tests" OFF)
+option(BUILD_TESTS "Build the tests" OFF)
 ${sharp}option(BUILD_TOOLS "Build the tools" OFF)
 option(BUILD_IDL "Build and install idl" ON)
 option(BUILD_SOURCES "Build and install sources" OFF)
@@ -118,9 +118,6 @@ else(WIN32)
    set(INSTALL_PREFIX "${dol}{OPENRTM_SHARE_PREFIX}/components/${dol}{PROJECT_TYPE}/${dol}{PROJECT_NAME}")
 endif(WIN32)
        
-${sharp} Universal settings
-${sharp}enable_testing()
-
 ${sharp} Subdirectories
 add_subdirectory(cmake)
 if(BUILD_DOCUMENTATION)
@@ -139,9 +136,11 @@ add_subdirectory(include)
 MAP_ADD_STR(headers  "include/" comp_hdrs)
 add_subdirectory(src)
 
-${sharp}if(BUILD_TESTS)
-${sharp}    add_subdirectory(test)
-${sharp}endif(BUILD_TESTS)
+if(BUILD_TESTS)
+    ${sharp} Universal settings
+    enable_testing()
+    add_subdirectory(test)
+endif(BUILD_TESTS)
 
 ${sharp}if(BUILD_TOOLS)
 ${sharp}    add_subdirectory(tools)

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/test/CMakeLists.txt.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/test/CMakeLists.txt.vsl
@@ -1,0 +1,3 @@
+add_subdirectory(include)
+MAP_ADD_STR(headers  "include/" comp_test_hdrs)
+add_subdirectory(src)

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/test/include/IncModuleCMakeLists.txt.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/test/include/IncModuleCMakeLists.txt.vsl
@@ -1,6 +1,6 @@
 set(hdrs ${rtcParam.name}Test.h
 #if( ${rtcParam.checkWithoutDefaultPathes()} == true )
-#foreach($consumerIdlFile in ${rtcParam.consumerIdlPathes})
+#foreach($consumerIdlFile in ${rtcParam.consumerIdlPathesAdded})
     ${tmpltHelper.getFilenameNoExt(${consumerIdlFile.idlFile})}${tmpltHelper.serviceImplSuffix}.h
 #end
 #end

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/test/include/IncModuleCMakeLists.txt.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/test/include/IncModuleCMakeLists.txt.vsl
@@ -1,0 +1,8 @@
+set(hdrs ${rtcParam.name}Test.h
+#if( ${rtcParam.checkWithoutDefaultPathes()} == true )
+#foreach($consumerIdlFile in ${rtcParam.consumerIdlPathes})
+    ${tmpltHelper.getFilenameNoExt(${consumerIdlFile.idlFile})}${tmpltHelper.serviceImplSuffix}.h
+#end
+#end
+    PARENT_SCOPE
+    )

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/test/include/IncludeCMakeLists.txt.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/test/include/IncludeCMakeLists.txt.vsl
@@ -1,0 +1,4 @@
+add_subdirectory(${rtcParam.name}Test)
+
+MAP_ADD_STR(hdrs "${dol}{PROJECT_NAME}Test/" headers)
+set(headers ${dol}{headers} PARENT_SCOPE)

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/test/src/SrcCMakeLists.txt.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/test/src/SrcCMakeLists.txt.vsl
@@ -1,4 +1,4 @@
-set(comp_srcs ${rtcParam.name}Test.cpp #if( ${rtcParam.checkWithoutDefaultPathes()} == true )#foreach($consumerIdlFile in ${rtcParam.consumerIdlPathes})${tmpltHelper.getFilenameNoExt(${consumerIdlFile.idlFile})}${tmpltHelper.serviceImplSuffix}.cpp #end#end#if( ${tmpltHelper.checkFSM(${rtcParam})})${rtcParam.name}FSM.cpp#end)
+set(comp_srcs ${rtcParam.name}Test.cpp #foreach($consumerIdlFile in ${rtcParam.consumerIdlPathesAdded})${tmpltHelper.getFilenameNoExt(${consumerIdlFile.idlFile})}${tmpltHelper.serviceImplSuffix}.cpp #end#if( ${tmpltHelper.checkFSM(${rtcParam})})${rtcParam.name}FSM.cpp#end)
 set(standalone_srcs ${rtcParam.name}TestComp.cpp)
 
 if(${dol}{OPENRTM_VERSION_MAJOR} LESS 2)

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/test/src/SrcCMakeLists.txt.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/test/src/SrcCMakeLists.txt.vsl
@@ -51,4 +51,4 @@ set_source_files_properties(${ALL_IDL_SRCS} PROPERTIES GENERATED 1)
 add_dependencies(${PROJECT_NAME}Test ${PROJECT_NAME})
 target_link_libraries(${PROJECT_NAME}Test ${OPENRTM_LIBRARIES} ${PROJECT_NAME})
 
-add_test(NAME ${PROJECT_NAME}_test COMMAND $<TARGET_FILE:${PROJECT_NAME}Test> -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:${PROJECT_NAME}0.in?port=${PROJECT_NAME}Test0.in,${PROJECT_NAME}0.out?port=${PROJECT_NAME}Test0.out,${PROJECT_NAME}0.MyServide?port=${PROJECT_NAME}Test0.MyServide" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0")
+add_test(NAME ${PROJECT_NAME}_test COMMAND $<TARGET_FILE:${PROJECT_NAME}Test> -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:${tmpltHelper.getConnectorString(${rtcParam})}" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0")

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/test/src/SrcCMakeLists.txt.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/test/src/SrcCMakeLists.txt.vsl
@@ -1,0 +1,54 @@
+set(comp_srcs ${rtcParam.name}Test.cpp #if( ${rtcParam.checkWithoutDefaultPathes()} == true )#foreach($consumerIdlFile in ${rtcParam.consumerIdlPathes})${tmpltHelper.getFilenameNoExt(${consumerIdlFile.idlFile})}${tmpltHelper.serviceImplSuffix}.cpp #end#end#if( ${tmpltHelper.checkFSM(${rtcParam})})${rtcParam.name}FSM.cpp#end)
+set(standalone_srcs ${rtcParam.name}TestComp.cpp)
+
+if(${dol}{OPENRTM_VERSION_MAJOR} LESS 2)
+  set(OPENRTM_CFLAGS ${dol}{OPENRTM_CFLAGS} ${dol}{OMNIORB_CFLAGS})
+  set(OPENRTM_INCLUDE_DIRS ${OPENRTM_INCLUDE_DIRS} ${dol}{OMNIORB_INCLUDE_DIRS})
+  set(OPENRTM_LIBRARY_DIRS ${OPENRTM_LIBRARY_DIRS} ${dol}{OMNIORB_LIBRARY_DIRS})
+endif()
+
+if (DEFINED OPENRTM_INCLUDE_DIRS)
+  string(REGEX REPLACE "-I" ";"
+    OPENRTM_INCLUDE_DIRS "${dol}{OPENRTM_INCLUDE_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_INCLUDE_DIRS "${dol}{OPENRTM_INCLUDE_DIRS}")
+endif (DEFINED OPENRTM_INCLUDE_DIRS)
+
+if (DEFINED OPENRTM_LIBRARY_DIRS)
+  string(REGEX REPLACE "-L" ";"
+    OPENRTM_LIBRARY_DIRS "${dol}{OPENRTM_LIBRARY_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARY_DIRS "${dol}{OPENRTM_LIBRARY_DIRS}")
+endif (DEFINED OPENRTM_LIBRARY_DIRS)
+
+if (DEFINED OPENRTM_LIBRARIES)
+  string(REGEX REPLACE "-l" ";"
+    OPENRTM_LIBRARIES "${dol}{OPENRTM_LIBRARIES}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARIES "${dol}{OPENRTM_LIBRARIES}")
+endif (DEFINED OPENRTM_LIBRARIES)
+
+include_directories(${dol}{PROJECT_SOURCE_DIR}/include)
+include_directories(${dol}{PROJECT_SOURCE_DIR}/include/${dol}{PROJECT_NAME})
+include_directories(${dol}{PROJECT_SOURCE_DIR}/test/include)
+include_directories(${dol}{PROJECT_SOURCE_DIR}/test/include/${dol}{PROJECT_NAME}Test)
+include_directories(${dol}{PROJECT_BINARY_DIR})
+include_directories(${dol}{PROJECT_BINARY_DIR}/idl)
+include_directories(${dol}{OPENRTM_INCLUDE_DIRS})
+add_definitions(${dol}{OPENRTM_CFLAGS})
+
+MAP_ADD_STR(comp_test_hdrs "../" comp_headers)
+
+link_directories(${dol}{OPENRTM_LIBRARY_DIRS})
+
+if(NOT TARGET ALL_IDL_TGT)
+ add_custom_target(ALL_IDL_TGT)
+endif(NOT TARGET ALL_IDL_TGT)
+
+add_executable(${dol}{PROJECT_NAME}Test ${dol}{standalone_srcs}
+  ${dol}{comp_srcs} ${dol}{comp_headers} ${dol}{ALL_IDL_SRCS})
+set_source_files_properties(${ALL_IDL_SRCS} PROPERTIES GENERATED 1)
+add_dependencies(${PROJECT_NAME}Test ${PROJECT_NAME})
+target_link_libraries(${PROJECT_NAME}Test ${OPENRTM_LIBRARIES} ${PROJECT_NAME})
+
+add_test(NAME ${PROJECT_NAME}_test COMMAND $<TARGET_FILE:${PROJECT_NAME}Test> -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:${PROJECT_NAME}0.in?port=${PROJECT_NAME}Test0.in,${PROJECT_NAME}0.out?port=${PROJECT_NAME}Test0.out,${PROJECT_NAME}0.MyServide?port=${PROJECT_NAME}Test0.MyServide" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0")

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/test/CXX_Test_Comp.cpp.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/test/CXX_Test_Comp.cpp.vsl
@@ -109,10 +109,10 @@ int main (int argc, char** argv)
 
   // run the manager in blocking mode
   // runManager(false) is the default.
-  manager->runManager();
+  // manager->runManager();
 
   // If you want to run the manager in non-blocking mode, do like this
-  // manager->runManager(true);
+  manager->runManager(true);
 
   bool ret = RunTest();
 

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/test/CXX_Test_Comp.cpp.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/test/CXX_Test_Comp.cpp.vsl
@@ -25,7 +25,7 @@ void MyModuleInit(RTC::Manager* manager)
   // Create a component
   comp = manager->createComponent("${rtcParam.name}Test");
 
-  if (comp==nullptr))
+  if (comp==nullptr)
   {
     std::cerr << "Component create failed." << std::endl;
     abort();

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/test/CXX_Test_Comp.cpp.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/test/CXX_Test_Comp.cpp.vsl
@@ -11,18 +11,21 @@ ${sharp}include <rtm/Manager.h>
 ${sharp}include <iostream>
 ${sharp}include <string>
 ${sharp}include <stdlib.h>
+${sharp}include <rtm/CORBA_RTCUtil.h>
 ${sharp}include "${rtcParam.name}Test.h"
+${sharp}include "${rtcParam.name}.h"
 
 
 void MyModuleInit(RTC::Manager* manager)
 {
   ${rtcParam.name}TestInit(manager);
+  ${rtcParam.name}Init(manager);
   RTC::RtcBase* comp;
 
   // Create a component
   comp = manager->createComponent("${rtcParam.name}Test");
 
-  if (comp==NULL)
+  if (comp==nullptr))
   {
     std::cerr << "Component create failed." << std::endl;
     abort();
@@ -71,6 +74,27 @@ void MyModuleInit(RTC::Manager* manager)
   return;
 }
 
+bool RunTest()
+{
+  RTC::RtcBase* comp;
+  RTC::Manager &mamager = RTC::Manager::instance();
+  comp = mamager.getComponent("${rtcParam.name}Test0");
+  if (comp == nullptr)
+  {
+    std::cerr << "Component get failed." << std::endl;
+    return false;
+  }
+
+  ${rtcParam.name}Test* testcomp = dynamic_cast<${rtcParam.name}Test*>(comp);
+  if (testcomp == nullptr)
+  {
+    std::cerr << "Component get failed." << std::endl;
+    return false;
+  }
+
+  return testcomp->runTest();
+}
+
 int main (int argc, char** argv)
 {
   RTC::Manager* manager;
@@ -90,5 +114,17 @@ int main (int argc, char** argv)
   // If you want to run the manager in non-blocking mode, do like this
   // manager->runManager(true);
 
-  return 0;
+  bool ret = RunTest();
+
+  manager->shutdown();
+
+  
+  if (ret)
+  {
+    return 0;
+  }
+  else
+  {
+    return 1;
+  }
 }

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/test/CXX_Test_RTC.cpp.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/test/CXX_Test_RTC.cpp.vsl
@@ -66,9 +66,9 @@ static const char* ${rtcParam.name.toLowerCase()}_spec[] =
  */
 ${rtcParam.name}Test::${rtcParam.name}Test(RTC::Manager* manager)
     // <rtc-template block="initializer">
-  : RTC::${rtcParam.componentKind}Base(manager)#foreach($port in ${rtcParam.inports})#if(${port.type}!=""),
-    ${rtcParam.commonPrefix}${rtcParam.dataPortPrefix}${port.tmplVarName}In${rtcParam.dataPortSuffix}${rtcParam.commonSuffix}("${port.name}", ${rtcParam.commonPrefix}${rtcParam.dataPortPrefix}${port.tmplVarName}${rtcParam.dataPortSuffix}${rtcParam.commonSuffix})#end#end#foreach($port in ${rtcParam.outports})#if(${port.type}!=""),
-    ${rtcParam.commonPrefix}${rtcParam.dataPortPrefix}${port.tmplVarName}Out${rtcParam.dataPortSuffix}${rtcParam.commonSuffix}("${port.name}", ${rtcParam.commonPrefix}${rtcParam.dataPortPrefix}${port.tmplVarName}${rtcParam.dataPortSuffix}${rtcParam.commonSuffix})#end#end
+  : RTC::${rtcParam.componentKind}Base(manager)#foreach($port in ${rtcParam.rawInports})#if(${port.type}!=""),
+    ${rtcParam.commonPrefix}${rtcParam.dataPortPrefix}${port.tmplVarName}Out${rtcParam.dataPortSuffix}${rtcParam.commonSuffix}("${port.name}", ${rtcParam.commonPrefix}${rtcParam.dataPortPrefix}${port.tmplVarName}${rtcParam.dataPortSuffix}${rtcParam.commonSuffix})#end#end#foreach($port in ${rtcParam.outports})#if(${port.type}!=""),
+    ${rtcParam.commonPrefix}${rtcParam.dataPortPrefix}${port.tmplVarName}In${rtcParam.dataPortSuffix}${rtcParam.commonSuffix}("${port.name}", ${rtcParam.commonPrefix}${rtcParam.dataPortPrefix}${port.tmplVarName}${rtcParam.dataPortSuffix}${rtcParam.commonSuffix})#end#end
 #if(${rtcParam.servicePorts.size()}>0)
 #foreach($servicePort in ${rtcParam.servicePorts})
 #if(${servicePort.servicePortInterfaces.size()}>0)
@@ -323,6 +323,11 @@ RTC::ReturnCode_t ${rtcParam.name}Test::onRateChanged(RTC::UniqueId ec_id)
 #end
 #if(${tmpltHelper.checkContents(${rtcParam.privateOpeSource})})${rtcParam.privateOpeSource}
 #end
+
+bool ${rtcParam.name}Test::runTest()
+{
+    return true;
+}
 
 
 extern "C"

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/test/CXX_Test_RTC.h.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/test/CXX_Test_RTC.h.vsl
@@ -16,8 +16,10 @@ ${sharp}include <rtm/idl/InterfaceDataTypesSkel.h>
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">
+#if( ${rtcParam.checkWithoutDefaultPathes()} == true )
 #foreach($consumerIdlFile in ${rtcParam.consumerIdlPathes})
 ${sharp}include "${tmpltHelper.getFilenameNoExt(${consumerIdlFile.idlFile})}${tmpltHelper.serviceImplSuffix}.h"
+#end
 #end
 
 // </rtc-template>
@@ -319,6 +321,7 @@ class ${rtcParam.name}Test
    */
   #if(${rtcParam.IsNotImplemented(11)})//#end virtual RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id);
 
+  bool runTest();
 
  protected:
   // <rtc-template block="protected_attribute">

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/test/CXX_Test_RTC.h.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/test/CXX_Test_RTC.h.vsl
@@ -16,10 +16,8 @@ ${sharp}include <rtm/idl/InterfaceDataTypesSkel.h>
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">
-#if( ${rtcParam.checkWithoutDefaultPathes()} == true )
-#foreach($consumerIdlFile in ${rtcParam.consumerIdlPathes})
+#foreach($consumerIdlFile in ${rtcParam.consumerIdlPathesAdded})
 ${sharp}include "${tmpltHelper.getFilenameNoExt(${consumerIdlFile.idlFile})}${tmpltHelper.serviceImplSuffix}.h"
-#end
 #end
 
 // </rtc-template>

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/test/CXX_Test_RTC.h.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/test/CXX_Test_RTC.h.vsl
@@ -447,7 +447,7 @@ class ${rtcParam.name}Test
 #if(${serviceInterface.docPostCondition.length()}>0)   * - PostCondition: ${tmpltHelper.convertInterfaceDetailDoc(${serviceInterface.docPostCondition})}
 #end
    */
-  ${serviceInterface.interfaceRawType}${tmpltHelper.serviceImplSuffix} ${rtcParam.commonPrefix}${rtcParam.serviceIFPrefix}${serviceInterface.tmplVarName}${rtcParam.serviceIFSuffix}${rtcParam.commonSuffix};
+  ${tmpltHelper.getBasename2(${serviceInterface.interfaceType})}${tmpltHelper.serviceImplSuffix} ${rtcParam.commonPrefix}${rtcParam.serviceIFPrefix}${serviceInterface.tmplVarName}${rtcParam.serviceIFSuffix}${rtcParam.commonSuffix};
 #end#end#end#end#end
   
   // </rtc-template>

--- a/jp.go.aist.rtm.rtcbuilder/test/jp/go/aist/rtm/rtcbuilder/_test/TestBase.java
+++ b/jp.go.aist.rtm.rtcbuilder/test/jp/go/aist/rtm/rtcbuilder/_test/TestBase.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import jp.go.aist.rtm.rtcbuilder.generator.GeneratedResult;
@@ -15,7 +16,7 @@ public class TestBase extends TestCase {
 	protected String expPath;
 	protected String expContent;
 	protected int index;
-	protected final int default_file_num = 30;
+	protected final int default_file_num = 34;
 
 	public TestBase () {
 		File fileCurrent = new File(".");
@@ -35,14 +36,22 @@ public class TestBase extends TestCase {
 		return stbRet.toString();
 	}
 	protected int getFileIndex(String targetName, List<GeneratedResult> targetList) {
-		int resultindex = -1;
-
+		List<Integer> indexList = new ArrayList<Integer>();
 		for( int intIdx=0; intIdx<targetList.size(); intIdx++ ) {
 			if( targetList.get(intIdx).getName().contains(targetName) ) {
-				return intIdx;
+				indexList.add(intIdx);
 			}
 		}
-		return resultindex;
+		if(indexList.size()==0) return -1;
+		else if(indexList.size()==1) return indexList.get(0);
+		else {
+			for(Integer index : indexList) {
+				if( targetList.get(index).getName().startsWith(targetName) ) {
+					return index;
+				}
+			}
+		}
+		return -1;
 	}
 
 	protected String replaceRootPath(String content) {


### PR DESCRIPTION
Identify the Bug
Link to #66

Description of the Change
お送り頂きましたサンプルを基に，テスト用コンポーネントをコンパイル・実行するためのCMakeListを出力するように修正してみました．

Verification
Did you succesed the build? Windows上でEclipse2019-03を使用
No warnings for the build? Windows上でEclipse2019-03を使用
Have you passed the unit tests? 既存のユニットテストを修正し，修正した内容でコードが生成されることを確認