### PR TITLE
AppVeyor設定ファイルを出力するように修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/XXX/test/src/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/XXX/test/src/CMakeLists.txt
@@ -52,4 +52,4 @@ add_dependencies(${PROJECT_NAME}Test ${PROJECT_NAME})
 target_link_libraries(${PROJECT_NAME}Test ${OPENRTM_LIBRARIES} ${PROJECT_NAME})
 set_property(TARGET ${PROJECT_NAME}Test PROPERTY CXX_STANDARD 11)
 
-add_test(NAME ${PROJECT_NAME}_test COMMAND $<TARGET_FILE:${PROJECT_NAME}Test> -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:${PROJECT_NAME}0.in?port=${PROJECT_NAME}Test0.in,${PROJECT_NAME}0.out?port=${PROJECT_NAME}Test0.out,${PROJECT_NAME}0.MyServide?port=${PROJECT_NAME}Test0.MyServide" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0")
+add_test(NAME ${PROJECT_NAME}_test COMMAND $<TARGET_FILE:${PROJECT_NAME}Test> -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:${PROJECT_NAME}0.in?port=${PROJECT_NAME}Test0.in,${PROJECT_NAME}0.out?port=${PROJECT_NAME}Test0.out,${PROJECT_NAME}0.MyServide?port=${PROJECT_NAME}Test0.MyServide" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/YYY/test/src/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/YYY/test/src/CMakeLists.txt
@@ -52,4 +52,4 @@ add_dependencies(${PROJECT_NAME}Test ${PROJECT_NAME})
 target_link_libraries(${PROJECT_NAME}Test ${OPENRTM_LIBRARIES} ${PROJECT_NAME})
 set_property(TARGET ${PROJECT_NAME}Test PROPERTY CXX_STANDARD 11)
 
-add_test(NAME ${PROJECT_NAME}_test COMMAND $<TARGET_FILE:${PROJECT_NAME}Test> -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:${PROJECT_NAME}0.MyService?port=${PROJECT_NAME}Test0.MyService" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0")
+add_test(NAME ${PROJECT_NAME}_test COMMAND $<TARGET_FILE:${PROJECT_NAME}Test> -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:${PROJECT_NAME}0.MyService?port=${PROJECT_NAME}Test0.MyService" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/manager/CXXGenerateManager.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/manager/CXXGenerateManager.java
@@ -82,6 +82,7 @@ public class CXXGenerateManager extends GenerateManager {
 		
 		result.add(generateScript1604(contextMap));
 		result.add(generateScript1804(contextMap));
+		result.add(generateAppVeyorTemplate(contextMap));
 		
 		if(isStaticFSM) {
 			result.add(generateFSMHeader(contextMap));
@@ -254,6 +255,12 @@ public class CXXGenerateManager extends GenerateManager {
 		outfile = "test/src/" + TemplateHelper.getBasename(idlParam.getIdlFileNoExt())
 					+ TemplateHelper.getServiceImplSuffix() + ".cpp";
 		String infile = "cpp/test/CXX_Test_SVC.cpp.vsl";
+		return generate(infile, outfile, contextMap);
+	}
+	
+	public GeneratedResult generateAppVeyorTemplate(Map<String, Object> contextMap) {
+		String outfile = ".appveyor.yml";
+		String infile = "cpp/appveyor.vsl";
 		return generate(infile, outfile, contextMap);
 	}
 	/////

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/manager/CommonGenerateManager.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/manager/CommonGenerateManager.java
@@ -55,7 +55,7 @@ public class CommonGenerateManager extends GenerateManager {
 		result.add(generateREADME(contextMap));
 		result.add(generateRTCConf10(contextMap));
 		result.add(generateComponentConf(contextMap));
-		result.add(generateCITemplate(contextMap));
+		result.add(generateTravisTemplate(contextMap));
 
 		return result;
 	}
@@ -91,7 +91,7 @@ public class CommonGenerateManager extends GenerateManager {
 		return result;
 	}
 
-	public GeneratedResult generateCITemplate(Map<String, Object> contextMap) {
+	public GeneratedResult generateTravisTemplate(Map<String, Object> contextMap) {
 		String outfile = ".travis.yml";
 		String infile = "common/travis.vsl";
 		return generate(infile, outfile, contextMap);

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/test/src/SrcCMakeLists.txt.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/test/src/SrcCMakeLists.txt.vsl
@@ -52,4 +52,4 @@ add_dependencies(${PROJECT_NAME}Test ${PROJECT_NAME})
 target_link_libraries(${PROJECT_NAME}Test ${OPENRTM_LIBRARIES} ${PROJECT_NAME})
 set_property(TARGET ${PROJECT_NAME}Test PROPERTY CXX_STANDARD 11)
 
-add_test(NAME ${PROJECT_NAME}_test COMMAND $<TARGET_FILE:${PROJECT_NAME}Test> -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:${tmpltHelper.getConnectorString(${rtcParam})}" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0")
+add_test(NAME ${dol}{PROJECT_NAME}_test COMMAND ${dol}<TARGET_FILE:${dol}{PROJECT_NAME}Test> -o "manager.components.precreate:${dol}{PROJECT_NAME}" -o "manager.components.preconnect:${tmpltHelper.getConnectorString(${rtcParam})}" -o "manager.components.preactivation:${dol}{PROJECT_NAME}0,${dol}{PROJECT_NAME}Test0" WORKING_DIRECTORY ${dol}{CMAKE_BINARY_DIR})

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/appveyor.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/appveyor.vsl
@@ -1,0 +1,81 @@
+version: '{build}'
+clone_folder: c:\workspace\\${rtcParam.name}
+platform:
+- x64
+environment:
+  openrtm_version: 1.2.0
+  CTEST_OUTPUT_ON_FAILURE: 1
+  matrix:
+    - cmake_generator: Visual Studio 15 2017
+      cmake_archtecture: x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      python: 37-x64
+matrix:
+  fast_finish: true
+
+init:
+  - git config --global core.autocrlf false
+  - ps: ${dol}Env:APPVEYOR_BUILD_WORKER_IMAGE
+  - ps: ${dol}Env:cmake_generator
+  - ps: ${dol}Env:cmake_archtecture
+  - ps: |
+      switch (${dol}Env:cmake_archtecture) {
+        "x64" { ${dol}arch = "x86_64" }
+        "x86" { ${dol}arch = "x86" }
+        "arm" { ${dol}arch = "arm" }
+        default {throw "invalid architecture."}
+      }
+      ${dol}openrtm = "OpenRTM-aist-${dol}{Env:openrtm_version}"
+      ${dol}openrtm_url = "https://github.com/OpenRTM/OpenRTM-aist/releases/download/v${dol}{Env:openrtm_version}/${dol}{openrtm}-RELEASE_${dol}{arch}.msi"
+      ${dol}Env:Path = "C:\Python${dol}{Env:python};c:\Python${dol}{Env:python}\scripts;${dol}{Env:Path}"
+  - ps: ${dol}Env:omni
+  - python --version
+
+before_build:
+  - ps: |
+      ${dol}Env:openrtm_path = "c:\openrtm\\${dol}{openrtm}_${dol}{Env:cmake_archtecture}"
+      if(-NOT (Test-Path "${dol}{Env:openrtm_path}\OpenRTM-aist")){
+        New-Item "${dol}{Env:openrtm_path}" -ItemType Directory
+        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;
+        Invoke-WebRequest -Uri ${dol}openrtm_url -OutFile "${dol}{Env:TEMP}\\${dol}{openrtm}.msi"
+        ${dol}arg = "/a `"${dol}{Env:TEMP}\\${dol}{openrtm}.msi`" targetdir=${dol}{Env:openrtm_path} /qn  /li `"c:\openrtm\install.log`""
+        ${dol}msi = Start-Process msiexec.exe -ArgumentList ${dol}arg -PassThru
+        Wait-Process -Id (${dol}msi.id)
+      }
+  - set RTM_ROOT=%openrtm_path%\OpenRTM-aist\%openrtm_version%\
+  - cmake --version
+  - echo cmake -DBUILD_TESTS=ON -DOpenRTM_DIR=%openrtm_path%/OpenRTM-aist/%openrtm_version%/cmake -G "%cmake_generator%" -A "%cmake_archtecture%" -S . -B../build
+  - cmake -DBUILD_TESTS=ON -DOpenRTM_DIR=%openrtm_path%/OpenRTM-aist/%openrtm_version%/cmake -G "%cmake_generator%" -A "%cmake_archtecture%" -S . -B../build
+
+build_script:
+  - ps: |
+      ${dol}vc_types = Get-ChildItem "${dol}{Env:openrtm_path}\OpenRTM-aist\\${dol}{Env:openrtm_version}\bin\*"
+      ${dol}omni_types = Get-ChildItem "${dol}{Env:openrtm_path}\OpenRTM-aist\\${dol}{Env:openrtm_version}\omniORB\*"
+      foreach(${dol}vc_type in ${dol}vc_types){
+          if(${dol}vc_type.PSIsContainer){
+                  ${dol}Env:Path = "${dol}{vc_type};${dol}{Env:Path}"
+          }
+      }
+      foreach(${dol}omni_type in ${dol}omni_types){
+          if(${dol}omni_type.PSIsContainer){
+                  ${dol}Env:Path = "${dol}{omni_type}\bin\x86_win32;${dol}{Env:Path}"
+          }
+      }
+  - ps: ${dol}Env:nproc = (Get-WmiObject -Class Win32_Processor).NumberOfLogicalProcessors + 1
+  - echo cmake --build ../build -j %nproc% --config Release
+  - cmake --build ../build -j %nproc% --config Release
+  - set PATH=%CD%\..\build\src\Release;%PATH%
+  - echo cmake --build ../build --target RUN_TESTS --config Release
+  - cmake --build ../build --target RUN_TESTS --config Release
+
+
+cache:
+  - C:/openrtm -> .appveyor.yml
+
+only_commits:
+  files:
+    - .appveyor.yml
+    - CMakeLists.txt
+    - include/
+    - src/
+    - test/

--- a/jp.go.aist.rtm.rtcbuilder/test/jp/go/aist/rtm/rtcbuilder/_test/TestBase.java
+++ b/jp.go.aist.rtm.rtcbuilder/test/jp/go/aist/rtm/rtcbuilder/_test/TestBase.java
@@ -17,7 +17,7 @@ public class TestBase extends TestCase {
 	protected String expPath;
 	protected String expContent;
 	protected int index;
-	protected final int default_file_num = 36;
+	protected final int default_file_num = 37;
 
 	public TestBase () {
 		File fileCurrent = new File(".");


### PR DESCRIPTION
## Identify the Bug

Link to #117

## Description of the Change

ご連絡を頂きましたサンプルを基に，C++版RTCのAppVeyor設定ファイルを追加しました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [x] Have you passed the unit tests?  既存のユニットテストを修正し，修正した内容でコードが生成されることを確認