### PR TITLE
"using namespace RTC"を削除

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/AIST2/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/AIST2/ModuleName.h
@@ -36,8 +36,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class ModuleName
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/CheckIDL/Sample.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/CheckIDL/Sample.h
@@ -36,8 +36,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class Sample
  * @brief Sample Comp

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/ConfigType/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/ConfigType/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset1/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset2/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset3/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset3/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset4/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset4/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Content/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Content/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/DataPortIDL/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/DataPortIDL/foo.h
@@ -37,8 +37,6 @@ using namespace MyType;
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -239,11 +237,11 @@ class foo
   MyType::Frame1 m_InP1;
   /*!
    */
-  InPort<MyType::Frame1> m_InP1In;
+  RTC::InPort<MyType::Frame1> m_InP1In;
   RTC::TimedLong m_InP2;
   /*!
    */
-  InPort<RTC::TimedLong> m_InP2In;
+  RTC::InPort<RTC::TimedLong> m_InP2In;
   
   // </rtc-template>
 
@@ -253,7 +251,7 @@ class foo
   RTC::TimedInt m_OutP1;
   /*!
    */
-  OutPort<RTC::TimedInt> m_OutP1Out;
+  RTC::OutPort<RTC::TimedInt> m_OutP1Out;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Doc/fullLong/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Doc/fullLong/foo.h
@@ -43,8 +43,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -410,7 +408,7 @@ class foo
    *                    890123456789012345678901234567890123456789
    *                    01234567890
    */
-  InPort<RTC::TimedShort> m_InName1In;
+  RTC::InPort<RTC::TimedShort> m_InName1In;
   RTC::TimedLong m_InNm2;
   /*!
    * InPort2の概要123456789012345678901234567890123456789012345678
@@ -429,7 +427,7 @@ class foo
    *                    890123456789012345678901234567890123456789
    *                    01234567890
    */
-  InPort<RTC::TimedLong> m_InNm2In;
+  RTC::InPort<RTC::TimedLong> m_InNm2In;
   
   // </rtc-template>
 
@@ -454,7 +452,7 @@ class foo
    *                    789012345678901234567890123456789012345678
    *                    901234567890
    */
-  OutPort<RTC::TimedLong> m_OutName1Out;
+  RTC::OutPort<RTC::TimedLong> m_OutName1Out;
   RTC::TimedFloat m_OutNme2;
   /*!
    * OutPort2の概要12345678901234567890123456789012345678901234567
@@ -473,7 +471,7 @@ class foo
    *                    789012345678901234567890123456789012345678
    *                    901234567890
    */
-  OutPort<RTC::TimedFloat> m_OutNme2Out;
+  RTC::OutPort<RTC::TimedFloat> m_OutNme2Out;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ExecutionCxt/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ExecutionCxt/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Manip/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Manip/ModuleName.h
@@ -36,8 +36,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class ModuleName
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ConMulti/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ConMulti/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief test module
@@ -239,7 +237,7 @@ class foo
   TimedShort m_in1;
   /*!
    */
-  InPort<TimedShort> m_in1In;
+  RTC::InPort<TimedShort> m_in1In;
   
   // </rtc-template>
 
@@ -249,7 +247,7 @@ class foo
   TimedLong m_out1;
   /*!
    */
-  OutPort<TimedLong> m_out1Out;
+  RTC::OutPort<TimedLong> m_out1Out;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ProConMulti/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ProConMulti/foo.h
@@ -38,8 +38,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief test module
@@ -240,7 +238,7 @@ class foo
   TimedShort m_in1;
   /*!
    */
-  InPort<TimedShort> m_in1In;
+  RTC::InPort<TimedShort> m_in1In;
   
   // </rtc-template>
 
@@ -250,7 +248,7 @@ class foo
   TimedLong m_out1;
   /*!
    */
-  OutPort<TimedLong> m_out1Out;
+  RTC::OutPort<TimedLong> m_out1Out;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ProMulti/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ProMulti/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief test module
@@ -239,7 +237,7 @@ class foo
   TimedShort m_in1;
   /*!
    */
-  InPort<TimedShort> m_in1In;
+  RTC::InPort<TimedShort> m_in1In;
   
   // </rtc-template>
 
@@ -249,7 +247,7 @@ class foo
   TimedLong m_out1;
   /*!
    */
-  OutPort<TimedLong> m_out1Out;
+  RTC::OutPort<TimedLong> m_out1Out;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/confprefix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/confprefix/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -245,11 +243,11 @@ class foo
   RTC::TimedShort p_dtInP1ds_s;
   /*!
    */
-  InPort<RTC::TimedShort> p_dtInP1Inds_s;
+  RTC::InPort<RTC::TimedShort> p_dtInP1Inds_s;
   RTC::TimedLong p_dtInP2ds_s;
   /*!
    */
-  InPort<RTC::TimedLong> p_dtInP2Inds_s;
+  RTC::InPort<RTC::TimedLong> p_dtInP2Inds_s;
   
   // </rtc-template>
 
@@ -259,11 +257,11 @@ class foo
   RTC::TimedOctet p_dtOutP1ds_s;
   /*!
    */
-  OutPort<RTC::TimedOctet> p_dtOutP1Outds_s;
+  RTC::OutPort<RTC::TimedOctet> p_dtOutP1Outds_s;
   RTC::TimedFloat p_dtOutP2ds_s;
   /*!
    */
-  OutPort<RTC::TimedFloat> p_dtOutP2Outds_s;
+  RTC::OutPort<RTC::TimedFloat> p_dtOutP2Outds_s;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/confsuffix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/confsuffix/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -245,11 +243,11 @@ class foo
   RTC::TimedShort p_dtInP1ds_s;
   /*!
    */
-  InPort<RTC::TimedShort> p_dtInP1Inds_s;
+  RTC::InPort<RTC::TimedShort> p_dtInP1Inds_s;
   RTC::TimedLong p_dtInP2ds_s;
   /*!
    */
-  InPort<RTC::TimedLong> p_dtInP2Inds_s;
+  RTC::InPort<RTC::TimedLong> p_dtInP2Inds_s;
   
   // </rtc-template>
 
@@ -259,11 +257,11 @@ class foo
   RTC::TimedOctet p_dtOutP1ds_s;
   /*!
    */
-  OutPort<RTC::TimedOctet> p_dtOutP1Outds_s;
+  RTC::OutPort<RTC::TimedOctet> p_dtOutP1Outds_s;
   RTC::TimedFloat p_dtOutP2ds_s;
   /*!
    */
-  OutPort<RTC::TimedFloat> p_dtOutP2Outds_s;
+  RTC::OutPort<RTC::TimedFloat> p_dtOutP2Outds_s;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/dtprefix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/dtprefix/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -245,11 +243,11 @@ class foo
   RTC::TimedShort p_dtInP1_s;
   /*!
    */
-  InPort<RTC::TimedShort> p_dtInP1In_s;
+  RTC::InPort<RTC::TimedShort> p_dtInP1In_s;
   RTC::TimedLong p_dtInP2_s;
   /*!
    */
-  InPort<RTC::TimedLong> p_dtInP2In_s;
+  RTC::InPort<RTC::TimedLong> p_dtInP2In_s;
   
   // </rtc-template>
 
@@ -259,11 +257,11 @@ class foo
   RTC::TimedOctet p_dtOutP1_s;
   /*!
    */
-  OutPort<RTC::TimedOctet> p_dtOutP1Out_s;
+  RTC::OutPort<RTC::TimedOctet> p_dtOutP1Out_s;
   RTC::TimedFloat p_dtOutP2_s;
   /*!
    */
-  OutPort<RTC::TimedFloat> p_dtOutP2Out_s;
+  RTC::OutPort<RTC::TimedFloat> p_dtOutP2Out_s;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/dtsuffix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/dtsuffix/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -245,11 +243,11 @@ class foo
   RTC::TimedShort p_dtInP1ds_s;
   /*!
    */
-  InPort<RTC::TimedShort> p_dtInP1Inds_s;
+  RTC::InPort<RTC::TimedShort> p_dtInP1Inds_s;
   RTC::TimedLong p_dtInP2ds_s;
   /*!
    */
-  InPort<RTC::TimedLong> p_dtInP2Inds_s;
+  RTC::InPort<RTC::TimedLong> p_dtInP2Inds_s;
   
   // </rtc-template>
 
@@ -259,11 +257,11 @@ class foo
   RTC::TimedOctet p_dtOutP1ds_s;
   /*!
    */
-  OutPort<RTC::TimedOctet> p_dtOutP1Outds_s;
+  RTC::OutPort<RTC::TimedOctet> p_dtOutP1Outds_s;
   RTC::TimedFloat p_dtOutP2ds_s;
   /*!
    */
-  OutPort<RTC::TimedFloat> p_dtOutP2Outds_s;
+  RTC::OutPort<RTC::TimedFloat> p_dtOutP2Outds_s;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/prefix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/prefix/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -245,11 +243,11 @@ class foo
   RTC::TimedShort p_InP1;
   /*!
    */
-  InPort<RTC::TimedShort> p_InP1In;
+  RTC::InPort<RTC::TimedShort> p_InP1In;
   RTC::TimedLong p_InP2;
   /*!
    */
-  InPort<RTC::TimedLong> p_InP2In;
+  RTC::InPort<RTC::TimedLong> p_InP2In;
   
   // </rtc-template>
 
@@ -259,11 +257,11 @@ class foo
   RTC::TimedOctet p_OutP1;
   /*!
    */
-  OutPort<RTC::TimedOctet> p_OutP1Out;
+  RTC::OutPort<RTC::TimedOctet> p_OutP1Out;
   RTC::TimedFloat p_OutP2;
   /*!
    */
-  OutPort<RTC::TimedFloat> p_OutP2Out;
+  RTC::OutPort<RTC::TimedFloat> p_OutP2Out;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/siprefix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/siprefix/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -245,11 +243,11 @@ class foo
   RTC::TimedShort p_dtInP1ds_s;
   /*!
    */
-  InPort<RTC::TimedShort> p_dtInP1Inds_s;
+  RTC::InPort<RTC::TimedShort> p_dtInP1Inds_s;
   RTC::TimedLong p_dtInP2ds_s;
   /*!
    */
-  InPort<RTC::TimedLong> p_dtInP2Inds_s;
+  RTC::InPort<RTC::TimedLong> p_dtInP2Inds_s;
   
   // </rtc-template>
 
@@ -259,11 +257,11 @@ class foo
   RTC::TimedOctet p_dtOutP1ds_s;
   /*!
    */
-  OutPort<RTC::TimedOctet> p_dtOutP1Outds_s;
+  RTC::OutPort<RTC::TimedOctet> p_dtOutP1Outds_s;
   RTC::TimedFloat p_dtOutP2ds_s;
   /*!
    */
-  OutPort<RTC::TimedFloat> p_dtOutP2Outds_s;
+  RTC::OutPort<RTC::TimedFloat> p_dtOutP2Outds_s;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/sisuffix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/sisuffix/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -245,11 +243,11 @@ class foo
   RTC::TimedShort p_dtInP1ds_s;
   /*!
    */
-  InPort<RTC::TimedShort> p_dtInP1Inds_s;
+  RTC::InPort<RTC::TimedShort> p_dtInP1Inds_s;
   RTC::TimedLong p_dtInP2ds_s;
   /*!
    */
-  InPort<RTC::TimedLong> p_dtInP2Inds_s;
+  RTC::InPort<RTC::TimedLong> p_dtInP2Inds_s;
   
   // </rtc-template>
 
@@ -259,11 +257,11 @@ class foo
   RTC::TimedOctet p_dtOutP1ds_s;
   /*!
    */
-  OutPort<RTC::TimedOctet> p_dtOutP1Outds_s;
+  RTC::OutPort<RTC::TimedOctet> p_dtOutP1Outds_s;
   RTC::TimedFloat p_dtOutP2ds_s;
   /*!
    */
-  OutPort<RTC::TimedFloat> p_dtOutP2Outds_s;
+  RTC::OutPort<RTC::TimedFloat> p_dtOutP2Outds_s;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/suffix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/suffix/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -245,11 +243,11 @@ class foo
   RTC::TimedShort p_InP1_s;
   /*!
    */
-  InPort<RTC::TimedShort> p_InP1In_s;
+  RTC::InPort<RTC::TimedShort> p_InP1In_s;
   RTC::TimedLong p_InP2_s;
   /*!
    */
-  InPort<RTC::TimedLong> p_InP2In_s;
+  RTC::InPort<RTC::TimedLong> p_InP2In_s;
   
   // </rtc-template>
 
@@ -259,11 +257,11 @@ class foo
   RTC::TimedOctet p_OutP1_s;
   /*!
    */
-  OutPort<RTC::TimedOctet> p_OutP1Out_s;
+  RTC::OutPort<RTC::TimedOctet> p_OutP1Out_s;
   RTC::TimedFloat p_OutP2_s;
   /*!
    */
-  OutPort<RTC::TimedFloat> p_OutP2Out_s;
+  RTC::OutPort<RTC::TimedFloat> p_OutP2Out_s;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/svprefix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/svprefix/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -245,11 +243,11 @@ class foo
   RTC::TimedShort p_dtInP1ds_s;
   /*!
    */
-  InPort<RTC::TimedShort> p_dtInP1Inds_s;
+  RTC::InPort<RTC::TimedShort> p_dtInP1Inds_s;
   RTC::TimedLong p_dtInP2ds_s;
   /*!
    */
-  InPort<RTC::TimedLong> p_dtInP2Inds_s;
+  RTC::InPort<RTC::TimedLong> p_dtInP2Inds_s;
   
   // </rtc-template>
 
@@ -259,11 +257,11 @@ class foo
   RTC::TimedOctet p_dtOutP1ds_s;
   /*!
    */
-  OutPort<RTC::TimedOctet> p_dtOutP1Outds_s;
+  RTC::OutPort<RTC::TimedOctet> p_dtOutP1Outds_s;
   RTC::TimedFloat p_dtOutP2ds_s;
   /*!
    */
-  OutPort<RTC::TimedFloat> p_dtOutP2Outds_s;
+  RTC::OutPort<RTC::TimedFloat> p_dtOutP2Outds_s;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/svsuffix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/svsuffix/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -245,11 +243,11 @@ class foo
   RTC::TimedShort p_dtInP1ds_s;
   /*!
    */
-  InPort<RTC::TimedShort> p_dtInP1Inds_s;
+  RTC::InPort<RTC::TimedShort> p_dtInP1Inds_s;
   RTC::TimedLong p_dtInP2ds_s;
   /*!
    */
-  InPort<RTC::TimedLong> p_dtInP2Inds_s;
+  RTC::InPort<RTC::TimedLong> p_dtInP2Inds_s;
   
   // </rtc-template>
 
@@ -259,11 +257,11 @@ class foo
   RTC::TimedOctet p_dtOutP1ds_s;
   /*!
    */
-  OutPort<RTC::TimedOctet> p_dtOutP1Outds_s;
+  RTC::OutPort<RTC::TimedOctet> p_dtOutP1Outds_s;
   RTC::TimedFloat p_dtOutP2ds_s;
   /*!
    */
-  OutPort<RTC::TimedFloat> p_dtOutP2Outds_s;
+  RTC::OutPort<RTC::TimedFloat> p_dtOutP2Outds_s;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/SystemConfig/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/SystemConfig/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/DataPort/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/DataPort/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -237,11 +235,11 @@ class foo
   RTC::TimedShort m_VarInP1;
   /*!
    */
-  InPort<RTC::TimedShort> m_VarInP1In;
+  RTC::InPort<RTC::TimedShort> m_VarInP1In;
   RTC::TimedLong m_InP2;
   /*!
    */
-  InPort<RTC::TimedLong> m_InP2In;
+  RTC::InPort<RTC::TimedLong> m_InP2In;
   
   // </rtc-template>
 
@@ -251,11 +249,11 @@ class foo
   RTC::TimedLong m_OutP1;
   /*!
    */
-  OutPort<RTC::TimedLong> m_OutP1Out;
+  RTC::OutPort<RTC::TimedLong> m_OutP1Out;
   RTC::TimedFloat m_VarOutP2;
   /*!
    */
-  OutPort<RTC::TimedFloat> m_VarOutP2Out;
+  RTC::OutPort<RTC::TimedFloat> m_VarOutP2Out;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/ServicePort1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/ServicePort1/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -239,11 +237,11 @@ class foo
   RTC::TimedShort m_InP1;
   /*!
    */
-  InPort<RTC::TimedShort> m_InP1In;
+  RTC::InPort<RTC::TimedShort> m_InP1In;
   RTC::TimedLong m_InP2;
   /*!
    */
-  InPort<RTC::TimedLong> m_InP2In;
+  RTC::InPort<RTC::TimedLong> m_InP2In;
   
   // </rtc-template>
 
@@ -253,11 +251,11 @@ class foo
   RTC::TimedLong m_OutP1;
   /*!
    */
-  OutPort<RTC::TimedLong> m_OutP1Out;
+  RTC::OutPort<RTC::TimedLong> m_OutP1Out;
   RTC::TimedFloat m_OutP2;
   /*!
    */
-  OutPort<RTC::TimedFloat> m_OutP2Out;
+  RTC::OutPort<RTC::TimedFloat> m_OutP2Out;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/ServicePort2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/ServicePort2/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -239,11 +237,11 @@ class foo
   RTC::TimedShort m_InP1;
   /*!
    */
-  InPort<RTC::TimedShort> m_InP1In;
+  RTC::InPort<RTC::TimedShort> m_InP1In;
   RTC::TimedLong m_InP2;
   /*!
    */
-  InPort<RTC::TimedLong> m_InP2In;
+  RTC::InPort<RTC::TimedLong> m_InP2In;
   
   // </rtc-template>
 
@@ -253,11 +251,11 @@ class foo
   RTC::TimedLong m_OutP1;
   /*!
    */
-  OutPort<RTC::TimedLong> m_OutP1Out;
+  RTC::OutPort<RTC::TimedLong> m_OutP1Out;
   RTC::TimedFloat m_OutP2;
   /*!
    */
-  OutPort<RTC::TimedFloat> m_OutP2Out;
+  RTC::OutPort<RTC::TimedFloat> m_OutP2Out;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/attribute/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/attribute/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/inport1/test.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/inport1/test.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class test
  * @brief MDesc
@@ -237,7 +235,7 @@ class test
   RTC::TimedShort m_InP1;
   /*!
    */
-  InPort<RTC::TimedShort> m_InP1In;
+  RTC::InPort<RTC::TimedShort> m_InP1In;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/inport2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/inport2/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -237,11 +235,11 @@ class foo
   RTC::TimedShort m_InP1;
   /*!
    */
-  InPort<RTC::TimedShort> m_InP1In;
+  RTC::InPort<RTC::TimedShort> m_InP1In;
   RTC::TimedLong m_InP2;
   /*!
    */
-  InPort<RTC::TimedLong> m_InP2In;
+  RTC::InPort<RTC::TimedLong> m_InP2In;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/name/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/name/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/operation/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/operation/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/outport1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/outport1/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -237,11 +235,11 @@ class foo
   RTC::TimedShort m_InP1;
   /*!
    */
-  InPort<RTC::TimedShort> m_InP1In;
+  RTC::InPort<RTC::TimedShort> m_InP1In;
   RTC::TimedLong m_InP2;
   /*!
    */
-  InPort<RTC::TimedLong> m_InP2In;
+  RTC::InPort<RTC::TimedLong> m_InP2In;
   
   // </rtc-template>
 
@@ -251,7 +249,7 @@ class foo
   RTC::TimedInt m_OutP1;
   /*!
    */
-  OutPort<RTC::TimedInt> m_OutP1Out;
+  RTC::OutPort<RTC::TimedInt> m_OutP1Out;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/outport2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/outport2/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -237,11 +235,11 @@ class foo
   RTC::TimedShort m_InP1;
   /*!
    */
-  InPort<RTC::TimedShort> m_InP1In;
+  RTC::InPort<RTC::TimedShort> m_InP1In;
   RTC::TimedLong m_InP2;
   /*!
    */
-  InPort<RTC::TimedLong> m_InP2In;
+  RTC::InPort<RTC::TimedLong> m_InP2In;
   
   // </rtc-template>
 
@@ -251,11 +249,11 @@ class foo
   RTC::TimedInt m_OutP1;
   /*!
    */
-  OutPort<RTC::TimedInt> m_OutP1Out;
+  RTC::OutPort<RTC::TimedInt> m_OutP1Out;
   RTC::TimedFloat m_OutP2;
   /*!
    */
-  OutPort<RTC::TimedFloat> m_OutP2Out;
+  RTC::OutPort<RTC::TimedFloat> m_OutP2Out;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/service1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/service1/foo.h
@@ -36,8 +36,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -238,11 +236,11 @@ class foo
   RTC::TimedShort m_InP1;
   /*!
    */
-  InPort<RTC::TimedShort> m_InP1In;
+  RTC::InPort<RTC::TimedShort> m_InP1In;
   RTC::TimedLong m_InP2;
   /*!
    */
-  InPort<RTC::TimedLong> m_InP2In;
+  RTC::InPort<RTC::TimedLong> m_InP2In;
   
   // </rtc-template>
 
@@ -252,11 +250,11 @@ class foo
   RTC::TimedInt m_OutP1;
   /*!
    */
-  OutPort<RTC::TimedInt> m_OutP1Out;
+  RTC::OutPort<RTC::TimedInt> m_OutP1Out;
   RTC::TimedFloat m_OutP2;
   /*!
    */
-  OutPort<RTC::TimedFloat> m_OutP2Out;
+  RTC::OutPort<RTC::TimedFloat> m_OutP2Out;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/service2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/service2/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -239,11 +237,11 @@ class foo
   RTC::TimedShort m_InP1;
   /*!
    */
-  InPort<RTC::TimedShort> m_InP1In;
+  RTC::InPort<RTC::TimedShort> m_InP1In;
   RTC::TimedLong m_InP2;
   /*!
    */
-  InPort<RTC::TimedLong> m_InP2In;
+  RTC::InPort<RTC::TimedLong> m_InP2In;
   
   // </rtc-template>
 
@@ -253,11 +251,11 @@ class foo
   RTC::TimedInt m_OutP1;
   /*!
    */
-  OutPort<RTC::TimedInt> m_OutP1Out;
+  RTC::OutPort<RTC::TimedInt> m_OutP1Out;
   RTC::TimedFloat m_OutP2;
   /*!
    */
-  OutPort<RTC::TimedFloat> m_OutP2Out;
+  RTC::OutPort<RTC::TimedFloat> m_OutP2Out;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/DFFSMMM/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/DFFSMMM/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/DataFlow/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/DataFlow/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/FSM/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/FSM/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/cmake1/include/foo/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/cmake1/include/foo/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief test module
@@ -239,11 +237,11 @@ class foo
   RTC::TimedShort m_InP1;
   /*!
    */
-  InPort<RTC::TimedShort> m_InP1In;
+  RTC::InPort<RTC::TimedShort> m_InP1In;
   RTC::TimedLong m_InP2;
   /*!
    */
-  InPort<RTC::TimedLong> m_InP2In;
+  RTC::InPort<RTC::TimedLong> m_InP2In;
   
   // </rtc-template>
 
@@ -253,11 +251,11 @@ class foo
   RTC::TimedInt m_OutP1;
   /*!
    */
-  OutPort<RTC::TimedInt> m_OutP1Out;
+  RTC::OutPort<RTC::TimedInt> m_OutP1Out;
   RTC::TimedFloat m_OutP2;
   /*!
    */
-  OutPort<RTC::TimedFloat> m_OutP2Out;
+  RTC::OutPort<RTC::TimedFloat> m_OutP2Out;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/cmake2/include/foo/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/cmake2/include/foo/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief test module

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint1/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint2/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint3/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint3/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlinherit/inherit1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlinherit/inherit1/foo.h
@@ -36,8 +36,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief test module

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlinherit/inherit2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlinherit/inherit2/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief test module

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceArg/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceArg/foo.h
@@ -36,8 +36,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceArgStruct/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceArgStruct/foo.h
@@ -36,8 +36,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceCon/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceCon/foo.h
@@ -36,8 +36,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceM/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceM/foo.h
@@ -36,8 +36,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath1/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -239,11 +237,11 @@ class foo
   RTC::TimedShort m_InP1;
   /*!
    */
-  InPort<RTC::TimedShort> m_InP1In;
+  RTC::InPort<RTC::TimedShort> m_InP1In;
   RTC::TimedLong m_InP2;
   /*!
    */
-  InPort<RTC::TimedLong> m_InP2In;
+  RTC::InPort<RTC::TimedLong> m_InP2In;
   
   // </rtc-template>
 
@@ -253,11 +251,11 @@ class foo
   RTC::TimedLong m_OutP1;
   /*!
    */
-  OutPort<RTC::TimedLong> m_OutP1Out;
+  RTC::OutPort<RTC::TimedLong> m_OutP1Out;
   RTC::TimedFloat m_OutP2;
   /*!
    */
-  OutPort<RTC::TimedFloat> m_OutP2Out;
+  RTC::OutPort<RTC::TimedFloat> m_OutP2Out;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath2/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -239,11 +237,11 @@ class foo
   RTC::TimedShort m_InP1;
   /*!
    */
-  InPort<RTC::TimedShort> m_InP1In;
+  RTC::InPort<RTC::TimedShort> m_InP1In;
   RTC::TimedLong m_InP2;
   /*!
    */
-  InPort<RTC::TimedLong> m_InP2In;
+  RTC::InPort<RTC::TimedLong> m_InP2In;
   
   // </rtc-template>
 
@@ -253,11 +251,11 @@ class foo
   RTC::TimedLong m_OutP1;
   /*!
    */
-  OutPort<RTC::TimedLong> m_OutP1Out;
+  RTC::OutPort<RTC::TimedLong> m_OutP1Out;
   RTC::TimedFloat m_OutP2;
   /*!
    */
-  OutPort<RTC::TimedFloat> m_OutP2Out;
+  RTC::OutPort<RTC::TimedFloat> m_OutP2Out;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath3/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath3/foo.h
@@ -37,8 +37,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc
@@ -239,11 +237,11 @@ class foo
   RTC::TimedShort m_InP1;
   /*!
    */
-  InPort<RTC::TimedShort> m_InP1In;
+  RTC::InPort<RTC::TimedShort> m_InP1In;
   RTC::TimedLong m_InP2;
   /*!
    */
-  InPort<RTC::TimedLong> m_InP2In;
+  RTC::InPort<RTC::TimedLong> m_InP2In;
   
   // </rtc-template>
 
@@ -253,11 +251,11 @@ class foo
   RTC::TimedLong m_OutP1;
   /*!
    */
-  OutPort<RTC::TimedLong> m_OutP1Out;
+  RTC::OutPort<RTC::TimedLong> m_OutP1Out;
   RTC::TimedFloat m_OutP2;
   /*!
    */
-  OutPort<RTC::TimedFloat> m_OutP2Out;
+  RTC::OutPort<RTC::TimedFloat> m_OutP2Out;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlstruct/TestModule.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlstruct/TestModule.h
@@ -36,8 +36,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class TestModule
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/IDLType1/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/IDLType1/ModuleName.h
@@ -36,8 +36,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class ModuleName
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/SeqString/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/SeqString/foo.h
@@ -36,8 +36,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/Struct/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/Struct/ModuleName.h
@@ -36,8 +36,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class ModuleName
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/Struct2/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/Struct2/ModuleName.h
@@ -36,8 +36,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class ModuleName
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/type/test.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/type/test.h
@@ -36,8 +36,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class test
  * @brief test component

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/all/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/all/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/execute/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/execute/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/finalize/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/finalize/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/initialize/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/initialize/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/library/library1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/library/library1/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/library/library2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/library/library2/foo.h
@@ -35,8 +35,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/DataPortIDL/include/MarkerPosition/MarkerPosition.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/DataPortIDL/include/MarkerPosition/MarkerPosition.h
@@ -39,8 +39,6 @@ using namespace GameFramework;
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class MarkerPosition
  * @brief ModuleDescription
@@ -241,7 +239,7 @@ class MarkerPosition
   arUco::arUcoPoint2D m_arUcoPoint2D;
   /*!
    */
-  InPort<arUco::arUcoPoint2D> m_arUcoPoint2DIn;
+  RTC::InPort<arUco::arUcoPoint2D> m_arUcoPoint2DIn;
   
   // </rtc-template>
 
@@ -251,7 +249,7 @@ class MarkerPosition
   GameFramework::CenterPosition m_CenterPosition;
   /*!
    */
-  OutPort<GameFramework::CenterPosition> m_CenterPositionOut;
+  RTC::OutPort<GameFramework::CenterPosition> m_CenterPositionOut;
   
   // </rtc-template>
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePort/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePort/ModuleName.h
@@ -36,8 +36,6 @@
 #include <rtm/DataOutPort.h>
 
 
-using namespace RTC;
-
 /*!
  * @class ModuleName
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/CXX_RTC.h.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/CXX_RTC.h.vsl
@@ -54,8 +54,6 @@ ${sharp}include "${rtcParam.name}FSM.h"
 #end
 
 
-using namespace RTC;
-
 /*!
  * @class ${rtcParam.name}
  * @brief ${rtcParam.description}
@@ -387,7 +385,7 @@ class ${rtcParam.name}
 #if(${port.docOperation.length()}>0)   * - Operation Cycle: ${tmpltHelper.convertCycleDoc(${port.docOperation})}
 #end
    */
-  InPort<${port.type}> ${rtcParam.commonPrefix}${rtcParam.dataPortPrefix}${port.tmplVarName}In${rtcParam.dataPortSuffix}${rtcParam.commonSuffix};
+  RTC::InPort<${port.type}> ${rtcParam.commonPrefix}${rtcParam.dataPortPrefix}${port.tmplVarName}In${rtcParam.dataPortSuffix}${rtcParam.commonSuffix};
 #end
 #end
   
@@ -414,7 +412,7 @@ class ${rtcParam.name}
 #if(${port.docOperation.length()}>0)   * - Operation Cycle: ${tmpltHelper.convertCycleDoc(${port.docOperation})}
 #end
    */
-  OutPort<${port.type}> ${rtcParam.commonPrefix}${rtcParam.dataPortPrefix}${port.tmplVarName}Out${rtcParam.dataPortSuffix}${rtcParam.commonSuffix};
+  RTC::OutPort<${port.type}> ${rtcParam.commonPrefix}${rtcParam.dataPortPrefix}${port.tmplVarName}Out${rtcParam.dataPortSuffix}${rtcParam.commonSuffix};
 #end
 #end
   

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/test/CXX_Test_RTC.h.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/test/CXX_Test_RTC.h.vsl
@@ -43,8 +43,6 @@ ${sharp}include <rtm/CorbaPort.h>
 ${sharp}include <rtm/DataInPort.h>
 ${sharp}include <rtm/DataOutPort.h>
 
-using namespace RTC;
-
 /*!
  * @class ${rtcParam.name}Test
  * @brief ${rtcParam.description}
@@ -377,7 +375,7 @@ class ${rtcParam.name}Test
 #if(${port.docOperation.length()}>0)   * - Operation Cycle: ${tmpltHelper.convertCycleDoc(${port.docOperation})}
 #end
    */
-  InPort<${port.type}> ${rtcParam.commonPrefix}${rtcParam.dataPortPrefix}${port.tmplVarName}In${rtcParam.dataPortSuffix}${rtcParam.commonSuffix};
+  RTC::InPort<${port.type}> ${rtcParam.commonPrefix}${rtcParam.dataPortPrefix}${port.tmplVarName}In${rtcParam.dataPortSuffix}${rtcParam.commonSuffix};
 #end
 #end
   
@@ -404,7 +402,7 @@ class ${rtcParam.name}Test
 #if(${port.docOperation.length()}>0)   * - Operation Cycle: ${tmpltHelper.convertCycleDoc(${port.docOperation})}
 #end
    */
-  OutPort<${port.type}> ${rtcParam.commonPrefix}${rtcParam.dataPortPrefix}${port.tmplVarName}Out${rtcParam.dataPortSuffix}${rtcParam.commonSuffix};
+  RTC::OutPort<${port.type}> ${rtcParam.commonPrefix}${rtcParam.dataPortPrefix}${port.tmplVarName}Out${rtcParam.dataPortSuffix}${rtcParam.commonSuffix};
 #end
 #end
   


### PR DESCRIPTION
Identify the Bug
Link to #76

Description of the Change
C++版RTCの｢using namespace RTC｣を削除しました．
また，併せてInPort/OutPortの宣言部分に｢RTC::｣を追加させて頂きました．

Verification
Did you succesed the build? Windows上でEclipse2019-03を使用
No warnings for the build? Windows上でEclipse2019-03を使用
Have you passed the unit tests? 既存のユニットテストを修正し，修正した内容でコードが生成されることを確認