### PR TITLE
IDLファイルのチェック方法を修正(REL_ENG_1_2)

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/Generator.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/Generator.java
@@ -231,8 +231,9 @@ public class Generator {
 		List<ServiceClassParam> serviceClassParamList = new ArrayList<ServiceClassParam>();
 		List<String> serviceClassNameList = new ArrayList<String>();
 		for( ServiceClassParam serviceClassParam : rtcServiceClasses ) {
-			if( !serviceClassNameList.contains(serviceClassParam.getName()) ) {
-				serviceClassNameList.add(serviceClassParam.getName());
+			String checkKey = serviceClassParam.getName() + "::" + serviceClassParam.getIdlPath();
+			if( !serviceClassNameList.contains(checkKey) ) {
+				serviceClassNameList.add(checkKey);
 				serviceClassParamList.add(serviceClassParam);
 			}
 		}

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/generator/param/RtcParam.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/generator/param/RtcParam.java
@@ -549,7 +549,7 @@ public class RtcParam extends AbstractRecordedParam implements Serializable {
 	public List<IdlFileParam> getConsumerIdlPathes() {
 		return consumerIdlPathes;
 	}
-	
+
 	public boolean checkWithoutDefaultPathes() {
 		if(0<providerIdlPathes.size()) {
 			for(IdlFileParam e : providerIdlPathes) {
@@ -704,6 +704,8 @@ public class RtcParam extends AbstractRecordedParam implements Serializable {
 		}
 		/////
 		for( DataPortParam target : inports ) {
+			if(checkExistIDL(providerIdlParams, consumerIdlParams, target)) continue;
+
 			List<String> localIdlPathes = new ArrayList<String>();
 			checkAndAddIDLPath(target.getType(), localIdlPathes, consumerIdlStrings, consumerIdlParams);
 			if(0<localIdlPathes.size()) {
@@ -712,6 +714,8 @@ public class RtcParam extends AbstractRecordedParam implements Serializable {
 			}
 		}
 		for( DataPortParam target : outports ) {
+			if(checkExistIDL(providerIdlParams, consumerIdlParams, target)) continue;
+
 			List<String> localIdlPathes = new ArrayList<String>();
 			checkAndAddIDLPath(target.getType(), localIdlPathes, consumerIdlStrings, consumerIdlParams);
 			if(0<localIdlPathes.size()) {
@@ -764,6 +768,24 @@ public class RtcParam extends AbstractRecordedParam implements Serializable {
 		getLibraryPathes().clear();
 		getLibraryPathes().addAll(libraries);
 		// this.setLibraryPathes(libraries);
+	}
+
+	private boolean checkExistIDL(List<IdlFileParam> providerIdlParams, List<IdlFileParam> consumerIdlParams,
+			DataPortParam target) {
+		boolean isExist = false;
+		for(IdlFileParam param : consumerIdlParams) {
+			if(param.getIdlFile().equals(target.getIdlFile())) {
+				isExist = true;
+				break;
+			}
+		}
+		for(IdlFileParam param : providerIdlParams) {
+			if(param.getIdlPath().equals(target.getIdlFile())) {
+				isExist = true;
+				break;
+			}
+		}
+		return isExist;
 	}
 
 	private void checkAndAddIDLPath(String targetType, List<String> idlPathes,


### PR DESCRIPTION
## Identify the Bug

Link to #165

## Description of the Change

データポートとサービスポートで同じIDLファイルを使用している場合に，対象IDLファイルがコード生成対象から外れてしまうのを修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse4.7.3を使用
- [x] No warnings for the build?  Windows上でEclipse4.7.3を使用
- [ ] Have you passed the unit tests? ユニットテストなし