### PR TITLE
FSMEditorのノードのフォントサイズを拡大

### DIFF
--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/fsm/editor/resources/basic-style.xml
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/fsm/editor/resources/basic-style.xml
@@ -2,7 +2,7 @@
 	<add as="defaultVertex">
 		<add as="shape" value="label"/>
 		<add as="perimeter" value="rectanglePerimeter"/>
-		<add as="fontSize" value="11"/>
+		<add as="fontSize" value="14"/>
 		<add as="align" value="center"/>
 		<add as="verticalAlign" value="middle"/>
 		<add as="strokeColor" value="black"/>


### PR DESCRIPTION
## Identify the Bug

Link to #48

## Description of the Change

FSM向け状態遷移エディタの各ノードのフォントサイズを11から14に変更

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests?  ユニットテスト無し