### PR TITLE
FSMタブのイベントリストに関する処理を修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/editor/editor/scxml/eleditor/SCXMLEditorRoot.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/editor/editor/scxml/eleditor/SCXMLEditorRoot.java
@@ -38,6 +38,7 @@ import com.mxgraph.util.mxUndoableEdit.mxUndoableChange;
 
 import jp.go.aist.rtm.rtcbuilder.fsm.EventParam;
 import jp.go.aist.rtm.rtcbuilder.fsm.editor.SCXMLGraphEditor;
+import jp.go.aist.rtm.rtcbuilder.fsm.editor.editor.fileimportexport.SCXMLNode;
 	
 public abstract class SCXMLEditorRoot extends JDialog implements ActionListener, WindowListener {
 	private static final long serialVersionUID = -3257633395118679718L;
@@ -207,6 +208,22 @@ public abstract class SCXMLEditorRoot extends JDialog implements ActionListener,
 				if(isExist==false) {
 					eventList.add(param);
 				}
+			} else if(this instanceof SCXMLStateEditor) {
+				String orgName = ((SCXMLStateEditor)this).getOrgName();
+				SCXMLNode newNode = (SCXMLNode) this.cell.getValue();
+				String newName = newNode.getID();
+				if(orgName.equals(newName)==false) {
+					List<EventParam> eventList = editor.getEventList();
+					for(EventParam item : eventList) {
+						if(item.getSource().equals(orgName)) {
+							item.setSource(newName);
+						}
+						if(item.getTarget().equals(orgName)) {
+							item.setTarget(newName);
+						}
+					}
+				}
+				
 			}
 			List<mxUndoableChange> changes = new ArrayList<mxUndoableEdit.mxUndoableChange>();
 			mxGraphModel model = (mxGraphModel) editor.getGraphComponent().getGraph().getModel();

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/editor/editor/scxml/eleditor/SCXMLStateEditor.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/editor/editor/scxml/eleditor/SCXMLStateEditor.java
@@ -31,6 +31,11 @@ public class SCXMLStateEditor extends SCXMLEditorRoot {
 	private JCheckBox chkExit;
 	private boolean isRoot = false;
 	private Shell shell;
+	private String orgName;
+
+	public String getOrgName() {
+		return orgName;
+	}
 
 	public SCXMLStateEditor(JFrame parent, mxCell nn, mxCell rootOfGraph, SCXMLGraphEditor editor, Point pos) {
 		super(parent, editor, nn);
@@ -58,6 +63,7 @@ public class SCXMLStateEditor extends SCXMLEditorRoot {
 	        txtName = new JTextField(node.getName());
 	        isRoot = true;
 		}
+		orgName = txtName.getText();
 		
         txtName.setPreferredSize(new Dimension(300, 20));
         addUIParts(panel, txtName, gbl, 1, 0, 2, 1);

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/FSMEditorFormPage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/FSMEditorFormPage.java
@@ -49,6 +49,7 @@ import jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants;
 import jp.go.aist.rtm.rtcbuilder.fsm.EventParam;
 import jp.go.aist.rtm.rtcbuilder.fsm.ScXMLHandler;
 import jp.go.aist.rtm.rtcbuilder.fsm.StateParam;
+import jp.go.aist.rtm.rtcbuilder.fsm.TransitionParam;
 import jp.go.aist.rtm.rtcbuilder.fsm.editor.SCXMLGraphEditor;
 import jp.go.aist.rtm.rtcbuilder.fsm.editor.SCXMLNotifier;
 import jp.go.aist.rtm.rtcbuilder.generator.param.EventPortParam;
@@ -644,8 +645,25 @@ public class FSMEditorFormPage extends AbstractEditorFormPage {
 			if(rootState!=null) {
 				rtcParam.setFsmParam(rootState);
 				rtcParam.setFsmContents(contents);
+				
+				List<EventParam> newEventList = new ArrayList<EventParam>();
+				List<TransitionParam> transList = rootState.getAllTransList();
+				for(TransitionParam trans : transList) {
+					EventParam newParam = new EventParam();
+					newParam.setName(trans.getEvent());
+					newParam.setCondition(trans.getCondition());
+					newParam.setSource(trans.getSource());
+					newParam.setTarget(trans.getTarget());
+					for(EventParam event : eventList) {
+						if(newParam.checkSame(event)) {
+							newParam.replaceContents(event);
+							break;
+						}
+					}
+					newEventList.add(newParam);
+				}
 				rtcParam.getEventports().get(0).getEvents().clear();
-				rtcParam.getEventports().get(0).getEvents().addAll(eventList);
+				rtcParam.getEventports().get(0).getEvents().addAll(newEventList);
 				editor.updateDirty();
 				PlatformUI.getWorkbench().getDisplay().asyncExec(new Runnable() {
 					public void run() {


### PR DESCRIPTION
## Identify the Bug

Link to #175

## Description of the Change

｢FSM｣タブのイベントリストに関連した処理を修正させて頂きました
- ノード名を変更した場合の処理
- イベント名を変更した場合の処理
- 遷移を削除した場合の処理
- 遷移を追加後，遷移設定ダイアログを表示せずにFSMエディタを閉じた場合の処理

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests? ユニットテストなし