### PR TITLE
Python版RTCのサービスポートのプロバイダのコードを修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/Doc/author/MyService_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/Doc/author/MyService_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file MyService_idl_examplefile.py
+ @file MyService_idl_example.py
  @brief Python example implementations generated from MyService.idl
  @date $Date$
  @author Noriaki Ando <n-ando@aist.go.jp>
@@ -47,7 +47,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/Doc/authorLong/MyService_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/Doc/authorLong/MyService_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file MyService_idl_examplefile.py
+ @file MyService_idl_example.py
  @brief Python example implementations generated from MyService.idl
  @date $Date$
  @author Noriaki Ando
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/Doc/full/MyService_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/Doc/full/MyService_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file MyService_idl_examplefile.py
+ @file MyService_idl_example.py
  @brief Python example implementations generated from MyService.idl
  @date $Date$
  @author Noriaki Ando <n-ando@aist.go.jp>
@@ -48,7 +48,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/Doc/refer/MyService_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/Doc/refer/MyService_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file MyService_idl_examplefile.py
+ @file MyService_idl_example.py
  @brief Python example implementations generated from MyService.idl
  @date $Date$
  @author Noriaki Ando <n-ando@aist.go.jp>
@@ -48,7 +48,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST1/MyService_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST1/MyService_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file MyService_idl_examplefile.py
+ @file MyService_idl_example.py
  @brief Python example implementations generated from MyService.idl
  @date $Date$
 """
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST3/MyService_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST3/MyService_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file MyService_idl_examplefile.py
+ @file MyService_idl_example.py
  @brief Python example implementations generated from MyService.idl
  @date $Date$
 """
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST4/MyService_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST4/MyService_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file MyService_idl_examplefile.py
+ @file MyService_idl_example.py
  @brief Python example implementations generated from MyService.idl
  @date $Date$
 """
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/base/service1/MyService_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/base/service1/MyService_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file MyService_idl_examplefile.py
+ @file MyService_idl_example.py
  @brief Python example implementations generated from MyService.idl
  @date $Date$
 """
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/base/service2/MyService_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/base/service2/MyService_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file MyService_idl_examplefile.py
+ @file MyService_idl_example.py
  @brief Python example implementations generated from MyService.idl
  @date $Date$
 """
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/build/cmake1/MyService_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/build/cmake1/MyService_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file MyService_idl_examplefile.py
+ @file MyService_idl_example.py
  @brief Python example implementations generated from MyService.idl
  @date $Date$
 """
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/build/cmake2/MyServiceChildMulti_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/build/cmake2/MyServiceChildMulti_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file MyServiceChildMulti_idl_examplefile.py
+ @file MyServiceChildMulti_idl_example.py
  @brief Python example implementations generated from MyServiceChildMulti.idl
  @date $Date$
 """
@@ -108,7 +108,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/build/cmake2/MyServiceChildWithType_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/build/cmake2/MyServiceChildWithType_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file MyServiceChildWithType_idl_examplefile.py
+ @file MyServiceChildWithType_idl_example.py
  @brief Python example implementations generated from MyServiceChildWithType.idl
  @date $Date$
 """
@@ -77,7 +77,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/idlinherit/inherit1/MyServiceChildMulti_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/idlinherit/inherit1/MyServiceChildMulti_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file MyServiceChildMulti_idl_examplefile.py
+ @file MyServiceChildMulti_idl_example.py
  @brief Python example implementations generated from MyServiceChildMulti.idl
  @date $Date$
 """
@@ -108,7 +108,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/idlinherit/inherit2/MyServiceChildMulti_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/idlinherit/inherit2/MyServiceChildMulti_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file MyServiceChildMulti_idl_examplefile.py
+ @file MyServiceChildMulti_idl_example.py
  @brief Python example implementations generated from MyServiceChildMulti.idl
  @date $Date$
 """
@@ -108,7 +108,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/idlinherit/inherit2/MyServiceChildWithType_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/idlinherit/inherit2/MyServiceChildWithType_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file MyServiceChildWithType_idl_examplefile.py
+ @file MyServiceChildWithType_idl_example.py
  @brief Python example implementations generated from MyServiceChildWithType.idl
  @date $Date$
 """
@@ -77,7 +77,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/idltype/type1/TestIDL_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/idltype/type1/TestIDL_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file TestIDL_idl_examplefile.py
+ @file TestIDL_idl_example.py
  @brief Python example implementations generated from TestIDL.idl
  @date $Date$
 """
@@ -111,7 +111,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/idltype/type2/MyService_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/idltype/type2/MyService_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file MyService_idl_examplefile.py
+ @file MyService_idl_example.py
  @brief Python example implementations generated from MyService.idl
  @date $Date$
 """
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/idltype/type3/MyService_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/idltype/type3/MyService_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file MyService_idl_examplefile.py
+ @file MyService_idl_example.py
  @brief Python example implementations generated from MyService.idl
  @date $Date$
 """
@@ -111,7 +111,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/module/serviceM/MyService_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/module/serviceM/MyService_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file MyService_idl_examplefile.py
+ @file MyService_idl_example.py
  @brief Python example implementations generated from MyService.idl
  @date $Date$
 """
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/module/serviceM2/DAQService_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/module/serviceM2/DAQService_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file DAQService_idl_examplefile.py
+ @file DAQService_idl_example.py
  @brief Python example implementations generated from DAQService.idl
  @date $Date$
 """
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/module/serviceM2/MyService_idl_example.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/module/serviceM2/MyService_idl_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 """
- @file MyService_idl_examplefile.py
+ @file MyService_idl_example.py
  @brief Python example implementations generated from MyService.idl
  @date $Date$
 """
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()
     # Run the ORB, blocking this thread

--- a/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/Py_SVC_idl_example.py.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/Py_SVC_idl_example.py.vsl
@@ -3,7 +3,7 @@
 # -*- Python -*-
 
 """
- @file ${idlFileParam.idlFileNoExt}_idl_examplefile.py
+ @file ${idlFileParam.idlFileNoExt}_idl_example.py
  @brief Python example implementations generated from ${idlFileParam.idlFile}
 #set( $Date$ = "dummy" )
  @date \$Date$
@@ -66,7 +66,7 @@ if __name__ == "__main__":
     objref = servant._this()
     
     # Print a stringified IOR for it
-    print orb.object_to_string(objref)
+    print(orb.object_to_string(objref))
 
     # Activate the Root POA's manager
     poa._get_the_POAManager().activate()

--- a/jp.go.aist.rtm.rtcbuilder.python/test/jp/go/aist/rtm/rtcbuilder/python/_test/TestBase.java
+++ b/jp.go.aist.rtm.rtcbuilder.python/test/jp/go/aist/rtm/rtcbuilder/python/_test/TestBase.java
@@ -16,7 +16,7 @@ public class TestBase extends TestCase {
 	protected String expContent;
 	protected int index;
 	protected String[] ignore_row_phrases = {"--service-idl=", "--consumer-idl"};
-	protected final int default_file_num = 25;
+	protected final int default_file_num = 29;
 	protected final int service_file_num = 7;
 
 	public TestBase () {


### PR DESCRIPTION
Identify the Bug
Link to #84

Description of the Change
ご連絡を頂きました内容を基にPython版RTCのサービスプロバイダのコードを修正しました．
 - ファイル内に記載しているファイル名を修正
 - Python3でもエラーにならないように括弧を追加

Verification
Did you succesed the build? Windows上でEclipse2019-03を使用
No warnings for the build? Windows上でEclipse2019-03を使用
Have you passed the unit tests? 既存のユニットテストを修正し，修正した内容でコードが生成されることを確認