### PR TITLE
｢IDLファイル｣のWidgetを変更

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/AbstractEditorFormPage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/AbstractEditorFormPage.java
@@ -267,6 +267,22 @@ public abstract class AbstractEditorFormPage extends FormPage {
 		return text;
 	}
 
+	protected Text createLabelAndRefText(FormToolkit toolkit, Composite composite,
+			String labelString, int style, int hspan) {
+		if( labelString!=null && labelString.length()>0 ) {
+			toolkit.createLabel(composite, labelString);
+		}
+
+		final Text text = toolkit.createText(composite, "", style);
+		text.setEditable(false);
+		text.setBackground(getSite().getShell().getDisplay().getSystemColor(SWT.COLOR_WIDGET_BACKGROUND));
+		
+		GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
+		gridData.horizontalSpan = hspan;
+		text.setLayoutData(gridData);
+		return text;
+	}
+	
 	protected Combo createLabelAndCombo(FormToolkit toolkit, Composite composite,
 			String labelString, String[] items) {
 		return createLabelAndCombo(toolkit, composite, labelString, items, 0);

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/DataPortEditorFormPage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/DataPortEditorFormPage.java
@@ -68,7 +68,7 @@ public class DataPortEditorFormPage extends AbstractEditorFormPage {
 	//
 	private Text portNameText;
 	private Combo typeCombo;
-	private Label idlFileLabel;
+	private Text idlFileText;
 	private Text varNameText;
 	private Combo positionCombo;
 	private Text descriptionText;
@@ -162,10 +162,8 @@ public class DataPortEditorFormPage extends AbstractEditorFormPage {
 		Composite composite = createSectionBaseWithLabel(toolkit, form,
 				"Detail", IMessageConstants.DATAPORT_DOCUMENT_EXPL, 2);
 		//
-		portNameText = createLabelAndText(toolkit, composite,
-				Messages.getString("IMC.DATAPORT_LBL_PORTNAME"), SWT.BORDER);
-		portNameText.setEditable(false);
-		portNameText.setBackground(getSite().getShell().getDisplay().getSystemColor(SWT.COLOR_WIDGET_BACKGROUND));
+		portNameText = createLabelAndRefText(toolkit, composite,
+				Messages.getString("IMC.DATAPORT_LBL_PORTNAME"), SWT.BORDER, 1);
 		//
 		Group detailGroup = new Group(composite, SWT.SHADOW_ETCHED_IN);
 		detailGroup.setLayout(new GridLayout(3, false));
@@ -191,7 +189,7 @@ public class DataPortEditorFormPage extends AbstractEditorFormPage {
 			typeCombo.add(item.typeName);
 		}
 		/////
-		typeCombo.select(0);
+		typeCombo.setText("");
 		typeCombo.addKeyListener(new KeyListener() {
 			public void keyReleased(KeyEvent e) {
 				String target = typeCombo.getText();
@@ -221,7 +219,7 @@ public class DataPortEditorFormPage extends AbstractEditorFormPage {
 		typeCombo.addSelectionListener(new SelectionListener() {
 			  public void widgetDefaultSelected(SelectionEvent e){}
 			  public void widgetSelected(SelectionEvent e){
-				  idlFileLabel.setText(currentList.get(typeCombo.getSelectionIndex()).idlPath);
+				  idlFileText.setText(currentList.get(typeCombo.getSelectionIndex()).idlPath);
 				  update();
 			  }
 			});
@@ -237,6 +235,7 @@ public class DataPortEditorFormPage extends AbstractEditorFormPage {
 				List<DataTypeParam> dataTypes = editor.getGeneratorParam().getDataTypeParams();
 				typeList.clear();
 				typeCombo.removeAll();
+				idlFileText.setText("");
 				for(DataTypeParam each : dataTypes) {
 					for(String eachType : each.getDefinedTypes()) {
 						typeList.add(new DataParam(eachType, each.getFullPath()));
@@ -251,11 +250,8 @@ public class DataPortEditorFormPage extends AbstractEditorFormPage {
 			}
 		});
 		//
-		toolkit.createLabel(detailGroup, Messages.getString("IMC.SERVICEPORT_LBL_IDLFILE"));
-		idlFileLabel = toolkit.createLabel(detailGroup, "", SWT.BORDER);
-		gd = new GridData(GridData.FILL_HORIZONTAL);
-		gd.horizontalSpan = 2;
-		idlFileLabel.setLayoutData(gd);
+		idlFileText = createLabelAndRefText(toolkit, detailGroup,
+				Messages.getString("IMC.SERVICEPORT_LBL_IDLFILE"), SWT.BORDER, 2);
 		//
 		varNameText = createLabelAndText(toolkit, detailGroup, Messages.getString("IMC.DATAPORT_TBLLBL_VARNAME"), SWT.BORDER);
 		gd = new GridData(GridData.FILL_HORIZONTAL);
@@ -411,6 +407,9 @@ public class DataPortEditorFormPage extends AbstractEditorFormPage {
 			selectParam.setDocUnit(StringUtil.getDocText(unitText.getText()));
 			selectParam.setDocOccurrence(StringUtil.getDocText(occurrenceText.getText()));
 			selectParam.setDocOperation(StringUtil.getDocText(operationText.getText()));
+			if(typeCombo.getText() != null && typeCombo.getText().length()==0) {
+				idlFileText.setText("");
+			}
 		}
 		//
 		editor.updateEMFDataPorts(
@@ -442,7 +441,8 @@ public class DataPortEditorFormPage extends AbstractEditorFormPage {
 
 	private void clearText() {
 		portNameText.setText("");
-		typeCombo.select(0);
+		typeCombo.setText("");
+		idlFileText.setText("");
 		varNameText.setText("");
 		positionCombo.select(0);
 		descriptionText.setText("");

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/ServicePortEditorFormPage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/ServicePortEditorFormPage.java
@@ -92,7 +92,7 @@ public class ServicePortEditorFormPage extends AbstractEditorFormPage {
 	private Combo directionCombo;
 	private Text instanceNameText;
 	private Text varNameText;
-	private Label idlFileLabel;
+	private Text idlFileText;
 	private Combo interfaceTypeCombo;
 	//
 	private Text ifdetailText;
@@ -278,7 +278,7 @@ public class ServicePortEditorFormPage extends AbstractEditorFormPage {
                         ServiceClassParam selectedIF = currentIFList.get(selected);
                         ((ServicePortInterfaceParam)selection.getData()).setIdlFile(selectedIF.getIdlFile());
                     } else {
-                        ((ServicePortInterfaceParam)selection.getData()).setIdlFile(idlFileLabel.getText());
+                        ((ServicePortInterfaceParam)selection.getData()).setIdlFile(idlFileText.getText());
                     }
 					((ServicePortInterfaceParam)selection.getData()).setInterfaceType(interfaceTypeCombo.getText());
 					//
@@ -613,7 +613,7 @@ public class ServicePortEditorFormPage extends AbstractEditorFormPage {
   			  public void widgetSelected(SelectionEvent e){
   				int selected = interfaceTypeCombo.getSelectionIndex();
   				ServiceClassParam selectedCalsss = currentIFList.get(selected);
-  				idlFileLabel.setText(selectedCalsss.getIdlFile());
+  				idlFileText.setText(selectedCalsss.getIdlFile());
 			  }
   			});
     		Button reloadButton = toolkit.createButton(client, "ReLoad", SWT.PUSH);
@@ -622,7 +622,7 @@ public class ServicePortEditorFormPage extends AbstractEditorFormPage {
     			public void widgetSelected(SelectionEvent e) {
     				interfaceTypeCombo.removeAll();
     				currentIFList.clear();
-    				idlFileLabel.setText("");
+    				idlFileText.setText("");
     				
     		        extractServiceInterface();
     	            List<String> ifTypes = new ArrayList<String>();
@@ -635,11 +635,12 @@ public class ServicePortEditorFormPage extends AbstractEditorFormPage {
     			}
     		});
     		
-    		toolkit.createLabel(client, Messages.getString("IMC.SERVICEPORT_LBL_IDLFILE"));
-    		idlFileLabel = toolkit.createLabel(client, "", SWT.BORDER);
-    		gd = new GridData(GridData.FILL_HORIZONTAL);
-    		gd.horizontalSpan = 2;
-    		idlFileLabel.setLayoutData(gd);
+    		idlFileText = createLabelAndRefText(toolkit, client,
+    				Messages.getString("IMC.SERVICEPORT_LBL_IDLFILE"), SWT.BORDER, 2);
+    		if(0<defaultIFList.size()) {
+				ServiceClassParam selectedCalsss = defaultIFList.get(0);
+				idlFileText.setText(selectedCalsss.getIdlFile());
+    		}
 			
 			createSrvPortIfDocumentSection(form, client);
 			section.setClient(client);
@@ -720,8 +721,10 @@ public class ServicePortEditorFormPage extends AbstractEditorFormPage {
 			directionCombo.select(serviceInterface.getIndex());
 			instanceNameText.setText(serviceInterface.getInstanceName());
 			varNameText.setText(serviceInterface.getVarName());
-			idlFileLabel.setText(serviceInterface.getIdlFile());
-			interfaceTypeCombo.setText(serviceInterface.getInterfaceType());
+			if(0<serviceInterface.getInterfaceType().length()) {
+				idlFileText.setText(serviceInterface.getIdlFile());
+				interfaceTypeCombo.setText(serviceInterface.getInterfaceType());
+			}
 			//
 			ifdetailText.setText(StringUtil.getDisplayDocText(serviceInterface.getDocDescription()));
 			ifargumentText.setText(StringUtil.getDisplayDocText(serviceInterface.getDocArgument()));


### PR DESCRIPTION
## Identify the Bug

Link to #213

## Description of the Change

｢データポート｣タブ，｢サービスポート｣タブの｢IDLファイル｣のWidgetをラベルから，テキストボックス(編集不可)に変更させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests? ユニットテストなし