### PR TITLE
結果比較の画面の表示/非表示判断を修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/util/StringUtil.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/util/StringUtil.java
@@ -244,7 +244,6 @@ public class StringUtil {
 	}
 	
 	public static String removeNewLine(String source) {
-		source = source.replace("\r\n ","");
 		source = source.replace("\r","");
 		source = source.replace("\n","");
         


### PR DESCRIPTION
## Identify the Bug

Link to #193

## Description of the Change

結果比較画面の表示/非表示を判断する部分の処理を修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests? ユニットテストなし