### PR TITLE
プロジェクト生成時にIDLディレクトリを作成するように修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/RtcBuilderEditor.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/RtcBuilderEditor.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import javax.xml.bind.JAXBException;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRoot;
@@ -120,13 +121,14 @@ public class RtcBuilderEditor extends FormEditor implements IActionFilter {
 		IEditorInput result = input;
 
 		FileEditorInput fileEditorInput = ((FileEditorInput) result);
+		
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		IWorkspaceRoot root = workspace.getRoot();
 		try {
 			ProfileHandler handler = new ProfileHandler();
 			generatorParam = handler.restorefromXMLFile(fileEditorInput.getPath().toOSString());
 			//
 			String targetFile = this.getRtcParam().getName() + "FSM.scxml";
-			IWorkspace workspace = ResourcesPlugin.getWorkspace();
-			IWorkspaceRoot root = workspace.getRoot();
 			IProject project = root.getProject(this.getRtcParam().getOutputProject());
 			IFile fsmFile  = project.getFile(targetFile);
 			if(fsmFile.exists()) {
@@ -157,6 +159,17 @@ public class RtcBuilderEditor extends FormEditor implements IActionFilter {
 			title = ((FileEditorInput) result).getPath().lastSegment();
 			generatorParam.getRtcParam().setOutputProject(title);
 		}
+		//
+		try {
+			IProject project = root.getProject(this.getRtcParam().getOutputProject());
+			IFolder idlDir  = project.getFolder("idl");
+			if (!idlDir.exists()) {
+				idlDir.create(true, true, null);
+			}			
+		} catch (Exception e) {
+			createGeneratorParam();
+		}
+		
 		//on_initializeは常にON
 		setOnInitialize();
 		//


### PR DESCRIPTION
## Identify the Bug

Link to #186

## Description of the Change

新規プロジェクトを生成する際に，｢idl｣ディレクトリを作成するように修正しました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests? ユニットテストなし