### PR TITLE
AppVeyor設定ファイルを出力するように修正(Python)

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/manager/PythonGenerateManager.java
+++ b/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/manager/PythonGenerateManager.java
@@ -124,6 +124,7 @@ public class PythonGenerateManager extends GenerateManager {
 		
 		result.add(generateScript1604(contextMap));
 		result.add(generateScript1804(contextMap));
+		result.add(generateAppVeyorTemplate(contextMap));
 
 		if ( 0<allIdlFileParams.size() ) {
 			result.add(generateIDLCompileBat(contextMap));
@@ -216,6 +217,12 @@ public class PythonGenerateManager extends GenerateManager {
 	public GeneratedResult generateScript1804(Map<String, Object> contextMap) {
 		String outfile = "scripts/ubuntu_1804/Dockerfile";
 		String infile = "python/scripts/Dockerfile_ubuntu_1804.vsl";
+		return generate(infile, outfile, contextMap);
+	}
+	
+	public GeneratedResult generateAppVeyorTemplate(Map<String, Object> contextMap) {
+		String outfile = ".appveyor.yml";
+		String infile = "python/appveyor.vsl";
 		return generate(infile, outfile, contextMap);
 	}
 	//////////

--- a/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/appveyor.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/appveyor.vsl
@@ -1,0 +1,71 @@
+version: '{build}'
+clone_folder: c:\workspace\\${rtcParam.name}
+platform:
+- x64
+environment:
+  openrtm_version: 1.2.0
+  CTEST_OUTPUT_ON_FAILURE: 1
+  matrix:
+    - cmake_generator: Visual Studio 15 2017
+      cmake_archtecture: x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      python: 37-x64
+matrix:
+  fast_finish: true
+
+init:
+  - git config --global core.autocrlf false
+  - ps: ${dol}Env:APPVEYOR_BUILD_WORKER_IMAGE
+  - ps: ${dol}Env:cmake_generator
+  - ps: ${dol}Env:cmake_archtecture
+  - ps: |
+      switch (${dol}Env:cmake_archtecture) {
+        "x64" { ${dol}arch = "x86_64" }
+        "x86" { ${dol}arch = "x86" }
+        "arm" { ${dol}arch = "arm" }
+        default {throw "invalid architecture."}
+      }
+      ${dol}openrtm = "OpenRTM-aist-${dol}{Env:openrtm_version}"
+      ${dol}openrtm_url = "https://github.com/OpenRTM/OpenRTM-aist/releases/download/v${dol}{Env:openrtm_version}/${dol}{openrtm}-RELEASE_${dol}{arch}.msi"
+      ${dol}Env:Path = "C:\Python${dol}{Env:python};c:\Python${dol}{Env:python}\scripts;${dol}{Env:Path}"
+  - ps: ${dol}Env:omni
+  - python --version
+
+before_build:
+  - ps: |
+      ${dol}Env:openrtm_path = "c:\openrtm\\${dol}{openrtm}_${dol}{Env:cmake_archtecture}"
+      if(-NOT (Test-Path "${dol}{Env:openrtm_path}\OpenRTM-aist")){
+        New-Item "${dol}{Env:openrtm_path}" -ItemType Directory
+        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;
+        Invoke-WebRequest -Uri ${dol}openrtm_url -OutFile "${dol}{Env:TEMP}\\${dol}{openrtm}.msi"
+        ${dol}arg = "/a `"${dol}{Env:TEMP}\\${dol}{openrtm}.msi`" targetdir=${dol}{Env:openrtm_path} /qn  /li `"c:\openrtm\install.log`""
+        ${dol}msi = Start-Process msiexec.exe -ArgumentList ${dol}arg -PassThru
+        Wait-Process -Id (${dol}msi.id)
+      }
+  - set PYTHONPATH=%openrtm_path%\Lib\site-packages;%openrtm_path%\Lib\site-packages\OpenRTM_aist;%PYTHONPATH%
+  - set PATH=%openrtm_path%\Lib\site-packages;%openrtm_path%;%PATH%
+  - copy %openrtm_path%\omniidl.exe C:\Python%python%\
+  - cmake --version
+  - echo cmake -DBUILD_TESTS=ON -DOpenRTM_DIR=%openrtm_path%/OpenRTM-aist/%openrtm_version%/cmake -G "%cmake_generator%" -A "%cmake_archtecture%" -S . -B../build
+  - cmake -DBUILD_TESTS=ON -DOpenRTM_DIR=%openrtm_path%/OpenRTM-aist/%openrtm_version%/cmake -G "%cmake_generator%" -A "%cmake_archtecture%" -S . -B../build
+
+build_script:
+  - echo cmake --build ../build --target ALL_BUILD --config Release	
+  - cmake --build ../build --target ALL_BUILD --config Release
+  - echo cmake --build ../build --target RUN_TESTS --config Release
+  - cmake --build ../build --target RUN_TESTS --config Release
+
+
+cache:
+  - C:/openrtm -> .appveyor.yml
+
+only_commits:
+  files:
+    - .appveyor.yml
+    - CMakeLists.txt
+    - ${rtcParam.name}.py
+#foreach($providerIdlFile in ${rtcParam.providerIdlPathes})
+    - ${tmpltHelper.getFilenameNoExt(${providerIdlFile.idlFile})}_idl_example.py
+#end
+    - src/
+    - test/

--- a/jp.go.aist.rtm.rtcbuilder.python/test/jp/go/aist/rtm/rtcbuilder/python/_test/TestBase.java
+++ b/jp.go.aist.rtm.rtcbuilder.python/test/jp/go/aist/rtm/rtcbuilder/python/_test/TestBase.java
@@ -16,7 +16,7 @@ public class TestBase extends TestCase {
 	protected String expContent;
 	protected int index;
 	protected String[] ignore_row_phrases = {"--service-idl=", "--consumer-idl"};
-	protected final int default_file_num = 29;
+	protected final int default_file_num = 30;
 	protected final int service_file_num = 7;
 
 	public TestBase () {

--- a/jp.go.aist.rtm.rtcbuilder.python/test/jp/go/aist/rtm/rtcbuilder/python/_test/_100/BaseTest.java
+++ b/jp.go.aist.rtm.rtcbuilder.python/test/jp/go/aist/rtm/rtcbuilder/python/_test/_100/BaseTest.java
@@ -271,7 +271,7 @@ public class BaseTest extends TestBase {
 
 		String resourceDir = rootPath + "/resource/100/base/name/";
 
-		assertEquals(8, result.size());
+		assertEquals(9, result.size());
 		checkCode(result, resourceDir, "foo.py");
 	}
 


### PR DESCRIPTION
## Identify the Bug

Link to #117

## Description of the Change

ご連絡を頂きましたサンプルを基に，Python版RTCのAppVeyor設定ファイルを追加しました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [x] Have you passed the unit tests?  既存のユニットテストを修正し，修正した内容でコードが生成されることを確認