### PR TITLE
JARA_ARMのインターフェースを指定した場合の生成コードを修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ManipulatorCommonInterface_CommonSVC_impl.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ManipulatorCommonInterface_CommonSVC_impl.cpp
@@ -1,0 +1,123 @@
+﻿// -*-C++-*-
+/*!
+ * @file  ManipulatorCommonInterface_CommonSVC_impl.cpp
+ * @brief Service implementation code of ManipulatorCommonInterface_Common.idl
+ *
+ */
+
+#include "ManipulatorCommonInterface_CommonSVC_impl.h"
+
+/*
+ * Example implementational code for IDL interface JARA_ARM::ManipulatorCommonInterface_Common
+ */
+JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl()
+{
+  // Please add extra constructor code here.
+}
+
+
+JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::~JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl()
+{
+  // Please add extra destructor code here.
+}
+
+
+/*
+ * Methods corresponding to IDL attributes and operations
+ */
+JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::clearAlarms()
+{
+	JARA_ARM::RETURN_ID* result;
+  // Please insert your code here and remove the following warning pragma
+#ifndef WIN32
+  #warning "Code missing in function <JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::clearAlarms()>"
+#endif
+  return result;
+}
+
+JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::getActiveAlarm(JARA_ARM::AlarmSeq_out alarms)
+{
+	JARA_ARM::RETURN_ID* result;
+  // Please insert your code here and remove the following warning pragma
+#ifndef WIN32
+  #warning "Code missing in function <JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::getActiveAlarm(JARA_ARM::AlarmSeq_out alarms)>"
+#endif
+  return result;
+}
+
+JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::getFeedbackPosJoint(JARA_ARM::JointPos_out pos)
+{
+	JARA_ARM::RETURN_ID* result;
+  // Please insert your code here and remove the following warning pragma
+#ifndef WIN32
+  #warning "Code missing in function <JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::getFeedbackPosJoint(JARA_ARM::JointPos_out pos)>"
+#endif
+  return result;
+}
+
+JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::getManipInfo(JARA_ARM::ManipInfo_out mInfo)
+{
+	JARA_ARM::RETURN_ID* result;
+  // Please insert your code here and remove the following warning pragma
+#ifndef WIN32
+  #warning "Code missing in function <JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::getManipInfo(JARA_ARM::ManipInfo_out mInfo)>"
+#endif
+  return result;
+}
+
+JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::getSoftLimitJoint(JARA_ARM::LimitSeq_out softLimit)
+{
+	JARA_ARM::RETURN_ID* result;
+  // Please insert your code here and remove the following warning pragma
+#ifndef WIN32
+  #warning "Code missing in function <JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::getSoftLimitJoint(JARA_ARM::LimitSeq_out softLimit)>"
+#endif
+  return result;
+}
+
+JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::getState(JARA_ARM::ULONG& state)
+{
+	JARA_ARM::RETURN_ID* result;
+  // Please insert your code here and remove the following warning pragma
+#ifndef WIN32
+  #warning "Code missing in function <JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::getState(JARA_ARM::ULONG& state)>"
+#endif
+  return result;
+}
+
+JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::servoOFF()
+{
+	JARA_ARM::RETURN_ID* result;
+  // Please insert your code here and remove the following warning pragma
+#ifndef WIN32
+  #warning "Code missing in function <JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::servoOFF()>"
+#endif
+  return result;
+}
+
+JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::servoON()
+{
+	JARA_ARM::RETURN_ID* result;
+  // Please insert your code here and remove the following warning pragma
+#ifndef WIN32
+  #warning "Code missing in function <JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::servoON()>"
+#endif
+  return result;
+}
+
+JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::setSoftLimitJoint(const JARA_ARM::LimitSeq& softLimit)
+{
+	JARA_ARM::RETURN_ID* result;
+  // Please insert your code here and remove the following warning pragma
+#ifndef WIN32
+  #warning "Code missing in function <JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::setSoftLimitJoint(const JARA_ARM::LimitSeq& softLimit)>"
+#endif
+  return result;
+}
+
+
+
+// End of example implementational code
+
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ManipulatorCommonInterface_CommonSVC_impl.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ManipulatorCommonInterface_CommonSVC_impl.h
@@ -1,0 +1,56 @@
+﻿// -*-C++-*-
+/*!
+ * @file  ManipulatorCommonInterface_CommonSVC_impl.h
+ * @brief Service implementation header of ManipulatorCommonInterface_Common.idl
+ *
+ */
+
+#include "ManipulatorCommonInterface_DataTypesSkel.h"
+#include "BasicDataTypeSkel.h"
+
+#include "ManipulatorCommonInterface_CommonSkel.h"
+
+#ifndef MANIPULATORCOMMONINTERFACE_COMMONSVC_IMPL_H
+#define MANIPULATORCOMMONINTERFACE_COMMONSVC_IMPL_H
+ 
+/*!
+ * @class JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl
+ * Example class implementing IDL interface JARA_ARM::ManipulatorCommonInterface_Common
+ */
+class JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl
+ : public virtual POA_JARA_ARM::ManipulatorCommonInterface_Common,
+   public virtual PortableServer::RefCountServantBase
+{
+ private:
+   // Make sure all instances are built on the heap by making the
+   // destructor non-public
+   //virtual ~JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl();
+
+ public:
+  /*!
+   * @brief standard constructor
+   */
+   JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl();
+  /*!
+   * @brief destructor
+   */
+   virtual ~JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl();
+
+   // attributes and operations
+   JARA_ARM::RETURN_ID* clearAlarms();
+   JARA_ARM::RETURN_ID* getActiveAlarm(JARA_ARM::AlarmSeq_out alarms);
+   JARA_ARM::RETURN_ID* getFeedbackPosJoint(JARA_ARM::JointPos_out pos);
+   JARA_ARM::RETURN_ID* getManipInfo(JARA_ARM::ManipInfo_out mInfo);
+   JARA_ARM::RETURN_ID* getSoftLimitJoint(JARA_ARM::LimitSeq_out softLimit);
+   JARA_ARM::RETURN_ID* getState(JARA_ARM::ULONG& state);
+   JARA_ARM::RETURN_ID* servoOFF();
+   JARA_ARM::RETURN_ID* servoON();
+   JARA_ARM::RETURN_ID* setSoftLimitJoint(const JARA_ARM::LimitSeq& softLimit);
+
+};
+
+
+
+#endif // MANIPULATORCOMMONINTERFACE_COMMONSVC_IMPL_H
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ModuleName.cpp
@@ -1,0 +1,170 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleName.cpp
+ * @brief ModuleDescription
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include "ModuleName.h"
+
+// Module specification
+// <rtc-template block="module_spec">
+static const char* modulename_spec[] =
+  {
+    "implementation_id", "ModuleName",
+    "type_name",         "ModuleName",
+    "description",       "ModuleDescription",
+    "version",           "1.0.0",
+    "vendor",            "VenderName",
+    "category",          "Category",
+    "activity_type",     "PERIODIC",
+    "kind",              "DataFlowComponent",
+    "max_instance",      "1",
+    "language",          "C++",
+    "lang_type",         "compile",
+    ""
+  };
+// </rtc-template>
+
+/*!
+ * @brief constructor
+ * @param manager Maneger Object
+ */
+ModuleName::ModuleName(RTC::Manager* manager)
+    // <rtc-template block="initializer">
+  : RTC::DataFlowComponentBase(manager),
+    m_sv_namePort("sv_name")
+    // </rtc-template>
+{
+}
+
+/*!
+ * @brief destructor
+ */
+ModuleName::~ModuleName()
+{
+}
+
+
+
+RTC::ReturnCode_t ModuleName::onInitialize()
+{
+  // Registration: InPort/OutPort/Service
+  // <rtc-template block="registration">
+  // Set InPort buffers
+  
+  // Set OutPort buffer
+
+  
+  // Set service provider to Ports
+  m_sv_namePort.registerProvider("if_name", "JARA_ARM::ManipulatorCommonInterface_Common", m_if_name);
+  
+  // Set service consumers to Ports
+  
+  // Set CORBA Service Ports
+  addPort(m_sv_namePort);
+  
+  // </rtc-template>
+
+  // <rtc-template block="bind_config">
+  // </rtc-template>
+
+  
+  return RTC::RTC_OK;
+}
+
+/*
+RTC::ReturnCode_t ModuleName::onFinalize()
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onStartup(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onShutdown(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onActivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onDeactivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onExecute(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onAborting(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onError(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onReset(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onStateUpdate(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onRateChanged(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+
+
+extern "C"
+{
+ 
+  void ModuleNameInit(RTC::Manager* manager)
+  {
+    coil::Properties profile(modulename_spec);
+    manager->registerFactory(profile,
+                             RTC::Create<ModuleName>,
+                             RTC::Delete<ModuleName>);
+  }
+  
+};
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ModuleName.h
@@ -1,14 +1,14 @@
 ﻿// -*- C++ -*-
 /*!
- * @file  XXXTest.h
+ * @file  ModuleName.h
  * @brief ModuleDescription
  * @date  $Date$
  *
  * $Id$
  */
 
-#ifndef XXX_TEST__H
-#define XXX_TEST_H
+#ifndef MODULENAME_H
+#define MODULENAME_H
 
 #include <rtm/idl/BasicDataTypeSkel.h>
 #include <rtm/idl/ExtendedDataTypesSkel.h>
@@ -16,17 +16,13 @@
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">
+#include "ManipulatorCommonInterface_CommonSVC_impl.h"
 
 // </rtc-template>
 
 // Service Consumer stub headers
 // <rtc-template block="consumer_stub_h">
-#include "MyServiceStub.h"
 
-// </rtc-template>
-
-// Service Consumer stub headers
-// <rtc-template block="port_stub_h">
 // </rtc-template>
 
 #include <rtm/Manager.h>
@@ -35,12 +31,13 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
+
 /*!
- * @class XXXTest
+ * @class ModuleName
  * @brief ModuleDescription
  *
  */
-class XXXTest
+class ModuleName
   : public RTC::DataFlowComponentBase
 {
  public:
@@ -48,12 +45,12 @@ class XXXTest
    * @brief constructor
    * @param manager Maneger Object
    */
-  XXXTest(RTC::Manager* manager);
+  ModuleName(RTC::Manager* manager);
 
   /*!
    * @brief destructor
    */
-  ~XXXTest() override;
+  ~ModuleName() override;
 
   // <rtc-template block="public_attribute">
   
@@ -66,7 +63,6 @@ class XXXTest
   /***
    *
    * The initialize action (on CREATED->ALIVE transition)
-   * formaer rtc_init_entry() 
    *
    * @return RTC::ReturnCode_t
    * 
@@ -77,7 +73,6 @@ class XXXTest
   /***
    *
    * The finalize action (on ALIVE->END transition)
-   * formaer rtc_exiting_entry()
    *
    * @return RTC::ReturnCode_t
    * 
@@ -88,7 +83,6 @@ class XXXTest
   /***
    *
    * The startup action when ExecutionContext startup
-   * former rtc_starting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -101,7 +95,6 @@ class XXXTest
   /***
    *
    * The shutdown action when ExecutionContext stop
-   * former rtc_stopping_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -114,7 +107,6 @@ class XXXTest
   /***
    *
    * The activated action (Active state entry action)
-   * former rtc_active_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -122,12 +114,11 @@ class XXXTest
    * 
    * 
    */
-   RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id) override;
+  // RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id) override;
 
   /***
    *
    * The deactivated action (Active state exit action)
-   * former rtc_active_exit()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -135,12 +126,11 @@ class XXXTest
    * 
    * 
    */
-   RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id) override;
+  // RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id) override;
 
   /***
    *
    * The execution action that is invoked periodically
-   * former rtc_active_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -148,12 +138,11 @@ class XXXTest
    * 
    * 
    */
-   RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
+  // RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
 
   /***
    *
    * The aborting action when main logic error occurred.
-   * former rtc_aborting_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -166,7 +155,6 @@ class XXXTest
   /***
    *
    * The error action in ERROR state
-   * former rtc_error_do()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -179,7 +167,6 @@ class XXXTest
   /***
    *
    * The reset action that is invoked resetting
-   * This is same but different the former rtc_init_entry()
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -192,7 +179,6 @@ class XXXTest
   /***
    *
    * The state update action that is invoked after onExecute() action
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -205,7 +191,6 @@ class XXXTest
   /***
    *
    * The action that is invoked when execution context's rate is changed
-   * no corresponding operation exists in OpenRTm-aist-0.2.0
    *
    * @param ec_id target ExecutionContext Id
    *
@@ -215,7 +200,6 @@ class XXXTest
    */
   // RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id) override;
 
-  bool runTest();
 
  protected:
   // <rtc-template block="protected_attribute">
@@ -233,20 +217,12 @@ class XXXTest
 
   // DataInPort declaration
   // <rtc-template block="inport_declare">
-  RTC::TimedLong m_out;
-  /*!
-   */
-  RTC::InPort<RTC::TimedLong> m_outIn;
   
   // </rtc-template>
 
 
   // DataOutPort declaration
   // <rtc-template block="outport_declare">
-  RTC::TimedLong m_in;
-  /*!
-   */
-  RTC::OutPort<RTC::TimedLong> m_inOut;
   
   // </rtc-template>
 
@@ -254,22 +230,23 @@ class XXXTest
   // <rtc-template block="corbaport_declare">
   /*!
    */
-  RTC::CorbaPort m_MyServidePort;
+  RTC::CorbaPort m_sv_namePort;
   
   // </rtc-template>
 
   // Service declaration
   // <rtc-template block="service_declare">
+  /*!
+   */
+  JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl m_if_name;
   
   // </rtc-template>
 
   // Consumer declaration
   // <rtc-template block="consumer_declare">
-  /*!
-   */
-  RTC::CorbaConsumer<SimpleService::MyService> m_myservice0;
   
   // </rtc-template>
+
 
  private:
   // <rtc-template block="private_attribute">
@@ -285,7 +262,7 @@ class XXXTest
 
 extern "C"
 {
-  DLL_EXPORT void XXXTestInit(RTC::Manager* manager);
+  DLL_EXPORT void ModuleNameInit(RTC::Manager* manager);
 };
 
-#endif // XXX_TEST_H
+#endif // MODULENAME_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ModuleNameComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ModuleNameComp.cpp
@@ -1,0 +1,94 @@
+﻿// -*- C++ -*-
+/*!
+ * @file ModuleNameComp.cpp
+ * @brief Standalone component
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include <rtm/Manager.h>
+#include <iostream>
+#include <string>
+#include <stdlib.h>
+#include "ModuleName.h"
+
+
+void MyModuleInit(RTC::Manager* manager)
+{
+  ModuleNameInit(manager);
+  RTC::RtcBase* comp;
+
+  // Create a component
+  comp = manager->createComponent("ModuleName");
+
+  if (comp==NULL)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
+
+  // Example
+  // The following procedure is examples how handle RT-Components.
+  // These should not be in this function.
+
+  // Get the component's object reference
+//  RTC::RTObject_var rtobj;
+//  rtobj = RTC::RTObject::_narrow(manager->getPOA()->servant_to_reference(comp));
+
+  // Get the port list of the component
+//  PortServiceList* portlist;
+//  portlist = rtobj->get_ports();
+
+  // getting port profiles
+//  std::cout << "Number of Ports: ";
+//  std::cout << portlist->length() << std::endl << std::endl; 
+//  for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
+//  {
+//    PortService_ptr port;
+//    port = (*portlist)[i];
+//    std::cout << "Port" << i << " (name): ";
+//    std::cout << port->get_port_profile()->name << std::endl;
+//    
+//    RTC::PortInterfaceProfileList iflist;
+//    iflist = port->get_port_profile()->interfaces;
+//    std::cout << "---interfaces---" << std::endl;
+//    for (CORBA::ULong i(0), n(iflist.length()); i < n; ++i)
+//    {
+//      std::cout << "I/F name: ";
+//      std::cout << iflist[i].instance_name << std::endl;
+//      std::cout << "I/F type: ";
+//      std::cout << iflist[i].type_name << std::endl;
+//      const char* pol;
+//      pol = iflist[i].polarity == 0 ? "PROVIDED" : "REQUIRED";
+//      std::cout << "Polarity: " << pol << std::endl;
+//    }
+//    std::cout << "---properties---" << std::endl;
+//    NVUtil::dump(port->get_port_profile()->properties);
+//    std::cout << "----------------" << std::endl << std::endl;
+//  }
+
+  return;
+}
+
+int main (int argc, char** argv)
+{
+  RTC::Manager* manager;
+  manager = RTC::Manager::init(argc, argv);
+
+  // Set module initialization proceduer
+  // This procedure will be invoked in activateManager() function.
+  manager->setModuleInitProc(MyModuleInit);
+
+  // Activate manager and register to naming service
+  manager->activateManager();
+
+  // run the manager in blocking mode
+  // runManager(false) is the default.
+  manager->runManager();
+
+  // If you want to run the manager in non-blocking mode, do like this
+  // manager->runManager(true);
+
+  return 0;
+}

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/Generator.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/Generator.java
@@ -578,7 +578,7 @@ public class Generator {
 			}
 			boolean isHit = false;
 			if(tdparam.isDefault()) {
-				if(targetType.equals(defFull)) {
+				if(targetType.equals(defFull) || targetFull.equals(defFull)) {
 					isHit = true;
 				}
 			} else {

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/manager/CXXConverter.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/manager/CXXConverter.java
@@ -175,7 +175,7 @@ public class CXXConverter {
 					result = result + "*";
 				}
 			}
-			if(typeDef.getModule()!=null && typeDef.getModule().length()>0 && typeDef.isDefault()==false) {
+			if(typeDef.getModule()!=null && typeDef.getModule().length()>0 && result.startsWith("RTC")==false) {
 				result = typeDef.getModule() + result;
 			}
 		}

--- a/jp.go.aist.rtm.rtcbuilder/test/jp/go/aist/rtm/rtcbuilder/_test/generateCode/ServicePortTest.java
+++ b/jp.go.aist.rtm.rtcbuilder/test/jp/go/aist/rtm/rtcbuilder/_test/generateCode/ServicePortTest.java
@@ -57,6 +57,11 @@ public class ServicePortTest extends TestBase {
 		param4.setDefault(true);
 		genParam.getDataTypeParams().add(param4);
 
+		DataTypeParam param5 = new DataTypeParam();
+		param5.setFullPath("C:\\Program Files\\OpenRTM-aist\\1.2.0\\rtm\\idl\\ManipulatorCommonInterface_Common.idl");
+		param5.setDefault(true);
+		genParam.getDataTypeParams().add(param5);
+		
 		genParam.setRtcParam(rtcParam);
 	}
 
@@ -86,4 +91,28 @@ public class ServicePortTest extends TestBase {
 		checkCode(result, targetDir, "idl/CMakeLists.txt");
 	}
 
+	public void testServicePortJARA() throws Exception {
+		ServicePortParam service1 = new ServicePortParam("sv_name",0);
+		List<ServicePortInterfaceParam> srvinterts = new ArrayList<ServicePortInterfaceParam>();
+		ServicePortInterfaceParam int1 = new ServicePortInterfaceParam(service1, "if_name", "", "",
+				"C:\\Program Files\\OpenRTM-aist\\1.2.0\\rtm\\idl\\ManipulatorCommonInterface_Common.idl",
+				"JARA_ARM::ManipulatorCommonInterface_Common",
+				"C:\\Program Files\\OpenRTM-aist\\1.2.0\\rtm\\idl",
+				0);
+		srvinterts.add(int1);
+		service1.getServicePortInterfaces().addAll(srvinterts);
+		List<ServicePortParam> srvports = new ArrayList<ServicePortParam>();
+		srvports.add(service1);
+		rtcParam.getServicePorts().addAll(srvports);
+
+		Generator generator = new Generator();
+		List<GeneratedResult> result = generator.generateTemplateCode(genParam);
+
+		String targetDir = rootPath + "/resource/100/ServicePortJARA/";
+		checkCode(result, targetDir, "ModuleNameComp.cpp");
+		checkCode(result, targetDir, "ModuleName.h");
+		checkCode(result, targetDir, "ModuleName.cpp");
+		checkCode(result, targetDir, "ManipulatorCommonInterface_CommonSVC_impl.h");
+		checkCode(result, targetDir, "ManipulatorCommonInterface_CommonSVC_impl.cpp");
+	}
 }


### PR DESCRIPTION
## Identify the Bug

Link to #79

## Description of the Change

C++版RTCでサービスインターフェースにJARA_ARMモジュールのインターフェースを指定した場合に，XXXSVC_impl.h, XXXSVC_impl.cppの戻り値に*が設定されておらず，ビルドエラーとなってしまっていたのを修正

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [x] Have you passed the unit tests?  ユニットテストを追加し，修正した内容でコードが生成されることを確認