### PR TITLE
Python版RTCの生成コードのコメントを修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/ConfigSet/ConfigSetType/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/ConfigSet/ConfigSetType/foo.py
@@ -110,7 +110,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -140,7 +139,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -152,7 +150,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -166,7 +163,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -180,7 +176,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -194,7 +189,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -208,7 +202,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -222,7 +215,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -236,7 +228,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -250,7 +241,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -264,7 +254,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -278,7 +267,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/ConfigSet/configset1/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/ConfigSet/configset1/foo.py
@@ -62,7 +62,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -86,7 +85,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -98,7 +96,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -112,7 +109,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -126,7 +122,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -140,7 +135,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -154,7 +148,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -168,7 +161,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -182,7 +174,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -196,7 +187,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -210,7 +200,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -224,7 +213,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/ConfigSet/configset2/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/ConfigSet/configset2/foo.py
@@ -70,7 +70,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -95,7 +94,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -107,7 +105,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -121,7 +118,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -135,7 +131,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -149,7 +144,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -163,7 +157,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -177,7 +170,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -191,7 +183,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -205,7 +196,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -219,7 +209,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -233,7 +222,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/ConfigSet/configset3/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/ConfigSet/configset3/foo.py
@@ -94,7 +94,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -122,7 +121,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -134,7 +132,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -148,7 +145,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -162,7 +158,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -176,7 +171,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -190,7 +184,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -204,7 +197,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -218,7 +210,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -232,7 +223,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -246,7 +236,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -260,7 +249,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/ConfigSet/configset4/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/ConfigSet/configset4/foo.py
@@ -102,7 +102,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -131,7 +130,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -143,7 +141,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -157,7 +154,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -171,7 +167,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -185,7 +180,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -199,7 +193,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -213,7 +206,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -227,7 +219,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -241,7 +232,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -255,7 +245,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -269,7 +258,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/Doc/author/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/Doc/author/foo.py
@@ -87,7 +87,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -118,7 +117,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -130,7 +128,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -144,7 +141,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -158,7 +154,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -172,7 +167,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -186,7 +180,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -200,7 +193,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -214,7 +206,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -228,7 +219,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -242,7 +232,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -256,7 +245,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/Doc/authorLong/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/Doc/authorLong/foo.py
@@ -89,7 +89,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -120,7 +119,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -132,7 +130,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -146,7 +143,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -160,7 +156,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -174,7 +169,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -188,7 +182,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -202,7 +195,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -216,7 +208,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -230,7 +221,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -244,7 +234,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -258,7 +247,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/Doc/full/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/Doc/full/foo.py
@@ -196,7 +196,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     # on_initialize概要説明
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -235,7 +234,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ## on_finalize概要説明
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -250,7 +248,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ## on_startup概要説明
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -267,7 +264,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ## on_shutdown概要説明
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -284,7 +280,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ## on_activated概要説明
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -301,7 +296,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ## on_deactivated概要説明
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -318,7 +312,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ## on_execute概要説明
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -335,7 +328,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ## on_aborting概要説明
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -352,7 +344,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ## on_error概要説明
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -369,7 +360,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ## on_reset概要説明
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -386,7 +376,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ## on_state_update概要説明
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -403,7 +392,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ## on_rate_changed概要説明
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/Doc/refer/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/Doc/refer/foo.py
@@ -96,7 +96,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -127,7 +126,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -139,7 +137,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -153,7 +150,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -167,7 +163,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -181,7 +176,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -195,7 +189,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -209,7 +202,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -223,7 +215,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -237,7 +228,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -251,7 +241,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -265,7 +254,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST1/test.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST1/test.py
@@ -62,7 +62,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -87,7 +86,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -99,7 +97,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -113,7 +110,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -127,7 +123,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -141,7 +136,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -155,7 +149,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -169,7 +162,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -183,7 +175,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -197,7 +188,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -211,7 +201,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -225,7 +214,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST2/test.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST2/test.py
@@ -70,7 +70,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -97,7 +96,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -109,7 +107,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -123,7 +120,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -137,7 +133,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -151,7 +146,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -165,7 +159,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -179,7 +172,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -193,7 +185,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -207,7 +198,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -221,7 +211,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -235,7 +224,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST3/test.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST3/test.py
@@ -77,7 +77,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -106,7 +105,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -118,7 +116,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -132,7 +129,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -146,7 +142,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -160,7 +155,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -174,7 +168,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -188,7 +181,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -202,7 +194,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -216,7 +207,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -230,7 +220,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -244,7 +233,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST4/test.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST4/test.py
@@ -68,7 +68,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -95,7 +94,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -107,7 +105,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -121,7 +118,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -135,7 +131,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -149,7 +144,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -163,7 +157,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -177,7 +170,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -191,7 +183,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -205,7 +196,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -219,7 +209,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -233,7 +222,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST6/test.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST6/test.py
@@ -54,7 +54,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -77,7 +76,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -89,7 +87,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -103,7 +100,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -117,7 +113,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -131,7 +126,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -145,7 +139,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -159,7 +152,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -173,7 +165,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -187,7 +178,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -201,7 +191,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -215,7 +204,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST7/ModuleName.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/aist/AIST7/ModuleName.py
@@ -64,7 +64,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -88,7 +87,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -100,7 +98,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -114,7 +111,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -128,7 +124,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -142,7 +137,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -156,7 +150,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -170,7 +163,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -184,7 +176,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -198,7 +189,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -212,7 +202,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -226,7 +215,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/base/inport1/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/base/inport1/foo.py
@@ -58,7 +58,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -82,7 +81,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -94,7 +92,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -108,7 +105,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -122,7 +118,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -136,7 +131,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -150,7 +144,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -164,7 +157,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -178,7 +170,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -192,7 +183,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -206,7 +196,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -220,7 +209,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/base/inport2/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/base/inport2/foo.py
@@ -62,7 +62,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -87,7 +86,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -99,7 +97,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -113,7 +110,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -127,7 +123,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -141,7 +136,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -155,7 +149,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -169,7 +162,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -183,7 +175,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -197,7 +188,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -211,7 +201,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -225,7 +214,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/base/name/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/base/name/foo.py
@@ -54,7 +54,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -77,7 +76,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -89,7 +87,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -103,7 +100,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -117,7 +113,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -131,7 +126,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -145,7 +139,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -159,7 +152,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -173,7 +165,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -187,7 +178,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -201,7 +191,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -215,7 +204,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/base/name2/Foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/base/name2/Foo.py
@@ -54,7 +54,6 @@ class Foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -77,7 +76,6 @@ class Foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -89,7 +87,6 @@ class Foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -103,7 +100,6 @@ class Foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -117,7 +113,6 @@ class Foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -131,7 +126,6 @@ class Foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -145,7 +139,6 @@ class Foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -159,7 +152,6 @@ class Foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -173,7 +165,6 @@ class Foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -187,7 +178,6 @@ class Foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -201,7 +191,6 @@ class Foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -215,7 +204,6 @@ class Foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/base/outport1/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/base/outport1/foo.py
@@ -66,7 +66,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -92,7 +91,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -104,7 +102,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -118,7 +115,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -132,7 +128,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -146,7 +141,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -160,7 +154,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -174,7 +167,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -188,7 +180,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -202,7 +193,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -216,7 +206,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -230,7 +219,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/base/outport2/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/base/outport2/foo.py
@@ -70,7 +70,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -97,7 +96,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -109,7 +107,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -123,7 +120,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -137,7 +133,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -151,7 +146,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -165,7 +159,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -179,7 +172,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -193,7 +185,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -207,7 +198,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -221,7 +211,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -235,7 +224,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/base/service1/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/base/service1/foo.py
@@ -78,7 +78,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -107,7 +106,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -119,7 +117,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -133,7 +130,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -147,7 +143,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -161,7 +156,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -175,7 +169,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -189,7 +182,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -203,7 +195,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -217,7 +208,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -231,7 +221,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -245,7 +234,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/base/service2/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/base/service2/foo.py
@@ -86,7 +86,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -117,7 +116,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -129,7 +127,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -143,7 +140,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -157,7 +153,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -171,7 +166,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -185,7 +179,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -199,7 +192,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -213,7 +205,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -227,7 +218,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -241,7 +231,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -255,7 +244,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/build/cmake1/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/build/cmake1/foo.py
@@ -86,7 +86,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -117,7 +116,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -129,7 +127,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -143,7 +140,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -157,7 +153,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -171,7 +166,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -185,7 +179,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -199,7 +192,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -213,7 +205,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -227,7 +218,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -241,7 +231,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -255,7 +244,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/build/cmake2/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/build/cmake2/foo.py
@@ -77,7 +77,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -106,7 +105,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -118,7 +116,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -132,7 +129,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -146,7 +142,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -160,7 +155,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -174,7 +168,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -188,7 +181,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -202,7 +194,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -216,7 +207,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -230,7 +220,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -244,7 +233,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/idlinherit/inherit1/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/idlinherit/inherit1/foo.py
@@ -69,7 +69,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -96,7 +95,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -108,7 +106,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -122,7 +119,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -136,7 +132,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -150,7 +145,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -164,7 +158,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -178,7 +171,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -192,7 +184,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -206,7 +197,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -220,7 +210,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -234,7 +223,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/idlinherit/inherit2/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/idlinherit/inherit2/foo.py
@@ -77,7 +77,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -106,7 +105,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -118,7 +116,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -132,7 +129,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -146,7 +142,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -160,7 +155,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -174,7 +168,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -188,7 +181,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -202,7 +194,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -216,7 +207,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -230,7 +220,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -244,7 +233,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/idltype/type1/ModuleName.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/idltype/type1/ModuleName.py
@@ -62,7 +62,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -87,7 +86,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -99,7 +97,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -113,7 +110,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -127,7 +123,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -141,7 +136,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -155,7 +149,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -169,7 +162,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -183,7 +175,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -197,7 +188,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -211,7 +201,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -225,7 +214,6 @@ class ModuleName(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/idltype/type2/test.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/idltype/type2/test.py
@@ -62,7 +62,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -87,7 +86,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -99,7 +97,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -113,7 +110,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -127,7 +123,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -141,7 +136,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -155,7 +149,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -169,7 +162,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -183,7 +175,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -197,7 +188,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -211,7 +201,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -225,7 +214,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/idltype/type3/test.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/idltype/type3/test.py
@@ -62,7 +62,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -87,7 +86,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -99,7 +97,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -113,7 +110,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -127,7 +123,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -141,7 +136,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -155,7 +149,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -169,7 +162,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -183,7 +175,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -197,7 +188,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -211,7 +201,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -225,7 +214,6 @@ class test(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/impl/all/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/impl/all/foo.py
@@ -54,7 +54,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -77,7 +76,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     # 
     # The finalize action (on ALIVE->END transition)
-    # formaer rtc_exiting_entry()
     # 
     # @return RTC::ReturnCode_t
     
@@ -89,7 +87,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The startup action when ExecutionContext startup
-    # former rtc_starting_entry()
     # 
     # @param ec_id target ExecutionContext Id
     #
@@ -103,7 +100,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The shutdown action when ExecutionContext stop
-    # former rtc_stopping_entry()
     #
     # @param ec_id target ExecutionContext Id
     #
@@ -117,7 +113,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The activated action (Active state entry action)
-    # former rtc_active_entry()
     #
     # @param ec_id target ExecutionContext Id
     # 
@@ -131,7 +126,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The deactivated action (Active state exit action)
-    # former rtc_active_exit()
     #
     # @param ec_id target ExecutionContext Id
     #
@@ -145,7 +139,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The execution action that is invoked periodically
-    # former rtc_active_do()
     #
     # @param ec_id target ExecutionContext Id
     #
@@ -159,7 +152,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The aborting action when main logic error occurred.
-    # former rtc_aborting_entry()
     #
     # @param ec_id target ExecutionContext Id
     #
@@ -173,7 +165,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The error action in ERROR state
-    # former rtc_error_do()
     #
     # @param ec_id target ExecutionContext Id
     #
@@ -187,7 +178,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The reset action that is invoked resetting
-    # This is same but different the former rtc_init_entry()
     #
     # @param ec_id target ExecutionContext Id
     #
@@ -201,7 +191,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The state update action that is invoked after onExecute() action
-    # no corresponding operation exists in OpenRTm-aist-0.2.0
     #
     # @param ec_id target ExecutionContext Id
     #
@@ -215,7 +204,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The action that is invoked when execution context's rate is changed
-    # no corresponding operation exists in OpenRTm-aist-0.2.0
     #
     # @param ec_id target ExecutionContext Id
     #

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/impl/execute/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/impl/execute/foo.py
@@ -54,7 +54,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -77,7 +76,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     # 
     # The finalize action (on ALIVE->END transition)
-    # formaer rtc_exiting_entry()
     # 
     # @return RTC::ReturnCode_t
     
@@ -89,7 +87,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -103,7 +100,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The shutdown action when ExecutionContext stop
-    # former rtc_stopping_entry()
     #
     # @param ec_id target ExecutionContext Id
     #
@@ -117,7 +113,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -131,7 +126,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The deactivated action (Active state exit action)
-    # former rtc_active_exit()
     #
     # @param ec_id target ExecutionContext Id
     #
@@ -145,7 +139,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The execution action that is invoked periodically
-    # former rtc_active_do()
     #
     # @param ec_id target ExecutionContext Id
     #
@@ -159,7 +152,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -173,7 +165,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -187,7 +178,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -201,7 +191,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -215,7 +204,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/impl/finalize/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/impl/finalize/foo.py
@@ -54,7 +54,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -77,7 +76,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     # 
     # The finalize action (on ALIVE->END transition)
-    # formaer rtc_exiting_entry()
     # 
     # @return RTC::ReturnCode_t
     
@@ -89,7 +87,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -103,7 +100,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -117,7 +113,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -131,7 +126,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -145,7 +139,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -159,7 +152,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -173,7 +165,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -187,7 +178,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -201,7 +191,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -215,7 +204,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/impl/initialize/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/impl/initialize/foo.py
@@ -54,7 +54,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -77,7 +76,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -89,7 +87,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -103,7 +100,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -117,7 +113,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -131,7 +126,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -145,7 +139,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -159,7 +152,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -173,7 +165,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -187,7 +178,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -201,7 +191,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -215,7 +204,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/module/serviceM/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/module/serviceM/foo.py
@@ -62,7 +62,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -87,7 +86,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -99,7 +97,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -113,7 +110,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -127,7 +123,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -141,7 +136,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -155,7 +149,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -169,7 +162,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -183,7 +175,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -197,7 +188,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -211,7 +201,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -225,7 +214,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/module/serviceM2/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/module/serviceM2/foo.py
@@ -67,7 +67,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -93,7 +92,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -105,7 +103,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -119,7 +116,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -133,7 +129,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -147,7 +142,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -161,7 +155,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -175,7 +168,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -189,7 +181,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -203,7 +194,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -217,7 +207,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -231,7 +220,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/module/serviceMC/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/module/serviceMC/foo.py
@@ -62,7 +62,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -87,7 +86,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -99,7 +97,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -113,7 +110,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -127,7 +123,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -141,7 +136,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -155,7 +149,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -169,7 +162,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -183,7 +175,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -197,7 +188,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -211,7 +201,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -225,7 +214,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/100/module/serviceMC2/foo.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/100/module/serviceMC2/foo.py
@@ -67,7 +67,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ##
     #
     # The initialize action (on CREATED->ALIVE transition)
-    # formaer rtc_init_entry() 
     # 
     # @return RTC::ReturnCode_t
     # 
@@ -93,7 +92,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ## 
     ## The finalize action (on ALIVE->END transition)
-    ## formaer rtc_exiting_entry()
     ## 
     ## @return RTC::ReturnCode_t
     #
@@ -105,7 +103,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The startup action when ExecutionContext startup
-    ## former rtc_starting_entry()
     ## 
     ## @param ec_id target ExecutionContext Id
     ##
@@ -119,7 +116,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The shutdown action when ExecutionContext stop
-    ## former rtc_stopping_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -133,7 +129,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The activated action (Active state entry action)
-    ## former rtc_active_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ## 
@@ -147,7 +142,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The deactivated action (Active state exit action)
-    ## former rtc_active_exit()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -161,7 +155,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The execution action that is invoked periodically
-    ## former rtc_active_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -175,7 +168,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The aborting action when main logic error occurred.
-    ## former rtc_aborting_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -189,7 +181,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The error action in ERROR state
-    ## former rtc_error_do()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -203,7 +194,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The reset action that is invoked resetting
-    ## This is same but different the former rtc_init_entry()
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -217,7 +207,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The state update action that is invoked after onExecute() action
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##
@@ -231,7 +220,6 @@ class foo(OpenRTM_aist.DataFlowComponentBase):
     ###
     ##
     ## The action that is invoked when execution context's rate is changed
-    ## no corresponding operation exists in OpenRTm-aist-0.2.0
     ##
     ## @param ec_id target ExecutionContext Id
     ##

--- a/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/Py_RTC.py.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/Py_RTC.py.vsl
@@ -247,7 +247,6 @@ class ${rtcParam.name}(OpenRTM_aist.DataFlowComponentBase):
 #end
     ${sharp}
     ${sharp} The initialize action (on CREATED->ALIVE transition)
-    ${sharp} formaer rtc_init_entry() 
     ${sharp} 
     ${sharp} @return RTC::ReturnCode_t
     ${sharp} 
@@ -306,7 +305,6 @@ class ${rtcParam.name}(OpenRTM_aist.DataFlowComponentBase):
 #end
     #if(${rtcParam.IsNotImplemented(1)})${sharp}#end${sharp} 
     #if(${rtcParam.IsNotImplemented(1)})${sharp}#end${sharp} The finalize action (on ALIVE->END transition)
-    #if(${rtcParam.IsNotImplemented(1)})${sharp}#end${sharp} formaer rtc_exiting_entry()
     #if(${rtcParam.IsNotImplemented(1)})${sharp}#end${sharp} 
     #if(${rtcParam.IsNotImplemented(1)})${sharp}#end${sharp} @return RTC::ReturnCode_t
     #if(${rtcParam.IsNotImplemented(1)})${sharp}#end
@@ -328,7 +326,6 @@ class ${rtcParam.name}(OpenRTM_aist.DataFlowComponentBase):
 #end
     #if(${rtcParam.IsNotImplemented(2)})${sharp}#end${sharp}
     #if(${rtcParam.IsNotImplemented(2)})${sharp}#end${sharp} The startup action when ExecutionContext startup
-    #if(${rtcParam.IsNotImplemented(2)})${sharp}#end${sharp} former rtc_starting_entry()
     #if(${rtcParam.IsNotImplemented(2)})${sharp}#end${sharp} 
     #if(${rtcParam.IsNotImplemented(2)})${sharp}#end${sharp} @param ec_id target ExecutionContext Id
     #if(${rtcParam.IsNotImplemented(2)})${sharp}#end${sharp}
@@ -351,7 +348,6 @@ class ${rtcParam.name}(OpenRTM_aist.DataFlowComponentBase):
 #end
     #if(${rtcParam.IsNotImplemented(3)})${sharp}#end${sharp}
     #if(${rtcParam.IsNotImplemented(3)})${sharp}#end${sharp} The shutdown action when ExecutionContext stop
-    #if(${rtcParam.IsNotImplemented(3)})${sharp}#end${sharp} former rtc_stopping_entry()
     #if(${rtcParam.IsNotImplemented(3)})${sharp}#end${sharp}
     #if(${rtcParam.IsNotImplemented(3)})${sharp}#end${sharp} @param ec_id target ExecutionContext Id
     #if(${rtcParam.IsNotImplemented(3)})${sharp}#end${sharp}
@@ -374,7 +370,6 @@ class ${rtcParam.name}(OpenRTM_aist.DataFlowComponentBase):
 #end
     #if(${rtcParam.IsNotImplemented(4)})${sharp}#end${sharp}
     #if(${rtcParam.IsNotImplemented(4)})${sharp}#end${sharp} The activated action (Active state entry action)
-    #if(${rtcParam.IsNotImplemented(4)})${sharp}#end${sharp} former rtc_active_entry()
     #if(${rtcParam.IsNotImplemented(4)})${sharp}#end${sharp}
     #if(${rtcParam.IsNotImplemented(4)})${sharp}#end${sharp} @param ec_id target ExecutionContext Id
     #if(${rtcParam.IsNotImplemented(4)})${sharp}#end${sharp} 
@@ -397,7 +392,6 @@ class ${rtcParam.name}(OpenRTM_aist.DataFlowComponentBase):
 #end
     #if(${rtcParam.IsNotImplemented(5)})${sharp}#end${sharp}
     #if(${rtcParam.IsNotImplemented(5)})${sharp}#end${sharp} The deactivated action (Active state exit action)
-    #if(${rtcParam.IsNotImplemented(5)})${sharp}#end${sharp} former rtc_active_exit()
     #if(${rtcParam.IsNotImplemented(5)})${sharp}#end${sharp}
     #if(${rtcParam.IsNotImplemented(5)})${sharp}#end${sharp} @param ec_id target ExecutionContext Id
     #if(${rtcParam.IsNotImplemented(5)})${sharp}#end${sharp}
@@ -420,7 +414,6 @@ class ${rtcParam.name}(OpenRTM_aist.DataFlowComponentBase):
 #end
     #if(${rtcParam.IsNotImplemented(9)})${sharp}#end${sharp}
     #if(${rtcParam.IsNotImplemented(9)})${sharp}#end${sharp} The execution action that is invoked periodically
-    #if(${rtcParam.IsNotImplemented(9)})${sharp}#end${sharp} former rtc_active_do()
     #if(${rtcParam.IsNotImplemented(9)})${sharp}#end${sharp}
     #if(${rtcParam.IsNotImplemented(9)})${sharp}#end${sharp} @param ec_id target ExecutionContext Id
     #if(${rtcParam.IsNotImplemented(9)})${sharp}#end${sharp}
@@ -443,7 +436,6 @@ class ${rtcParam.name}(OpenRTM_aist.DataFlowComponentBase):
 #end
     #if(${rtcParam.IsNotImplemented(6)})${sharp}#end${sharp}
     #if(${rtcParam.IsNotImplemented(6)})${sharp}#end${sharp} The aborting action when main logic error occurred.
-    #if(${rtcParam.IsNotImplemented(6)})${sharp}#end${sharp} former rtc_aborting_entry()
     #if(${rtcParam.IsNotImplemented(6)})${sharp}#end${sharp}
     #if(${rtcParam.IsNotImplemented(6)})${sharp}#end${sharp} @param ec_id target ExecutionContext Id
     #if(${rtcParam.IsNotImplemented(6)})${sharp}#end${sharp}
@@ -466,7 +458,6 @@ class ${rtcParam.name}(OpenRTM_aist.DataFlowComponentBase):
 #end
     #if(${rtcParam.IsNotImplemented(7)})${sharp}#end${sharp}
     #if(${rtcParam.IsNotImplemented(7)})${sharp}#end${sharp} The error action in ERROR state
-    #if(${rtcParam.IsNotImplemented(7)})${sharp}#end${sharp} former rtc_error_do()
     #if(${rtcParam.IsNotImplemented(7)})${sharp}#end${sharp}
     #if(${rtcParam.IsNotImplemented(7)})${sharp}#end${sharp} @param ec_id target ExecutionContext Id
     #if(${rtcParam.IsNotImplemented(7)})${sharp}#end${sharp}
@@ -489,7 +480,6 @@ class ${rtcParam.name}(OpenRTM_aist.DataFlowComponentBase):
 #end
     #if(${rtcParam.IsNotImplemented(8)})${sharp}#end${sharp}
     #if(${rtcParam.IsNotImplemented(8)})${sharp}#end${sharp} The reset action that is invoked resetting
-    #if(${rtcParam.IsNotImplemented(8)})${sharp}#end${sharp} This is same but different the former rtc_init_entry()
     #if(${rtcParam.IsNotImplemented(8)})${sharp}#end${sharp}
     #if(${rtcParam.IsNotImplemented(8)})${sharp}#end${sharp} @param ec_id target ExecutionContext Id
     #if(${rtcParam.IsNotImplemented(8)})${sharp}#end${sharp}
@@ -512,7 +502,6 @@ class ${rtcParam.name}(OpenRTM_aist.DataFlowComponentBase):
 #end
     #if(${rtcParam.IsNotImplemented(10)})${sharp}#end${sharp}
     #if(${rtcParam.IsNotImplemented(10)})${sharp}#end${sharp} The state update action that is invoked after onExecute() action
-    #if(${rtcParam.IsNotImplemented(10)})${sharp}#end${sharp} no corresponding operation exists in OpenRTm-aist-0.2.0
     #if(${rtcParam.IsNotImplemented(10)})${sharp}#end${sharp}
     #if(${rtcParam.IsNotImplemented(10)})${sharp}#end${sharp} @param ec_id target ExecutionContext Id
     #if(${rtcParam.IsNotImplemented(10)})${sharp}#end${sharp}
@@ -536,7 +525,6 @@ class ${rtcParam.name}(OpenRTM_aist.DataFlowComponentBase):
 #end
     #if(${rtcParam.IsNotImplemented(11)})${sharp}#end${sharp}
     #if(${rtcParam.IsNotImplemented(11)})${sharp}#end${sharp} The action that is invoked when execution context's rate is changed
-    #if(${rtcParam.IsNotImplemented(11)})${sharp}#end${sharp} no corresponding operation exists in OpenRTm-aist-0.2.0
     #if(${rtcParam.IsNotImplemented(11)})${sharp}#end${sharp}
     #if(${rtcParam.IsNotImplemented(11)})${sharp}#end${sharp} @param ec_id target ExecutionContext Id
     #if(${rtcParam.IsNotImplemented(11)})${sharp}#end${sharp}


### PR DESCRIPTION
## Identify the Bug

Link to #124

## Description of the Change

Python版RTCのコメント部分にあった｢former｣や｢in OpenRTm-aist-0.2.0｣などの記述を削除させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [x] Have you passed the unit tests?  既存のユニットテストを修正し，修正した内容でコードが生成されることを確認