### PR TITLE
RELENG_1_2ブランチのRCPプラグインのバージョン番号を1.2.1へ更新

### DIFF
--- a/jp.go.aist.rtm.systemeditor.RCP/META-INF/MANIFEST.MF
+++ b/jp.go.aist.rtm.systemeditor.RCP/META-INF/MANIFEST.MF
@@ -2,15 +2,15 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: jp.go.aist.rtm.systemeditor.RCP; singleton:=true
-Bundle-Version: 1.2.0
+Bundle-Version: 1.2.1
 Bundle-Activator: jp.go.aist.rtm.systemeditor.rcp.SystemEditorActivator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- jp.go.aist.rtm.nameserviceview;bundle-version="1.2.0",
- jp.go.aist.rtm.repositoryView;bundle-version="1.2.0",
- jp.go.aist.rtm.systemeditor;bundle-version="1.2.0",
- jp.go.aist.rtm.toolscommon;bundle-version="1.2.0",
- jp.go.aist.rtm.toolscommon.profiles;bundle-version="1.2.0"
+ jp.go.aist.rtm.nameserviceview;bundle-version="1.2.1",
+ jp.go.aist.rtm.repositoryView;bundle-version="1.2.1",
+ jp.go.aist.rtm.systemeditor;bundle-version="1.2.1",
+ jp.go.aist.rtm.toolscommon;bundle-version="1.2.1",
+ jp.go.aist.rtm.toolscommon.profiles;bundle-version="1.2.1"
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
 Export-Package: jp.go.aist.rtm.systemeditor.rcp


### PR DESCRIPTION
Link #106 

- RELENG_1_2ブランチの jp.go.aist.rtm.systemeditor.RCP 下の MANIFEST.MF に記載されているバージョン番号を1.2.1へ更新した
- この修正により、「jp.go.aist.rtm.systemeditor.RCP_1.2.1.jar」が生成されることを確認した
- このjarファイルは通常のソースビルドでは生成されず、RCP版RTSystemEditor作成時に生成される
- ビルド手順については、下記Wikiページを参照
https://openrtm.org/redmine/projects/rtsystemeditor/wiki/Eclipse473ベースのRCP版RTSystemEditorの作成手順

## Verification 

- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [x] Eclipse 4.7.3 でビルド確認
 