### PR TITLE
Java版RTCの生成コードのコメントを修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/AIST6/src/ModuleNameImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/AIST6/src/ModuleNameImpl.java
@@ -29,7 +29,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /*!
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -47,7 +46,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -60,7 +58,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -75,7 +72,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -90,7 +86,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -105,7 +100,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -120,7 +114,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -135,7 +128,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -150,7 +142,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -165,7 +156,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -180,7 +170,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -195,7 +184,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/AIST7/src/ModuleNameImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/AIST7/src/ModuleNameImpl.java
@@ -29,7 +29,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /*!
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -46,7 +45,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -59,7 +57,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -74,7 +71,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -89,7 +85,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -104,7 +99,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -119,7 +113,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -134,7 +127,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -149,7 +141,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -164,7 +155,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -179,7 +169,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -194,7 +183,6 @@ public class ModuleNameImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/ConfigSetType/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/ConfigSetType/src/fooImpl.java
@@ -34,7 +34,6 @@ public class fooImpl extends DataFlowComponentBase {
     /*!
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -57,7 +56,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -70,7 +68,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -85,7 +82,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -100,7 +96,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -115,7 +110,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -130,7 +124,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -145,7 +138,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -160,7 +152,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -175,7 +166,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -190,7 +180,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -205,7 +194,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/configset1/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/configset1/src/fooImpl.java
@@ -29,7 +29,6 @@ public class fooImpl extends DataFlowComponentBase {
     /*!
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -46,7 +45,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -59,7 +57,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -74,7 +71,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -89,7 +85,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -104,7 +99,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -119,7 +113,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -134,7 +127,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -149,7 +141,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -164,7 +155,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -179,7 +169,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -194,7 +183,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/configset2/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/configset2/src/fooImpl.java
@@ -29,7 +29,6 @@ public class fooImpl extends DataFlowComponentBase {
     /*!
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -47,7 +46,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -60,7 +58,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -75,7 +72,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -90,7 +86,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -105,7 +100,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -120,7 +114,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -135,7 +128,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -150,7 +142,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -165,7 +156,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -180,7 +170,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -195,7 +184,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/configset3/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/ConfigSet/configset3/src/fooImpl.java
@@ -31,7 +31,6 @@ public class fooImpl extends DataFlowComponentBase {
     /*!
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -52,7 +51,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -65,7 +63,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -80,7 +77,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -95,7 +91,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -110,7 +105,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -125,7 +119,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -140,7 +133,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -155,7 +147,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -170,7 +161,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -185,7 +175,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -200,7 +189,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/Multi/ConMulti/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/Multi/ConMulti/src/fooImpl.java
@@ -50,7 +50,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -79,7 +78,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -92,7 +90,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -107,7 +104,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -122,7 +118,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -137,7 +132,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -152,7 +146,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -167,7 +160,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -182,7 +174,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -197,7 +188,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -212,7 +202,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -227,7 +216,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/Multi/ProConMulti/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/Multi/ProConMulti/src/fooImpl.java
@@ -55,7 +55,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -98,7 +97,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -111,7 +109,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -126,7 +123,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -141,7 +137,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -156,7 +151,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -171,7 +165,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -186,7 +179,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -201,7 +193,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -216,7 +207,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -231,7 +221,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -246,7 +235,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/Multi/ProMulti/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/Multi/ProMulti/src/fooImpl.java
@@ -52,7 +52,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -91,7 +90,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -104,7 +102,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -119,7 +116,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -134,7 +130,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -149,7 +144,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -164,7 +158,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -179,7 +172,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -194,7 +186,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -209,7 +200,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -224,7 +214,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -239,7 +228,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/inport1/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/inport1/src/fooImpl.java
@@ -40,7 +40,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -58,7 +57,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -71,7 +69,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -86,7 +83,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -101,7 +97,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -116,7 +111,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -131,7 +125,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -146,7 +139,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -161,7 +153,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -176,7 +167,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -191,7 +181,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -206,7 +195,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/inport2/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/inport2/src/fooImpl.java
@@ -45,7 +45,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -64,7 +63,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -77,7 +75,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -92,7 +89,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -107,7 +103,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -122,7 +117,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -137,7 +131,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -152,7 +145,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -167,7 +159,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -182,7 +173,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -197,7 +187,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -212,7 +201,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/name/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/name/src/fooImpl.java
@@ -27,7 +27,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -43,7 +42,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -56,7 +54,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -71,7 +68,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -86,7 +82,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -101,7 +96,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -116,7 +110,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -131,7 +124,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -146,7 +138,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -161,7 +152,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -176,7 +166,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -191,7 +180,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/outport1/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/outport1/src/fooImpl.java
@@ -50,7 +50,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -72,7 +71,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -85,7 +83,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -100,7 +97,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -115,7 +111,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -130,7 +125,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -145,7 +139,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -160,7 +153,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -175,7 +167,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -190,7 +181,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -205,7 +195,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -220,7 +209,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/outport2/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/outport2/src/fooImpl.java
@@ -55,7 +55,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -78,7 +77,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -91,7 +89,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -106,7 +103,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -121,7 +117,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -136,7 +131,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -151,7 +145,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -166,7 +159,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -181,7 +173,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -196,7 +187,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -211,7 +201,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -226,7 +215,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/service1/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/service1/src/fooImpl.java
@@ -60,7 +60,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -99,7 +98,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -112,7 +110,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -127,7 +124,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -142,7 +138,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -157,7 +152,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -172,7 +166,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -187,7 +180,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -202,7 +194,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -217,7 +208,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -232,7 +222,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -247,7 +236,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/service2/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/base/service2/src/fooImpl.java
@@ -62,7 +62,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -103,7 +102,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -116,7 +114,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -131,7 +128,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -146,7 +142,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -161,7 +156,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -176,7 +170,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -191,7 +184,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -206,7 +198,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -221,7 +212,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -236,7 +226,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -251,7 +240,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/build/cmake1/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/build/cmake1/src/fooImpl.java
@@ -63,7 +63,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -104,7 +103,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -117,7 +115,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -132,7 +129,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -147,7 +143,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -162,7 +157,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -177,7 +171,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -192,7 +185,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -207,7 +199,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -222,7 +213,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -237,7 +227,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -252,7 +241,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/build/cmake2/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/build/cmake2/src/fooImpl.java
@@ -35,7 +35,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -71,7 +70,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -84,7 +82,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -99,7 +96,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -114,7 +110,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -129,7 +124,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -144,7 +138,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -159,7 +152,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -174,7 +166,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -189,7 +180,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -204,7 +194,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -219,7 +208,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/idlinherit/inherit1/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/idlinherit/inherit1/src/fooImpl.java
@@ -35,7 +35,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -69,7 +68,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -82,7 +80,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -97,7 +94,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -112,7 +108,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -127,7 +122,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -142,7 +136,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -157,7 +150,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -172,7 +164,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -187,7 +178,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -202,7 +192,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -217,7 +206,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/idlinherit/inherit2/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/idlinherit/inherit2/src/fooImpl.java
@@ -35,7 +35,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -71,7 +70,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -84,7 +82,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -99,7 +96,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -114,7 +110,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -129,7 +124,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -144,7 +138,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -159,7 +152,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -174,7 +166,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -189,7 +180,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -204,7 +194,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -219,7 +208,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/idltype/type1/src/testImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/idltype/type1/src/testImpl.java
@@ -33,7 +33,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -65,7 +64,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -78,7 +76,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -93,7 +90,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -108,7 +104,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -123,7 +118,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -138,7 +132,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -153,7 +146,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -168,7 +160,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -183,7 +174,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -198,7 +188,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -213,7 +202,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/idltype/type2/src/testImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/idltype/type2/src/testImpl.java
@@ -33,7 +33,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -65,7 +64,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -78,7 +76,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -93,7 +90,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -108,7 +104,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -123,7 +118,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -138,7 +132,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -153,7 +146,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -168,7 +160,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -183,7 +174,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -198,7 +188,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -213,7 +202,6 @@ public class testImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/module/serviceCon/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/module/serviceCon/src/fooImpl.java
@@ -32,7 +32,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -54,7 +53,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -67,7 +65,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -82,7 +79,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -97,7 +93,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -112,7 +107,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -127,7 +121,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -142,7 +135,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -157,7 +149,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -172,7 +163,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -187,7 +177,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -202,7 +191,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/module/serviceM/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/module/serviceM/src/fooImpl.java
@@ -33,7 +33,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -65,7 +64,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -78,7 +76,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -93,7 +90,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -108,7 +104,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -123,7 +118,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -138,7 +132,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -153,7 +146,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -168,7 +160,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -183,7 +174,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -198,7 +188,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -213,7 +202,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/100/module/serviceMC/src/fooImpl.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/100/module/serviceMC/src/fooImpl.java
@@ -36,7 +36,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -70,7 +69,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -83,7 +81,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -98,7 +95,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -113,7 +109,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -128,7 +123,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -143,7 +137,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -158,7 +151,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -173,7 +165,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -188,7 +179,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -203,7 +193,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -218,7 +207,6 @@ public class fooImpl extends DataFlowComponentBase {
     /**
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *

--- a/jp.go.aist.rtm.rtcbuilder.java/src/jp/go/aist/rtm/rtcbuilder/java/template/java/Java_RTC_Impl.java.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.java/src/jp/go/aist/rtm/rtcbuilder/java/template/java/Java_RTC_Impl.java.vsl
@@ -124,7 +124,6 @@ public class ${rtcParam.name}Impl extends DataFlowComponentBase {
 #end
      *
      * The initialize action (on CREATED-&gt;ALIVE transition)
-     * former rtc_init_entry() 
      *
      * @return RTC::ReturnCode_t
      * 
@@ -210,7 +209,6 @@ public class ${rtcParam.name}Impl extends DataFlowComponentBase {
 #end
      *
      * The finalize action (on ALIVE-&gt;END transition)
-     * former rtc_exiting_entry()
      *
      * @return RTC::ReturnCode_t
      * 
@@ -232,7 +230,6 @@ public class ${rtcParam.name}Impl extends DataFlowComponentBase {
 #end
      *
      * The startup action when ExecutionContext startup
-     * former rtc_starting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -256,7 +253,6 @@ public class ${rtcParam.name}Impl extends DataFlowComponentBase {
 #end
      *
      * The shutdown action when ExecutionContext stop
-     * former rtc_stopping_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -280,7 +276,6 @@ public class ${rtcParam.name}Impl extends DataFlowComponentBase {
 #end
      *
      * The activated action (Active state entry action)
-     * former rtc_active_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -304,7 +299,6 @@ public class ${rtcParam.name}Impl extends DataFlowComponentBase {
 #end
      *
      * The deactivated action (Active state exit action)
-     * former rtc_active_exit()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -328,7 +322,6 @@ public class ${rtcParam.name}Impl extends DataFlowComponentBase {
 #end
      *
      * The execution action that is invoked periodically
-     * former rtc_active_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -352,7 +345,6 @@ public class ${rtcParam.name}Impl extends DataFlowComponentBase {
 #end
      *
      * The aborting action when main logic error occurred.
-     * former rtc_aborting_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -376,7 +368,6 @@ public class ${rtcParam.name}Impl extends DataFlowComponentBase {
 #end
      *
      * The error action in ERROR state
-     * former rtc_error_do()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -400,7 +391,6 @@ public class ${rtcParam.name}Impl extends DataFlowComponentBase {
 #end
      *
      * The reset action that is invoked resetting
-     * This is same but different the former rtc_init_entry()
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -424,7 +414,6 @@ public class ${rtcParam.name}Impl extends DataFlowComponentBase {
 #end
      *
      * The state update action that is invoked after onExecute() action
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *
@@ -448,7 +437,6 @@ public class ${rtcParam.name}Impl extends DataFlowComponentBase {
 #end
      *
      * The action that is invoked when execution context's rate is changed
-     * no corresponding operation exists in OpenRTm-aist-0.2.0
      *
      * @param ec_id target ExecutionContext Id
      *


### PR DESCRIPTION
## Identify the Bug

Link to #125

## Description of the Change

Java版RTCのコメント部分にあった｢former｣や｢in OpenRTm-aist-0.2.0｣などの記述を削除させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [x] Have you passed the unit tests?  既存のユニットテストを修正し，修正した内容でコードが生成されることを確認