### PR TITLE
C++版RTCの生成コードを修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder.java/test/jp/go/aist/rtm/rtcbuilder/java/_test/TestBase.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/test/jp/go/aist/rtm/rtcbuilder/java/_test/TestBase.java
@@ -16,7 +16,7 @@ public class TestBase extends TestCase {
 	protected String expContent;
 	protected int index;
 	protected String[] ignore_row_phrases = {"--service-idl=", "--consumer-idl"};
-	protected final int default_file_num = 35;
+	protected final int default_file_num = 39;
 
 	public TestBase () {
 		File fileCurrent = new File(".");

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/AIST2/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/AIST2/ModuleName.h
@@ -25,10 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -67,7 +63,6 @@ class ModuleName
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -78,7 +73,6 @@ class ModuleName
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -89,7 +83,6 @@ class ModuleName
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -102,7 +95,6 @@ class ModuleName
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -115,7 +107,6 @@ class ModuleName
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -128,7 +119,6 @@ class ModuleName
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -141,7 +131,6 @@ class ModuleName
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -154,7 +143,6 @@ class ModuleName
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -167,7 +155,6 @@ class ModuleName
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -180,7 +167,6 @@ class ModuleName
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -193,7 +179,6 @@ class ModuleName
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -206,7 +191,6 @@ class ModuleName
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/CheckIDL/Sample.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/CheckIDL/Sample.h
@@ -25,10 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -67,7 +63,6 @@ class Sample
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -78,7 +73,6 @@ class Sample
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -89,7 +83,6 @@ class Sample
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -102,7 +95,6 @@ class Sample
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -115,7 +107,6 @@ class Sample
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -128,7 +119,6 @@ class Sample
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -141,7 +131,6 @@ class Sample
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -154,7 +143,6 @@ class Sample
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -167,7 +155,6 @@ class Sample
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -180,7 +167,6 @@ class Sample
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -193,7 +179,6 @@ class Sample
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -206,7 +191,6 @@ class Sample
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/ConfigType/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/ConfigType/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset1/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset2/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset3/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset3/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset4/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset4/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Content/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Content/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/DataPortIDL/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/DataPortIDL/foo.h
@@ -25,11 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-using namespace MyType;
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +63,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +73,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +83,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +95,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +107,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +119,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +131,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +143,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +155,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +167,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +179,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +191,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Doc/fullLong/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Doc/fullLong/foo.h
@@ -32,10 +32,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -88,7 +84,6 @@ class foo
    * 123456789012345678901234567890
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -105,7 +100,6 @@ class foo
    * 3456789012345678901234567890
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -122,7 +116,6 @@ class foo
    * 456789012345678901234567890
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -141,7 +134,6 @@ class foo
    * 3456789012345678901234567890
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -160,7 +152,6 @@ class foo
    * 23456789012345678901234567890
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +170,6 @@ class foo
    * 0123456789012345678901234567890
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -198,7 +188,6 @@ class foo
    * 456789012345678901234567890
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -217,7 +206,6 @@ class foo
    * 3456789012345678901234567890
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -236,7 +224,6 @@ class foo
    * 6789012345678901234567890
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -255,7 +242,6 @@ class foo
    * 6789012345678901234567890
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -274,7 +260,6 @@ class foo
    * 90123456789012345678901234567890
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -293,7 +278,6 @@ class foo
    * 90123456789012345678901234567890
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ExecutionCxt/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ExecutionCxt/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ExecutionCxt/rtc.conf
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ExecutionCxt/rtc.conf
@@ -317,13 +317,8 @@ manip2.foo.config_file: foo.conf
 ## The delimiter between names is "/".
 ## The delimiter between name and kind is ".".
 ##
-## example: (OpenRTM-aist-0.2.0 style)
-##       %h.host_cxt/%M.mgr_cxt/%c.cat_cxt/%m.mod_cxt/%n.rtc
-## This is formatted according to the following replacement rules.
-##
 ## %n: The instance name of the component.
 ## %t: The type name of the component.
-## %m: The module name of the component.
 ## %v: The version of the component.
 ## %V: The component vendor.
 ## %c: The category of the component.

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Manip/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Manip/ModuleName.h
@@ -25,10 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -67,7 +63,6 @@ class ModuleName
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -78,7 +73,6 @@ class ModuleName
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -89,7 +83,6 @@ class ModuleName
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -102,7 +95,6 @@ class ModuleName
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -115,7 +107,6 @@ class ModuleName
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -128,7 +119,6 @@ class ModuleName
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -141,7 +131,6 @@ class ModuleName
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -154,7 +143,6 @@ class ModuleName
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -167,7 +155,6 @@ class ModuleName
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -180,7 +167,6 @@ class ModuleName
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -193,7 +179,6 @@ class ModuleName
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -206,7 +191,6 @@ class ModuleName
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ConMulti/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ConMulti/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ProConMulti/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ProConMulti/foo.h
@@ -27,10 +27,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -69,7 +65,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -80,7 +75,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -91,7 +85,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -104,7 +97,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -117,7 +109,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -130,7 +121,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -143,7 +133,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -156,7 +145,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -169,7 +157,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -182,7 +169,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -195,7 +181,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -208,7 +193,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ProMulti/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ProMulti/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/confprefix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/confprefix/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/confsuffix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/confsuffix/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/dtprefix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/dtprefix/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/dtsuffix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/dtsuffix/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/prefix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/prefix/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/siprefix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/siprefix/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/sisuffix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/sisuffix/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/suffix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/suffix/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/svprefix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/svprefix/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/svsuffix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/svsuffix/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/SystemConfig/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/SystemConfig/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/SystemConfig/rtc.conf
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/SystemConfig/rtc.conf
@@ -317,13 +317,8 @@ manip2.foo.config_file: foo.conf
 ## The delimiter between names is "/".
 ## The delimiter between name and kind is ".".
 ##
-## example: (OpenRTM-aist-0.2.0 style)
-##       %h.host_cxt/%M.mgr_cxt/%c.cat_cxt/%m.mod_cxt/%n.rtc
-## This is formatted according to the following replacement rules.
-##
 ## %n: The instance name of the component.
 ## %t: The type name of the component.
-## %m: The module name of the component.
 ## %v: The version of the component.
 ## %V: The component vendor.
 ## %c: The category of the component.

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/DataPort/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/DataPort/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/ServicePort1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/ServicePort1/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/ServicePort2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/ServicePort2/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/attribute/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/attribute/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/inport1/test.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/inport1/test.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class test
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class test
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class test
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class test
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class test
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class test
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class test
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class test
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class test
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class test
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class test
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class test
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/inport2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/inport2/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/name/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/name/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/operation/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/operation/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -70,7 +66,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -81,7 +76,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -92,7 +86,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -105,7 +98,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -118,7 +110,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -131,7 +122,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -144,7 +134,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -157,7 +146,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -170,7 +158,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -183,7 +170,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -196,7 +182,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -209,7 +194,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/outport1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/outport1/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/outport2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/outport2/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/service1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/service1/foo.h
@@ -25,10 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -67,7 +63,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -78,7 +73,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -89,7 +83,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -102,7 +95,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -115,7 +107,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -128,7 +119,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -141,7 +131,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -154,7 +143,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -167,7 +155,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -180,7 +167,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -193,7 +179,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -206,7 +191,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/service2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/service2/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/DFFSMMM/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/DFFSMMM/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowFiniteStateMachineMultiModeComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/DataFlow/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/DataFlow/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/FSM/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/FSM/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/FiniteStateMachineComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/cmake1/include/foo/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/cmake1/include/foo/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/cmake2/include/foo/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/cmake2/include/foo/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint1/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint1/rtc.conf
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint1/rtc.conf
@@ -317,13 +317,8 @@ manip2.foo.config_file: foo.conf
 ## The delimiter between names is "/".
 ## The delimiter between name and kind is ".".
 ##
-## example: (OpenRTM-aist-0.2.0 style)
-##       %h.host_cxt/%M.mgr_cxt/%c.cat_cxt/%m.mod_cxt/%n.rtc
-## This is formatted according to the following replacement rules.
-##
 ## %n: The instance name of the component.
 ## %t: The type name of the component.
-## %m: The module name of the component.
 ## %v: The version of the component.
 ## %V: The component vendor.
 ## %c: The category of the component.

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint2/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint2/rtc.conf
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint2/rtc.conf
@@ -317,13 +317,8 @@ manip2.foo.config_file: foo.conf
 ## The delimiter between names is "/".
 ## The delimiter between name and kind is ".".
 ##
-## example: (OpenRTM-aist-0.2.0 style)
-##       %h.host_cxt/%M.mgr_cxt/%c.cat_cxt/%m.mod_cxt/%n.rtc
-## This is formatted according to the following replacement rules.
-##
 ## %n: The instance name of the component.
 ## %t: The type name of the component.
-## %m: The module name of the component.
 ## %v: The version of the component.
 ## %V: The component vendor.
 ## %c: The category of the component.

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint3/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint3/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint3/rtc.conf
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint3/rtc.conf
@@ -317,13 +317,8 @@ manip2.foo.config_file: foo.conf
 ## The delimiter between names is "/".
 ## The delimiter between name and kind is ".".
 ##
-## example: (OpenRTM-aist-0.2.0 style)
-##       %h.host_cxt/%M.mgr_cxt/%c.cat_cxt/%m.mod_cxt/%n.rtc
-## This is formatted according to the following replacement rules.
-##
 ## %n: The instance name of the component.
 ## %t: The type name of the component.
-## %m: The module name of the component.
 ## %v: The version of the component.
 ## %V: The component vendor.
 ## %c: The category of the component.

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlinherit/inherit1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlinherit/inherit1/foo.h
@@ -25,10 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -67,7 +63,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -78,7 +73,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -89,7 +83,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -102,7 +95,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -115,7 +107,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -128,7 +119,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -141,7 +131,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -154,7 +143,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -167,7 +155,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -180,7 +167,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -193,7 +179,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -206,7 +191,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlinherit/inherit2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlinherit/inherit2/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceArg/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceArg/foo.h
@@ -25,10 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -67,7 +63,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -78,7 +73,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -89,7 +83,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -102,7 +95,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -115,7 +107,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -128,7 +119,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -141,7 +131,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -154,7 +143,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -167,7 +155,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -180,7 +167,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -193,7 +179,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -206,7 +191,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceArgStruct/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceArgStruct/foo.h
@@ -25,10 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -67,7 +63,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -78,7 +73,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -89,7 +83,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -102,7 +95,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -115,7 +107,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -128,7 +119,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -141,7 +131,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -154,7 +143,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -167,7 +155,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -180,7 +167,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -193,7 +179,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -206,7 +191,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceCon/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceCon/foo.h
@@ -25,10 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -67,7 +63,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -78,7 +73,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -89,7 +83,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -102,7 +95,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -115,7 +107,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -128,7 +119,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -141,7 +131,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -154,7 +143,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -167,7 +155,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -180,7 +167,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -193,7 +179,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -206,7 +191,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceM/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceM/foo.h
@@ -25,10 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -67,7 +63,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -78,7 +73,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -89,7 +83,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -102,7 +95,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -115,7 +107,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -128,7 +119,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -141,7 +131,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -154,7 +143,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -167,7 +155,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -180,7 +167,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -193,7 +179,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -206,7 +191,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath1/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath2/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath3/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath3/foo.h
@@ -26,10 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -68,7 +64,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -79,7 +74,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -90,7 +84,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -103,7 +96,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -116,7 +108,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -129,7 +120,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -142,7 +132,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -155,7 +144,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -168,7 +156,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +168,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -194,7 +180,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -207,7 +192,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlstruct/TestModule.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlstruct/TestModule.h
@@ -25,10 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -67,7 +63,6 @@ class TestModule
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -78,7 +73,6 @@ class TestModule
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -89,7 +83,6 @@ class TestModule
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -102,7 +95,6 @@ class TestModule
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -115,7 +107,6 @@ class TestModule
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -128,7 +119,6 @@ class TestModule
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -141,7 +131,6 @@ class TestModule
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -154,7 +143,6 @@ class TestModule
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -167,7 +155,6 @@ class TestModule
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -180,7 +167,6 @@ class TestModule
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -193,7 +179,6 @@ class TestModule
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -206,7 +191,6 @@ class TestModule
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/IDLType1/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/IDLType1/ModuleName.h
@@ -25,10 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -67,7 +63,6 @@ class ModuleName
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -78,7 +73,6 @@ class ModuleName
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -89,7 +83,6 @@ class ModuleName
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -102,7 +95,6 @@ class ModuleName
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -115,7 +107,6 @@ class ModuleName
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -128,7 +119,6 @@ class ModuleName
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -141,7 +131,6 @@ class ModuleName
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -154,7 +143,6 @@ class ModuleName
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -167,7 +155,6 @@ class ModuleName
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -180,7 +167,6 @@ class ModuleName
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -193,7 +179,6 @@ class ModuleName
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -206,7 +191,6 @@ class ModuleName
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/SeqString/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/SeqString/foo.h
@@ -25,10 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -67,7 +63,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -78,7 +73,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -89,7 +83,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -102,7 +95,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -115,7 +107,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -128,7 +119,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -141,7 +131,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -154,7 +143,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -167,7 +155,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -180,7 +167,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -193,7 +179,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -206,7 +191,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/Struct/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/Struct/ModuleName.h
@@ -25,10 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -67,7 +63,6 @@ class ModuleName
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -78,7 +73,6 @@ class ModuleName
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -89,7 +83,6 @@ class ModuleName
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -102,7 +95,6 @@ class ModuleName
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -115,7 +107,6 @@ class ModuleName
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -128,7 +119,6 @@ class ModuleName
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -141,7 +131,6 @@ class ModuleName
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -154,7 +143,6 @@ class ModuleName
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -167,7 +155,6 @@ class ModuleName
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -180,7 +167,6 @@ class ModuleName
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -193,7 +179,6 @@ class ModuleName
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -206,7 +191,6 @@ class ModuleName
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/Struct2/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/Struct2/ModuleName.h
@@ -25,10 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -67,7 +63,6 @@ class ModuleName
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -78,7 +73,6 @@ class ModuleName
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -89,7 +83,6 @@ class ModuleName
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -102,7 +95,6 @@ class ModuleName
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -115,7 +107,6 @@ class ModuleName
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -128,7 +119,6 @@ class ModuleName
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -141,7 +131,6 @@ class ModuleName
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -154,7 +143,6 @@ class ModuleName
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -167,7 +155,6 @@ class ModuleName
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -180,7 +167,6 @@ class ModuleName
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -193,7 +179,6 @@ class ModuleName
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -206,7 +191,6 @@ class ModuleName
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/type/test.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/type/test.h
@@ -25,10 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -67,7 +63,6 @@ class test
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -78,7 +73,6 @@ class test
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -89,7 +83,6 @@ class test
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -102,7 +95,6 @@ class test
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -115,7 +107,6 @@ class test
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -128,7 +119,6 @@ class test
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -141,7 +131,6 @@ class test
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -154,7 +143,6 @@ class test
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -167,7 +155,6 @@ class test
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -180,7 +167,6 @@ class test
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -193,7 +179,6 @@ class test
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -206,7 +191,6 @@ class test
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/all/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/all/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/execute/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/execute/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/finalize/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/finalize/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/initialize/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/initialize/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/library/library1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/library/library1/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/library/library2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/library/library2/foo.h
@@ -24,10 +24,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class foo
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class foo
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class foo
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class foo
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class foo
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class foo
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class foo
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class foo
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class foo
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class foo
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class foo
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class foo
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/DataPortIDL/include/MarkerPosition/MarkerPosition.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/DataPortIDL/include/MarkerPosition/MarkerPosition.h
@@ -26,12 +26,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-using namespace arUco;
-using namespace GameFramework;
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -70,7 +64,6 @@ class MarkerPosition
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -81,7 +74,6 @@ class MarkerPosition
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -92,7 +84,6 @@ class MarkerPosition
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -105,7 +96,6 @@ class MarkerPosition
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -118,7 +108,6 @@ class MarkerPosition
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -131,7 +120,6 @@ class MarkerPosition
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -144,7 +132,6 @@ class MarkerPosition
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -157,7 +144,6 @@ class MarkerPosition
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -170,7 +156,6 @@ class MarkerPosition
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -183,7 +168,6 @@ class MarkerPosition
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -196,7 +180,6 @@ class MarkerPosition
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -209,7 +192,6 @@ class MarkerPosition
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePort/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePort/ModuleName.h
@@ -25,10 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -67,7 +63,6 @@ class ModuleName
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -78,7 +73,6 @@ class ModuleName
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -89,7 +83,6 @@ class ModuleName
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -102,7 +95,6 @@ class ModuleName
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -115,7 +107,6 @@ class ModuleName
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -128,7 +119,6 @@ class ModuleName
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -141,7 +131,6 @@ class ModuleName
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -154,7 +143,6 @@ class ModuleName
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -167,7 +155,6 @@ class ModuleName
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -180,7 +167,6 @@ class ModuleName
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -193,7 +179,6 @@ class ModuleName
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -206,7 +191,6 @@ class ModuleName
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/XXX/include/XXX/XXX.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/XXX/include/XXX/XXX.h
@@ -25,10 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -67,7 +63,6 @@ class XXX
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -78,7 +73,6 @@ class XXX
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -89,7 +83,6 @@ class XXX
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -102,7 +95,6 @@ class XXX
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -115,7 +107,6 @@ class XXX
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -128,7 +119,6 @@ class XXX
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -141,7 +131,6 @@ class XXX
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -154,7 +143,6 @@ class XXX
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -167,7 +155,6 @@ class XXX
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -180,7 +167,6 @@ class XXX
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -193,7 +179,6 @@ class XXX
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -206,7 +191,6 @@ class XXX
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/XXX/rtc.conf
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/XXX/rtc.conf
@@ -317,13 +317,8 @@ Category.XXX.config_file: XXX.conf
 ## The delimiter between names is "/".
 ## The delimiter between name and kind is ".".
 ##
-## example: (OpenRTM-aist-0.2.0 style)
-##       %h.host_cxt/%M.mgr_cxt/%c.cat_cxt/%m.mod_cxt/%n.rtc
-## This is formatted according to the following replacement rules.
-##
 ## %n: The instance name of the component.
 ## %t: The type name of the component.
-## %m: The module name of the component.
 ## %v: The version of the component.
 ## %V: The component vendor.
 ## %c: The category of the component.

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/XXX/test/include/XXXTest/XXXTest.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/XXX/test/include/XXXTest/XXXTest.h
@@ -25,10 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class XXXTest
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class XXXTest
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class XXXTest
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class XXXTest
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class XXXTest
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class XXXTest
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class XXXTest
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class XXXTest
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class XXXTest
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class XXXTest
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class XXXTest
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class XXXTest
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/YYY/include/YYY/YYY.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/YYY/include/YYY/YYY.h
@@ -25,10 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -67,7 +63,6 @@ class YYY
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -78,7 +73,6 @@ class YYY
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -89,7 +83,6 @@ class YYY
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -102,7 +95,6 @@ class YYY
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -115,7 +107,6 @@ class YYY
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -128,7 +119,6 @@ class YYY
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -141,7 +131,6 @@ class YYY
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -154,7 +143,6 @@ class YYY
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -167,7 +155,6 @@ class YYY
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -180,7 +167,6 @@ class YYY
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -193,7 +179,6 @@ class YYY
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -206,7 +191,6 @@ class YYY
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/YYY/rtc.conf
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/YYY/rtc.conf
@@ -317,13 +317,8 @@ Category.YYY.config_file: YYY.conf
 ## The delimiter between names is "/".
 ## The delimiter between name and kind is ".".
 ##
-## example: (OpenRTM-aist-0.2.0 style)
-##       %h.host_cxt/%M.mgr_cxt/%c.cat_cxt/%m.mod_cxt/%n.rtc
-## This is formatted according to the following replacement rules.
-##
 ## %n: The instance name of the component.
 ## %t: The type name of the component.
-## %m: The module name of the component.
 ## %v: The version of the component.
 ## %V: The component vendor.
 ## %c: The category of the component.

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/YYY/test/include/YYYTest/YYYTest.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/YYY/test/include/YYYTest/YYYTest.h
@@ -25,10 +25,6 @@
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-// </rtc-template>
-
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -66,7 +62,6 @@ class YYYTest
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +72,6 @@ class YYYTest
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +82,6 @@ class YYYTest
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +94,6 @@ class YYYTest
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +106,6 @@ class YYYTest
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -127,7 +118,6 @@ class YYYTest
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -140,7 +130,6 @@ class YYYTest
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +142,6 @@ class YYYTest
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +154,6 @@ class YYYTest
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +166,6 @@ class YYYTest
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +178,6 @@ class YYYTest
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +190,6 @@ class YYYTest
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/manager/CXXConverter.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/manager/CXXConverter.java
@@ -403,17 +403,6 @@ public class CXXConverter {
 	}
 
 	/**
-	 * データポート用のデータ型using namespace 文を返す
-	 * 
-	 * @param rtcType ポートの型
-	 * @return using文字列
-	 */
-	public String getDataportUsingNamespace(String rtcType) {
-		if(rtcType.matches("RTC.*")) return "";
-		return "using namespace " + rtcType + ";";
-	}
-	
-	/**
 	 * データポート初期化用にmodule名をカットしたデータ型クラス名を返す
 	 * 
 	 * @param rtcType ポートの型

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/choreonoid/CXX_RTC.h.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/choreonoid/CXX_RTC.h.vsl
@@ -31,13 +31,6 @@ ${sharp}include "${tmpltHelper.getFilenameNoExt(${consumerIdlFile.idlFile})}${tm
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-#foreach($type in ${cXXConv.getPortModules(${rtcParam})})
-${cXXConv.getDataportUsingNamespace(${type})}
-#end
-// </rtc-template>
-
 ${sharp}include <rtm/Manager.h>
 ${sharp}include <rtm/CorbaPort.h>
 ${sharp}include <rtm/DataInPort.h>
@@ -98,7 +91,6 @@ class ${rtcParam.name} : public BodyIoRTC {
 #end
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -115,7 +107,6 @@ class ${rtcParam.name} : public BodyIoRTC {
 #end
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -132,7 +123,6 @@ class ${rtcParam.name} : public BodyIoRTC {
 #end
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -151,7 +141,6 @@ class ${rtcParam.name} : public BodyIoRTC {
 #end
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -170,7 +159,6 @@ class ${rtcParam.name} : public BodyIoRTC {
 #end
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -189,7 +177,6 @@ class ${rtcParam.name} : public BodyIoRTC {
 #end
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -208,7 +195,6 @@ class ${rtcParam.name} : public BodyIoRTC {
 #end
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -227,7 +213,6 @@ class ${rtcParam.name} : public BodyIoRTC {
 #end
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -246,7 +231,6 @@ class ${rtcParam.name} : public BodyIoRTC {
 #end
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -265,7 +249,6 @@ class ${rtcParam.name} : public BodyIoRTC {
 #end
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -284,7 +267,6 @@ class ${rtcParam.name} : public BodyIoRTC {
 #end
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -303,7 +285,6 @@ class ${rtcParam.name} : public BodyIoRTC {
 #end
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/common/rtc.conf.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/common/rtc.conf.vsl
@@ -318,13 +318,8 @@ ${sharp}${sharp} The name format of components that is bound to naming services.
 ${sharp}${sharp} The delimiter between names is "/".
 ${sharp}${sharp} The delimiter between name and kind is ".".
 ${sharp}${sharp}
-${sharp}${sharp} example: (OpenRTM-aist-0.2.0 style)
-${sharp}${sharp}       %h.host_cxt/%M.mgr_cxt/%c.cat_cxt/%m.mod_cxt/%n.rtc
-${sharp}${sharp} This is formatted according to the following replacement rules.
-${sharp}${sharp}
 ${sharp}${sharp} %n: The instance name of the component.
 ${sharp}${sharp} %t: The type name of the component.
-${sharp}${sharp} %m: The module name of the component.
 ${sharp}${sharp} %v: The version of the component.
 ${sharp}${sharp} %V: The component vendor.
 ${sharp}${sharp} %c: The category of the component.

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/CXX_RTC.h.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/CXX_RTC.h.vsl
@@ -30,13 +30,6 @@ ${sharp}include "${tmpltHelper.getFilenameNoExt(${consumerIdlFile.idlFile})}${tm
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-#foreach($type in ${cXXConv.getPortModules(${rtcParam})})
-${cXXConv.getDataportUsingNamespace(${type})}
-#end
-// </rtc-template>
-
 ${sharp}include <rtm/Manager.h>
 ${sharp}include <rtm/${rtcParam.componentKind}Base.h>
 ${sharp}include <rtm/CorbaPort.h>
@@ -109,7 +102,6 @@ class ${rtcParam.name}
 #end
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -126,7 +118,6 @@ class ${rtcParam.name}
 #end
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -143,7 +134,6 @@ class ${rtcParam.name}
 #end
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -162,7 +152,6 @@ class ${rtcParam.name}
 #end
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -181,7 +170,6 @@ class ${rtcParam.name}
 #end
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -200,7 +188,6 @@ class ${rtcParam.name}
 #end
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -219,7 +206,6 @@ class ${rtcParam.name}
 #end
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -238,7 +224,6 @@ class ${rtcParam.name}
 #end
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -257,7 +242,6 @@ class ${rtcParam.name}
 #end
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -276,7 +260,6 @@ class ${rtcParam.name}
 #end
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -295,7 +278,6 @@ class ${rtcParam.name}
 #end
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -314,7 +296,6 @@ class ${rtcParam.name}
 #end
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/test/CXX_Test_RTC.h.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/test/CXX_Test_RTC.h.vsl
@@ -30,13 +30,6 @@ ${sharp}include "${tmpltHelper.getFilenameNoExt(${providerIdlFile.idlFile})}${tm
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-#foreach($type in ${cXXConv.getPortModules(${rtcParam})})
-${cXXConv.getDataportUsingNamespace(${type})}
-#end
-// </rtc-template>
-
 ${sharp}include <rtm/Manager.h>
 ${sharp}include <rtm/${rtcParam.componentKind}Base.h>
 ${sharp}include <rtm/CorbaPort.h>
@@ -98,7 +91,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -115,7 +107,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -132,7 +123,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -151,7 +141,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -170,7 +159,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -189,7 +177,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -208,7 +195,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -227,7 +213,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -246,7 +231,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -265,7 +249,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -284,7 +267,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -303,7 +285,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/fsm/CXX_FSM_Test_RTC.h.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/fsm/CXX_FSM_Test_RTC.h.vsl
@@ -30,13 +30,6 @@ ${sharp}include "${tmpltHelper.getFilenameNoExt(${providerIdlFile.idlFile})}${tm
 
 // </rtc-template>
 
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
-#foreach($type in ${cXXConv.getPortModules(${rtcParam})})
-${cXXConv.getDataportUsingNamespace(${type})}
-#end
-// </rtc-template>
-
 ${sharp}include <rtm/Manager.h>
 ${sharp}include <rtm/${rtcParam.componentKind}Base.h>
 ${sharp}include <rtm/CorbaPort.h>
@@ -100,7 +93,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -117,7 +109,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -134,7 +125,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -153,7 +143,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -172,7 +161,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -191,7 +179,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -210,7 +197,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -229,7 +215,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -248,7 +233,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -267,7 +251,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -286,7 +269,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -305,7 +287,6 @@ class ${rtcParam.name}Test
 #end
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *


### PR DESCRIPTION
## Identify the Bug

Link to #101

## Description of the Change

C++版RTCの生成コードを修正させて頂きました．
- rtc.conf内の｢Naming format｣の部分
　- ｢example｣を削除
　- %mの説明を削除
- ModuleName.h
　- ｢formaer｣で始まるコメント行の削除
　- Service Consumer stub headers部分のusing節を出力しないようにする
　　- ｢port_stub_h｣のブロック自体を削除

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [x] Have you passed the unit tests?  既存のユニットテストを修正し，修正した内容でコードが生成されることを確認