### PR TITLE
JARA_ARMのインターフェースを指定した場合の生成コードを修正(RELENG_1_2)

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/dtsuffix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/dtsuffix/foo.h
@@ -36,7 +36,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/prefix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/prefix/foo.h
@@ -36,7 +36,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/siprefix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/siprefix/foo.h
@@ -36,7 +36,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/sisuffix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/sisuffix/foo.h
@@ -36,7 +36,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/suffix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/suffix/foo.h
@@ -36,7 +36,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/svprefix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/svprefix/foo.h
@@ -36,7 +36,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/svsuffix/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/svsuffix/foo.h
@@ -36,7 +36,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/SystemConfig/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/SystemConfig/foo.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/DataPort/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/DataPort/foo.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/ServicePort1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/ServicePort1/foo.h
@@ -36,7 +36,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/ServicePort2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/ServicePort2/foo.h
@@ -36,7 +36,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/attribute/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/attribute/foo.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/inport1/test.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/inport1/test.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class test
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/inport2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/inport2/foo.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/name/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/name/foo.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/operation/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/operation/foo.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/outport1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/outport1/foo.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/outport2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/outport2/foo.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/service1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/service1/foo.h
@@ -35,7 +35,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/service2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/service2/foo.h
@@ -36,7 +36,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/DFFSMMM/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/DFFSMMM/foo.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/DataFlow/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/DataFlow/foo.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/FSM/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basicClass/FSM/foo.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/cmake2/include/foo/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/cmake2/include/foo/foo.h
@@ -36,7 +36,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief test module

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint1/foo.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint2/foo.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint3/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint3/foo.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlinherit/inherit1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlinherit/inherit1/foo.h
@@ -35,7 +35,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief test module

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlinherit/inherit2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlinherit/inherit2/foo.h
@@ -36,7 +36,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief test module

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceArg/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceArg/foo.h
@@ -35,7 +35,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceArgStruct/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceArgStruct/foo.h
@@ -35,7 +35,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceCon/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceCon/foo.h
@@ -35,7 +35,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceM/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceM/foo.h
@@ -35,7 +35,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath1/foo.h
@@ -36,7 +36,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath2/foo.h
@@ -36,7 +36,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath3/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath3/foo.h
@@ -36,7 +36,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlstruct/TestModule.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlstruct/TestModule.h
@@ -35,7 +35,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class TestModule
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/IDLType1/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/IDLType1/ModuleName.h
@@ -35,7 +35,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class ModuleName
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/SeqString/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/SeqString/foo.h
@@ -35,7 +35,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/Struct/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/Struct/ModuleName.h
@@ -35,7 +35,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class ModuleName
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/Struct2/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/Struct2/ModuleName.h
@@ -35,7 +35,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class ModuleName
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/type/test.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/type/test.h
@@ -35,7 +35,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class test
  * @brief test component

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/all/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/all/foo.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/execute/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/execute/foo.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/finalize/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/finalize/foo.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/initialize/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/initialize/foo.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/library/library1/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/library/library1/foo.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/library/library2/foo.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/library/library2/foo.h
@@ -34,7 +34,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class foo
  * @brief MDesc

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/DataPortIDL/include/MarkerPosition/MarkerPosition.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/DataPortIDL/include/MarkerPosition/MarkerPosition.h
@@ -38,7 +38,6 @@ using namespace GameFramework;
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class MarkerPosition
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePort/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePort/ModuleName.h
@@ -35,7 +35,6 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
-
 /*!
  * @class ModuleName
  * @brief ModuleDescription

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ManipulatorCommonInterface_CommonSVC_impl.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ManipulatorCommonInterface_CommonSVC_impl.cpp
@@ -1,0 +1,123 @@
+// -*-C++-*-
+/*!
+ * @file  ManipulatorCommonInterface_CommonSVC_impl.cpp
+ * @brief Service implementation code of ManipulatorCommonInterface_Common.idl
+ *
+ */
+
+#include "ManipulatorCommonInterface_CommonSVC_impl.h"
+
+/*
+ * Example implementational code for IDL interface JARA_ARM::ManipulatorCommonInterface_Common
+ */
+JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl()
+{
+  // Please add extra constructor code here.
+}
+
+
+JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::~JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl()
+{
+  // Please add extra destructor code here.
+}
+
+
+/*
+ * Methods corresponding to IDL attributes and operations
+ */
+JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::clearAlarms()
+{
+	JARA_ARM::RETURN_ID* result;
+  // Please insert your code here and remove the following warning pragma
+#ifndef WIN32
+  #warning "Code missing in function <JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::clearAlarms()>"
+#endif
+  return result;
+}
+
+JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::getActiveAlarm(JARA_ARM::AlarmSeq_out alarms)
+{
+	JARA_ARM::RETURN_ID* result;
+  // Please insert your code here and remove the following warning pragma
+#ifndef WIN32
+  #warning "Code missing in function <JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::getActiveAlarm(JARA_ARM::AlarmSeq_out alarms)>"
+#endif
+  return result;
+}
+
+JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::getFeedbackPosJoint(JARA_ARM::JointPos_out pos)
+{
+	JARA_ARM::RETURN_ID* result;
+  // Please insert your code here and remove the following warning pragma
+#ifndef WIN32
+  #warning "Code missing in function <JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::getFeedbackPosJoint(JARA_ARM::JointPos_out pos)>"
+#endif
+  return result;
+}
+
+JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::getManipInfo(JARA_ARM::ManipInfo_out mInfo)
+{
+	JARA_ARM::RETURN_ID* result;
+  // Please insert your code here and remove the following warning pragma
+#ifndef WIN32
+  #warning "Code missing in function <JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::getManipInfo(JARA_ARM::ManipInfo_out mInfo)>"
+#endif
+  return result;
+}
+
+JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::getSoftLimitJoint(JARA_ARM::LimitSeq_out softLimit)
+{
+	JARA_ARM::RETURN_ID* result;
+  // Please insert your code here and remove the following warning pragma
+#ifndef WIN32
+  #warning "Code missing in function <JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::getSoftLimitJoint(JARA_ARM::LimitSeq_out softLimit)>"
+#endif
+  return result;
+}
+
+JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::getState(JARA_ARM::ULONG& state)
+{
+	JARA_ARM::RETURN_ID* result;
+  // Please insert your code here and remove the following warning pragma
+#ifndef WIN32
+  #warning "Code missing in function <JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::getState(JARA_ARM::ULONG& state)>"
+#endif
+  return result;
+}
+
+JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::servoOFF()
+{
+	JARA_ARM::RETURN_ID* result;
+  // Please insert your code here and remove the following warning pragma
+#ifndef WIN32
+  #warning "Code missing in function <JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::servoOFF()>"
+#endif
+  return result;
+}
+
+JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::servoON()
+{
+	JARA_ARM::RETURN_ID* result;
+  // Please insert your code here and remove the following warning pragma
+#ifndef WIN32
+  #warning "Code missing in function <JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::servoON()>"
+#endif
+  return result;
+}
+
+JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::setSoftLimitJoint(const JARA_ARM::LimitSeq& softLimit)
+{
+	JARA_ARM::RETURN_ID* result;
+  // Please insert your code here and remove the following warning pragma
+#ifndef WIN32
+  #warning "Code missing in function <JARA_ARM::RETURN_ID* JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl::setSoftLimitJoint(const JARA_ARM::LimitSeq& softLimit)>"
+#endif
+  return result;
+}
+
+
+
+// End of example implementational code
+
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ManipulatorCommonInterface_CommonSVC_impl.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ManipulatorCommonInterface_CommonSVC_impl.h
@@ -1,0 +1,56 @@
+// -*-C++-*-
+/*!
+ * @file  ManipulatorCommonInterface_CommonSVC_impl.h
+ * @brief Service implementation header of ManipulatorCommonInterface_Common.idl
+ *
+ */
+
+#include "ManipulatorCommonInterface_DataTypesSkel.h"
+#include "BasicDataTypeSkel.h"
+
+#include "ManipulatorCommonInterface_CommonSkel.h"
+
+#ifndef MANIPULATORCOMMONINTERFACE_COMMONSVC_IMPL_H
+#define MANIPULATORCOMMONINTERFACE_COMMONSVC_IMPL_H
+ 
+/*!
+ * @class JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl
+ * Example class implementing IDL interface JARA_ARM::ManipulatorCommonInterface_Common
+ */
+class JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl
+ : public virtual POA_JARA_ARM::ManipulatorCommonInterface_Common,
+   public virtual PortableServer::RefCountServantBase
+{
+ private:
+   // Make sure all instances are built on the heap by making the
+   // destructor non-public
+   //virtual ~JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl();
+
+ public:
+  /*!
+   * @brief standard constructor
+   */
+   JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl();
+  /*!
+   * @brief destructor
+   */
+   virtual ~JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl();
+
+   // attributes and operations
+   JARA_ARM::RETURN_ID* clearAlarms();
+   JARA_ARM::RETURN_ID* getActiveAlarm(JARA_ARM::AlarmSeq_out alarms);
+   JARA_ARM::RETURN_ID* getFeedbackPosJoint(JARA_ARM::JointPos_out pos);
+   JARA_ARM::RETURN_ID* getManipInfo(JARA_ARM::ManipInfo_out mInfo);
+   JARA_ARM::RETURN_ID* getSoftLimitJoint(JARA_ARM::LimitSeq_out softLimit);
+   JARA_ARM::RETURN_ID* getState(JARA_ARM::ULONG& state);
+   JARA_ARM::RETURN_ID* servoOFF();
+   JARA_ARM::RETURN_ID* servoON();
+   JARA_ARM::RETURN_ID* setSoftLimitJoint(const JARA_ARM::LimitSeq& softLimit);
+
+};
+
+
+
+#endif // MANIPULATORCOMMONINTERFACE_COMMONSVC_IMPL_H
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ModuleName.cpp
@@ -1,0 +1,169 @@
+// -*- C++ -*-
+/*!
+ * @file  ModuleName.cpp
+ * @brief ModuleDescription
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include "ModuleName.h"
+
+// Module specification
+// <rtc-template block="module_spec">
+static const char* modulename_spec[] =
+  {
+    "implementation_id", "ModuleName",
+    "type_name",         "ModuleName",
+    "description",       "ModuleDescription",
+    "version",           "1.0.0",
+    "vendor",            "VenderName",
+    "category",          "Category",
+    "activity_type",     "PERIODIC",
+    "kind",              "DataFlowComponent",
+    "max_instance",      "1",
+    "language",          "C++",
+    "lang_type",         "compile",
+    ""
+  };
+// </rtc-template>
+
+/*!
+ * @brief constructor
+ * @param manager Maneger Object
+ */
+ModuleName::ModuleName(RTC::Manager* manager)
+    // <rtc-template block="initializer">
+  : RTC::DataFlowComponentBase(manager),
+    m_sv_namePort("sv_name")
+
+    // </rtc-template>
+{
+}
+
+/*!
+ * @brief destructor
+ */
+ModuleName::~ModuleName()
+{
+}
+
+
+
+RTC::ReturnCode_t ModuleName::onInitialize()
+{
+  // Registration: InPort/OutPort/Service
+  // <rtc-template block="registration">
+  // Set InPort buffers
+  
+  // Set OutPort buffer
+  
+  // Set service provider to Ports
+  m_sv_namePort.registerProvider("if_name", "JARA_ARM::ManipulatorCommonInterface_Common", m_if_name);
+  
+  // Set service consumers to Ports
+  
+  // Set CORBA Service Ports
+  addPort(m_sv_namePort);
+  
+  // </rtc-template>
+
+  // <rtc-template block="bind_config">
+  // </rtc-template>
+  
+  return RTC::RTC_OK;
+}
+
+/*
+RTC::ReturnCode_t ModuleName::onFinalize()
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onStartup(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onShutdown(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onActivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onDeactivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onExecute(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onAborting(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onError(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onReset(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onStateUpdate(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onRateChanged(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+
+
+extern "C"
+{
+ 
+  void ModuleNameInit(RTC::Manager* manager)
+  {
+    coil::Properties profile(modulename_spec);
+    manager->registerFactory(profile,
+                             RTC::Create<ModuleName>,
+                             RTC::Delete<ModuleName>);
+  }
+  
+};
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ModuleName.h
@@ -1,14 +1,14 @@
 // -*- C++ -*-
 /*!
- * @file  foo.h
- * @brief test module
+ * @file  ModuleName.h
+ * @brief ModuleDescription
  * @date  $Date$
  *
  * $Id$
  */
 
-#ifndef FOO_H
-#define FOO_H
+#ifndef MODULENAME_H
+#define MODULENAME_H
 
 #include <rtm/idl/BasicDataTypeSkel.h>
 #include <rtm/idl/ExtendedDataTypesSkel.h>
@@ -16,13 +16,12 @@
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">
-#include "MyServiceSVC_impl.h"
+#include "ManipulatorCommonInterface_CommonSVC_impl.h"
 
 // </rtc-template>
 
 // Service Consumer stub headers
 // <rtc-template block="consumer_stub_h">
-#include "DAQServiceStub.h"
 
 // </rtc-template>
 
@@ -37,11 +36,11 @@
 #include <rtm/DataOutPort.h>
 
 /*!
- * @class foo
- * @brief test module
+ * @class ModuleName
+ * @brief ModuleDescription
  *
  */
-class foo
+class ModuleName
   : public RTC::DataFlowComponentBase
 {
  public:
@@ -49,12 +48,12 @@ class foo
    * @brief constructor
    * @param manager Maneger Object
    */
-  foo(RTC::Manager* manager);
+  ModuleName(RTC::Manager* manager);
 
   /*!
    * @brief destructor
    */
-  ~foo();
+  ~ModuleName();
 
   // <rtc-template block="public_attribute">
   
@@ -233,28 +232,12 @@ class foo
 
   // DataInPort declaration
   // <rtc-template block="inport_declare">
-  RTC::TimedShort m_InP1;
-  /*!
-   */
-  RTC::InPort<RTC::TimedShort> m_InP1In;
-  RTC::TimedLong m_InP2;
-  /*!
-   */
-  RTC::InPort<RTC::TimedLong> m_InP2In;
   
   // </rtc-template>
 
 
   // DataOutPort declaration
   // <rtc-template block="outport_declare">
-  RTC::TimedInt m_OutP1;
-  /*!
-   */
-  RTC::OutPort<RTC::TimedInt> m_OutP1Out;
-  RTC::TimedFloat m_OutP2;
-  /*!
-   */
-  RTC::OutPort<RTC::TimedFloat> m_OutP2Out;
   
   // </rtc-template>
 
@@ -262,10 +245,7 @@ class foo
   // <rtc-template block="corbaport_declare">
   /*!
    */
-  RTC::CorbaPort m_svPortPort;
-  /*!
-   */
-  RTC::CorbaPort m_cmPortPort;
+  RTC::CorbaPort m_sv_namePort;
   
   // </rtc-template>
 
@@ -273,15 +253,12 @@ class foo
   // <rtc-template block="service_declare">
   /*!
    */
-  MyServiceSVC_impl m_acc;
+  JARA_ARM_ManipulatorCommonInterface_CommonSVC_impl m_if_name;
   
   // </rtc-template>
 
   // Consumer declaration
   // <rtc-template block="consumer_declare">
-  /*!
-   */
-  RTC::CorbaConsumer<DAQService> m_rate;
   
   // </rtc-template>
 
@@ -299,7 +276,7 @@ class foo
 
 extern "C"
 {
-  DLL_EXPORT void fooInit(RTC::Manager* manager);
+  DLL_EXPORT void ModuleNameInit(RTC::Manager* manager);
 };
 
-#endif // FOO_H
+#endif // MODULENAME_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ModuleNameComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ModuleNameComp.cpp
@@ -1,0 +1,94 @@
+// -*- C++ -*-
+/*!
+ * @file ModuleNameComp.cpp
+ * @brief Standalone component
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include <rtm/Manager.h>
+#include <iostream>
+#include <string>
+#include <stdlib.h>
+#include "ModuleName.h"
+
+
+void MyModuleInit(RTC::Manager* manager)
+{
+  ModuleNameInit(manager);
+  RTC::RtcBase* comp;
+
+  // Create a component
+  comp = manager->createComponent("ModuleName");
+
+  if (comp==NULL)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
+
+  // Example
+  // The following procedure is examples how handle RT-Components.
+  // These should not be in this function.
+
+  // Get the component's object reference
+//  RTC::RTObject_var rtobj;
+//  rtobj = RTC::RTObject::_narrow(manager->getPOA()->servant_to_reference(comp));
+
+  // Get the port list of the component
+//  PortServiceList* portlist;
+//  portlist = rtobj->get_ports();
+
+  // getting port profiles
+//  std::cout << "Number of Ports: ";
+//  std::cout << portlist->length() << std::endl << std::endl; 
+//  for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
+//  {
+//    PortService_ptr port;
+//    port = (*portlist)[i];
+//    std::cout << "Port" << i << " (name): ";
+//    std::cout << port->get_port_profile()->name << std::endl;
+//    
+//    RTC::PortInterfaceProfileList iflist;
+//    iflist = port->get_port_profile()->interfaces;
+//    std::cout << "---interfaces---" << std::endl;
+//    for (CORBA::ULong i(0), n(iflist.length()); i < n; ++i)
+//    {
+//      std::cout << "I/F name: ";
+//      std::cout << iflist[i].instance_name << std::endl;
+//      std::cout << "I/F type: ";
+//      std::cout << iflist[i].type_name << std::endl;
+//      const char* pol;
+//      pol = iflist[i].polarity == 0 ? "PROVIDED" : "REQUIRED";
+//      std::cout << "Polarity: " << pol << std::endl;
+//    }
+//    std::cout << "---properties---" << std::endl;
+//    NVUtil::dump(port->get_port_profile()->properties);
+//    std::cout << "----------------" << std::endl << std::endl;
+//  }
+
+  return;
+}
+
+int main (int argc, char** argv)
+{
+  RTC::Manager* manager;
+  manager = RTC::Manager::init(argc, argv);
+
+  // Set module initialization proceduer
+  // This procedure will be invoked in activateManager() function.
+  manager->setModuleInitProc(MyModuleInit);
+
+  // Activate manager and register to naming service
+  manager->activateManager();
+
+  // run the manager in blocking mode
+  // runManager(false) is the default.
+  manager->runManager();
+
+  // If you want to run the manager in non-blocking mode, do like this
+  // manager->runManager(true);
+
+  return 0;
+}

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/Generator.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/Generator.java
@@ -545,7 +545,7 @@ public class Generator {
 			}
 			boolean isHit = false;
 			if(tdparam.isDefault()) {
-				if(targetType.equals(defFull)) {
+                if(targetType.equals(defFull) || targetFull.equals(defFull)) {
 					isHit = true;
 				}
 			} else {

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/manager/CXXConverter.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/manager/CXXConverter.java
@@ -175,7 +175,7 @@ public class CXXConverter {
 					result = result + "*";
 				}
 			}
-			if(typeDef.getModule()!=null && typeDef.getModule().length()>0 && typeDef.isDefault()==false) {
+            if(typeDef.getModule()!=null && typeDef.getModule().length()>0 && result.startsWith("RTC")==false) {
 				result = typeDef.getModule() + result;
 			}
 		}

--- a/jp.go.aist.rtm.rtcbuilder/test/jp/go/aist/rtm/rtcbuilder/_test/generateCode/ServicePortTest.java
+++ b/jp.go.aist.rtm.rtcbuilder/test/jp/go/aist/rtm/rtcbuilder/_test/generateCode/ServicePortTest.java
@@ -57,6 +57,11 @@ public class ServicePortTest extends TestBase {
 		param4.setDefault(true);
 		genParam.getDataTypeParams().add(param4);
 
+        DataTypeParam param5 = new DataTypeParam();
+        param5.setFullPath("C:\\Program Files\\OpenRTM-aist\\1.2.0\\rtm\\idl\\ManipulatorCommonInterface_Common.idl");
+        param5.setDefault(true);
+        genParam.getDataTypeParams().add(param5);
+
 		genParam.setRtcParam(rtcParam);
 	}
 
@@ -86,4 +91,28 @@ public class ServicePortTest extends TestBase {
 		checkCode(result, targetDir, "idl/CMakeLists.txt");
 	}
 
+    public void testServicePortJARA() throws Exception {
+        ServicePortParam service1 = new ServicePortParam("sv_name",0);
+        List<ServicePortInterfaceParam> srvinterts = new ArrayList<ServicePortInterfaceParam>();
+        ServicePortInterfaceParam int1 = new ServicePortInterfaceParam(service1, "if_name", "", "",
+                "C:\\Program Files\\OpenRTM-aist\\1.2.0\\rtm\\idl\\ManipulatorCommonInterface_Common.idl",
+                "JARA_ARM::ManipulatorCommonInterface_Common",
+                "C:\\Program Files\\OpenRTM-aist\\1.2.0\\rtm\\idl",
+                0);
+        srvinterts.add(int1);
+        service1.getServicePortInterfaces().addAll(srvinterts);
+        List<ServicePortParam> srvports = new ArrayList<ServicePortParam>();
+        srvports.add(service1);
+        rtcParam.getServicePorts().addAll(srvports);
+
+        Generator generator = new Generator();
+        List<GeneratedResult> result = generator.generateTemplateCode(genParam);
+
+        String targetDir = rootPath + "/resource/100/ServicePortJARA/";
+        checkCode(result, targetDir, "ModuleNameComp.cpp");
+        checkCode(result, targetDir, "ModuleName.h");
+        checkCode(result, targetDir, "ModuleName.cpp");
+        checkCode(result, targetDir, "ManipulatorCommonInterface_CommonSVC_impl.h");
+        checkCode(result, targetDir, "ManipulatorCommonInterface_CommonSVC_impl.cpp");
+    }
 }


### PR DESCRIPTION
## Identify the Bug

Link to #79

## Description of the Change

C++版RTCでサービスインターフェースにJARA_ARMモジュールのインターフェースを指定した場合に，XXXSVC_impl.h, XXXSVC_impl.cppの戻り値に*が設定されておらず，ビルドエラーとなってしまっていたのを修正

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [x] Have you passed the unit tests?  ユニットテストを追加し，修正した内容でコードが生成されることを確認