### PR TITLE
Windows用buildall.batスクリプトを整備

### DIFF
--- a/buildall.bat
+++ b/buildall.bat
@@ -1,7 +1,10 @@
 @echo off
 rem ---------------------------------------------------------------------------
 rem ---------------------------------------------------------------------------
-@set JARDIR=openrtp_1.1.0
+@set /p LINE= < version
+@set VERSION=%LINE:~8%
+@set PROJECT_VERSION=%VERSION%
+@set JARDIR=openrtp_%VERSION%
 @set LIBS=-lib ..\lib -lib ..\lib\a4e-2137 -lib ..\lib\a4e-2137\libs -lib %ECLIPSE_HOME%\plugins
 
 rem ---------------------------------------------------------------------------
@@ -34,7 +37,11 @@ for /D %%p in ( %TARGETS% ) do (
     @set target=%%p
     echo %%p
     cd %%p
-    call ant buildAll %LIBS%
+    if "%%p" == "jp.go.aist.rtm.toolscommon" (
+        call ant buildAll_win %LIBS%
+    ) else (
+        call ant buildAll %LIBS%
+    )
     if ERRORLEVEL 1 goto FAIL
     copy jar\*aist*.jar ..\%JARDIR%
     cd ..

--- a/jp.go.aist.rtm.toolscommon/build.xml
+++ b/jp.go.aist.rtm.toolscommon/build.xml
@@ -42,9 +42,19 @@
 	<target name="buildAll">
 		<antcall target="clean" />
 		<antcall target="idlCompile" />
+		<antcall target="Native2ascii" />
 		<antcall target="compile" />
 		<antcall target="jar" />
 	</target>
+  
+  	<target name="buildAll_win">
+		<antcall target="clean" />
+		<antcall target="idlCompile" />
+		<antcall target="Native2ascii_win" />
+		<antcall target="compile" />
+		<antcall target="jar" />
+	</target>
+
 
 	<target name="idlCompile" description="IDLファイルをコンパイルします">
 		<delete dir="${source.sdo}" />
@@ -64,7 +74,9 @@
 		<exec executable="${java.home}\..\bin\idlj">
 			<arg line="-fall -td ${source} -i ${idl.path} -emitAll ${idl.Logger}"/>
 		</exec>
+	</target>
 
+	<target name="Native2ascii" description="ネイティブコードからUnicodeへ変換(Linux)">
 		<exec executable="./n2a">
 			<arg line="${source}/_SDOPackage/*.java"/>
 		</exec>
@@ -76,6 +88,21 @@
 		</exec>
 		<exec executable="./n2a">
 			<arg line="${source}/RTM/*.java"/>
+		</exec>
+	</target>
+  
+  	<target name="Native2ascii_win" description="ネイティブコードからUnicodeへ変換(Windows)">
+		<exec executable="./n2a.bat">
+			<arg line="${source}\_SDOPackage\*.java"/>
+		</exec>
+		<exec executable="./n2a.bat">
+			<arg line="${source}\OpenRTM\*.java"/>
+		</exec>
+		<exec executable="./n2a.bat">
+			<arg line="${source}\RTC\*.java"/>
+		</exec>
+		<exec executable="./n2a.bat">
+			<arg line="${source}\RTM\*.java"/>
 		</exec>
 	</target>
 


### PR DESCRIPTION
close #61 

Link #61 

Windows環境で buildall.bat を実行して jar ファイルを生成できるように整備した

- Windows環境で「native2ascii」用スクリプトを実行可能とした
  - この処理は「jp.go.aist.rtm.toolscommon」でのみ実行され、LinuxとWindowsではスクリプト名が異なる。このため、「native2ascii」処理を新たな target として切り出し、Linux用は「Native2ascii」、Windows用は「Native2ascii_win」と定義した。
  - Windows用 buildall.bat は、「jp.go.aist.rtm.toolscommon」をビルドする際、「Native2ascii_win」を含む「buildAll_win」ターゲットを ant の引数に渡すようにした。

- Windows環境では、バージョン番号を更新しても jar ファイル名のバージョン番号が更新されなかったので修正した
  - 原因は、buildall.bat で version ファイルから PROJECT_VERSION を取得していなかったため
  - ビルド時、PROJECT_VERSION で MANIFEST.MF の Bundle-Version を書き換え、Jar ファイル名にはBundle-Version のバージョン番号が含まれる。
  - Linux環境では、version ファイルから「1.2.0.v20190626」形式の PROJECT_VERSION を取得できるが、Windows環境で同じ動作に対応しようとすると処理が長くなるので、とりあえず「1.2.0」形式のバージョン番号のみとした。

## Verification 

- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- Windows環境でのビルドは、eclipse-rcp-2019-03-R-win32-x86_64.zip を展開し、buildall.bat を実行して確認。今後masterブランチはバージョン番号2.0.0へ更新予定なので、この場合でもjarファイル名が正しいバージョン番号になることを確認。
- Linux環境での build_all 実行動作も問題ないことを確認

