### PR TITLE
ホームディレクトリの機能を削除

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder.nl1/plugin_ja.properties
+++ b/jp.go.aist.rtm.rtcbuilder.nl1/plugin_ja.properties
@@ -36,9 +36,9 @@ perspectiveName = RTC Builder
 
 preferecePagesName = RtcBuilder
 preferecePagesCodeGenerateName = \u30b3\u30fc\u30c9\u751f\u6210
-preferecePagesPortsName = Port
-preferecePagesDocumentName = Document
-preferecePagesDataTypeName = Data Type
+preferecePagesPortsName = \u30dd\u30fc\u30c8
+preferecePagesDocumentName = \u30a2\u30af\u30c6\u30a3\u30d3\u30c6\u30a3, \u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u751f\u6210
+preferecePagesConfigurationName = \u30b3\u30f3\u30d5\u30a3\u30ae\u30e5\u30ec\u30fc\u30b7\u30e7\u30f3
 
 #Content Types
 rtcProfileName = RTC\u30d7\u30ed\u30d5\u30a1\u30a4\u30eb

--- a/jp.go.aist.rtm.rtcbuilder.nl1/src/jp/go/aist/rtm/rtcbuilder/nl/messages_ja.properties
+++ b/jp.go.aist.rtm.rtcbuilder.nl1/src/jp/go/aist/rtm/rtcbuilder/nl/messages_ja.properties
@@ -480,10 +480,6 @@ IRTCBMessageConstants.CONFIRM_PROJECT_GENERATE_TITLE=\u30d7\u30ed\u30b8\u30a7\u3
 IRTCBMessageConstants.CONFIRM_PROJECT_GENERATE_P1=\u6307\u5b9a\u3055\u308c\u305f\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u304cWorkspace\u5185\u306b\u5b58\u5728\u3057\u307e\u305b\u3093\u3002
 IRTCBMessageConstants.CONFIRM_PROJECT_GENERATE_P2=\u65b0\u898f\u306b\u751f\u6210\u3057\u3066\u3082\u3088\u308d\u3057\u3044\u3067\u3059\u304b\uff1f
 
-IPreferenceMessageConstants.HOME_DIR=\u30db\u30fc\u30e0\u30c7\u30a3\u30ec\u30af\u30c8\u30ea
-IPreferenceMessageConstants.DATA_TYPE_BTN_ADD=Add
-IPreferenceMessageConstants.DATA_TYPE_BTN_DELETE=Delete
-
 IPreferenceMessageConstants.PREFIX=\u63a5\u982d\u8a9e
 IPreferenceMessageConstants.SUFFIX=\u63a5\u5c3e\u8a9e
 

--- a/jp.go.aist.rtm.rtcbuilder/plugin.properties
+++ b/jp.go.aist.rtm.rtcbuilder/plugin.properties
@@ -37,8 +37,8 @@ perspectiveName = RTC Builder
 preferecePagesName = RtcBuilder
 preferecePagesCodeGenerateName = Code Generate
 preferecePagesPortsName = Port
-preferecePagesDocumentName = Document
-preferecePagesDataTypeName = Data Type
+preferecePagesDocumentName = Activity, Document
+preferecePagesConfigurationName = Configuration
 
 #Content Types
 rtcProfileName = RTC Profile

--- a/jp.go.aist.rtm.rtcbuilder/plugin.xml
+++ b/jp.go.aist.rtm.rtcbuilder/plugin.xml
@@ -109,6 +109,11 @@
            class="jp.go.aist.rtm.rtcbuilder.ui.preference.DocumentPreferencePage"
            id="jp.go.aist.rtm.rtcbuilder.ui.preferencePage.codeGenerate.Document"
            name="%preferecePagesDocumentName"/>
+     <page
+           category="jp.go.aist.rtm.rtcbuilder.ui.preferencePage.codeGenerate"
+           class="jp.go.aist.rtm.rtcbuilder.ui.preference.CodeGenerateConfigPreferencePage"
+           id="jp.go.aist.rtm.rtcbuilder.ui.preferencePage.codeGenerate.Configuration"
+           name="%preferecePagesConfigurationName"/>
   </extension>
   <extension
         point="org.eclipse.core.runtime.contentTypes">

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/nl/messages.properties
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/nl/messages.properties
@@ -481,10 +481,6 @@ IRTCBMessageConstants.CONFIRM_PROJECT_GENERATE_TITLE=Project Generation
 IRTCBMessageConstants.CONFIRM_PROJECT_GENERATE_P1=The specified project does not exist in Workspace.
 IRTCBMessageConstants.CONFIRM_PROJECT_GENERATE_P2=Are you sure you want to generate new project?
 
-IPreferenceMessageConstants.HOME_DIR=Home Directory
-IPreferenceMessageConstants.DATA_TYPE_BTN_ADD=Add
-IPreferenceMessageConstants.DATA_TYPE_BTN_DELETE=Delete
-
 IPreferenceMessageConstants.PREFIX=Prefix
 IPreferenceMessageConstants.SUFFIX=Suffix
 

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/BasicEditorFormPage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/BasicEditorFormPage.java
@@ -139,7 +139,6 @@ public class BasicEditorFormPage extends AbstractEditorFormPage {
 	 * {@inheritDoc}
 	 */
 	protected void createFormContent(final IManagedForm managedForm) {
-		RTCUtil.setDefaultUserDir();
 		ScrolledForm form = super.createBase(managedForm, Messages.getString("IMC.BASIC_COMPONENT_TITLE"));
 		FormToolkit toolkit = managedForm.getToolkit();
 		createModuleSection(toolkit, form);

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/preference/CodeGenerateConfigPreferencePage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/preference/CodeGenerateConfigPreferencePage.java
@@ -1,0 +1,84 @@
+package jp.go.aist.rtm.rtcbuilder.ui.preference;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.StringFieldEditor;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+
+import jp.go.aist.rtm.rtcbuilder.RtcBuilderPlugin;
+import jp.go.aist.rtm.rtcbuilder.nl.Messages;
+
+public class CodeGenerateConfigPreferencePage extends AbstarctFieldEditorPreferencePage implements
+							IWorkbenchPreferencePage {
+	public CodeGenerateConfigPreferencePage(){
+		setPreferenceStore(RtcBuilderPlugin.getDefault().getPreferenceStore());
+	}
+	
+	@Override
+	public void init(IWorkbench workbench) {
+		IPreferenceStore store = RtcBuilderPlugin.getDefault().getPreferenceStore();
+		storeConfigurationSetInitialSetting(store);
+	}
+
+	@Override
+	protected void createFieldEditors() {
+		Composite composite = new Composite(getFieldEditorParent(), SWT.NULL);
+		composite.setLayout(new GridLayout());
+		GridData gd = new GridData(GridData.FILL_HORIZONTAL);
+		gd.grabExcessHorizontalSpace = true;
+		composite.setLayoutData(gd);
+		createConfigurationSetParts(composite);
+	}
+
+	private void createConfigurationSetParts(Composite composite) {
+		Composite configGroup = createGroup(composite, IPreferenceMessageConstants.CODE_GEN_TITLE_CONFIG);
+		DigitAlphabetStringFieldEditor configurationNameEditor = 
+			new DigitAlphabetStringFieldEditor(ComponentPreferenceManager.Generate_Configuration_Name,
+					Messages.getString("IMC.CONFIGURATION_TBLLBL_NAME"), configGroup);
+		addField(configurationNameEditor);
+		StringFieldEditor configurationTypeEditor = 
+			new StringFieldEditor(ComponentPreferenceManager.Generate_Configuration_Type,
+					Messages.getString("IMC.CONFIGURATION_TBLLBL_TYPE"), configGroup);
+		addField(configurationTypeEditor);
+		StringFieldEditor configurationVarNameEditor = 
+			new StringFieldEditor(ComponentPreferenceManager.Generate_Configuration_VarName,
+					Messages.getString("IMC.CONFIGURATION_LBL_VARNAME"), configGroup);
+		addField(configurationVarNameEditor);
+		DigitAlphabetStringFieldEditor configurationDefaultEditor = 
+			new DigitAlphabetStringFieldEditor(ComponentPreferenceManager.Generate_Configuration_Default,
+					Messages.getString("IMC.CONFIGURATION_TBLLBL_DEFAULTVAL"), configGroup);
+		addField(configurationDefaultEditor);
+		StringFieldEditor configurationConstraintEditor = 
+			new StringFieldEditor(ComponentPreferenceManager.Generate_Configuration_Constraint,
+					Messages.getString("IMC.CONFIGURATION_LBL_CONSTRAINT"), configGroup);
+		addField(configurationConstraintEditor);
+		StringFieldEditor configurationUnitEditor = 
+			new StringFieldEditor(ComponentPreferenceManager.Generate_Configuration_Unit,
+					Messages.getString("IMC.CONFIGURATION_LBL_UNIT"), configGroup);
+		addField(configurationUnitEditor);
+		//
+		StringFieldEditor configurationPrefixEditor = 
+			new StringFieldEditor(ComponentPreferenceManager.Generate_Configuration_Prefix,
+					IPreferenceMessageConstants.PORT_LBL_PREFIX, configGroup);
+		addField(configurationPrefixEditor);
+		StringFieldEditor configurationSuffixEditor = 
+			new StringFieldEditor(ComponentPreferenceManager.Generate_Configuration_Suffix,
+					IPreferenceMessageConstants.PORT_LBL_SUFFIX, configGroup);
+		addField(configurationSuffixEditor);
+	}
+
+	private void storeConfigurationSetInitialSetting(IPreferenceStore store) {
+		store.setDefault(ComponentPreferenceManager.Generate_Configuration_Name, ComponentPreferenceManager.DEFAULT_CONFIGURATION_NAME);
+		store.setDefault(ComponentPreferenceManager.Generate_Configuration_Type, ComponentPreferenceManager.DEFAULT_CONFIGURATION_TYPE);
+		store.setDefault(ComponentPreferenceManager.Generate_Configuration_VarName, ComponentPreferenceManager.DEFAULT_CONFIGURATION_VARNAME);
+		store.setDefault(ComponentPreferenceManager.Generate_Configuration_Default, ComponentPreferenceManager.DEFAULT_CONFIGURATION_DEFAULT);
+		store.setDefault(ComponentPreferenceManager.Generate_Configuration_Constraint, ComponentPreferenceManager.DEFAULT_CONFIGURATION_CONSTRAINT);
+		store.setDefault(ComponentPreferenceManager.Generate_Configuration_Unit, ComponentPreferenceManager.DEFAULT_CONFIGURATION_UNIT);
+		store.setDefault(ComponentPreferenceManager.Generate_Configuration_Prefix, ComponentPreferenceManager.DEFAULT_CONFIGURATION_PREFIX);
+		store.setDefault(ComponentPreferenceManager.Generate_Configuration_Suffix, ComponentPreferenceManager.DEFAULT_CONFIGURATION_SUFFIX);
+	}
+}

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/preference/CodeGeneratePreferencePage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/preference/CodeGeneratePreferencePage.java
@@ -1,9 +1,5 @@
 package jp.go.aist.rtm.rtcbuilder.ui.preference;
 
-import jp.go.aist.rtm.rtcbuilder.RtcBuilderPlugin;
-import jp.go.aist.rtm.rtcbuilder.nl.Messages;
-import jp.go.aist.rtm.rtcbuilder.ui.editors.IMessageConstants;
-
 import org.eclipse.jface.preference.ComboFieldEditor;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.IntegerFieldEditor;
@@ -14,6 +10,9 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
+
+import jp.go.aist.rtm.rtcbuilder.RtcBuilderPlugin;
+import jp.go.aist.rtm.rtcbuilder.nl.Messages;
 
 public class CodeGeneratePreferencePage extends AbstarctFieldEditorPreferencePage implements
 							IWorkbenchPreferencePage {
@@ -46,8 +45,6 @@ public class CodeGeneratePreferencePage extends AbstarctFieldEditorPreferencePag
 	public void init(IWorkbench workbench) {
 		IPreferenceStore store = RtcBuilderPlugin.getDefault().getPreferenceStore();
 		storeComponentInitialSetting(store);
-		storeConfigurationSetInitialSetting(store);
-		storeBackupInitialSetting(store);
 	}
 
 	@Override
@@ -58,52 +55,6 @@ public class CodeGeneratePreferencePage extends AbstarctFieldEditorPreferencePag
 		gd.grabExcessHorizontalSpace = true;
 		composite.setLayoutData(gd);
 		createComponentPart(composite);
-		createConfigurationSetParts(composite);
-		createBackupParts(composite);
-	}
-
-	private void createBackupParts(Composite composite) {
-		Composite backupGroup = createGroup(composite, IPreferenceMessageConstants.CODE_GEN_TITLE_BACKUP);
-		IntegerFieldEditor moduleMaxInstanceTextEditor = new IntegerFieldEditor(ComponentPreferenceManager.Generate_Backup_Num,
-				IMessageConstants.BACKUP_FILE_NUM, backupGroup);
-		addField(moduleMaxInstanceTextEditor);
-	}
-	
-	private void createConfigurationSetParts(Composite composite) {
-		Composite configGroup = createGroup(composite, IPreferenceMessageConstants.CODE_GEN_TITLE_CONFIG);
-		DigitAlphabetStringFieldEditor configurationNameEditor = 
-			new DigitAlphabetStringFieldEditor(ComponentPreferenceManager.Generate_Configuration_Name,
-					Messages.getString("IMC.CONFIGURATION_TBLLBL_NAME"), configGroup);
-		addField(configurationNameEditor);
-		StringFieldEditor configurationTypeEditor = 
-			new StringFieldEditor(ComponentPreferenceManager.Generate_Configuration_Type,
-					Messages.getString("IMC.CONFIGURATION_TBLLBL_TYPE"), configGroup);
-		addField(configurationTypeEditor);
-		StringFieldEditor configurationVarNameEditor = 
-			new StringFieldEditor(ComponentPreferenceManager.Generate_Configuration_VarName,
-					Messages.getString("IMC.CONFIGURATION_LBL_VARNAME"), configGroup);
-		addField(configurationVarNameEditor);
-		DigitAlphabetStringFieldEditor configurationDefaultEditor = 
-			new DigitAlphabetStringFieldEditor(ComponentPreferenceManager.Generate_Configuration_Default,
-					Messages.getString("IMC.CONFIGURATION_TBLLBL_DEFAULTVAL"), configGroup);
-		addField(configurationDefaultEditor);
-		StringFieldEditor configurationConstraintEditor = 
-			new StringFieldEditor(ComponentPreferenceManager.Generate_Configuration_Constraint,
-					Messages.getString("IMC.CONFIGURATION_LBL_CONSTRAINT"), configGroup);
-		addField(configurationConstraintEditor);
-		StringFieldEditor configurationUnitEditor = 
-			new StringFieldEditor(ComponentPreferenceManager.Generate_Configuration_Unit,
-					Messages.getString("IMC.CONFIGURATION_LBL_UNIT"), configGroup);
-		addField(configurationUnitEditor);
-		//
-		StringFieldEditor configurationPrefixEditor = 
-			new StringFieldEditor(ComponentPreferenceManager.Generate_Configuration_Prefix,
-					IPreferenceMessageConstants.PORT_LBL_PREFIX, configGroup);
-		addField(configurationPrefixEditor);
-		StringFieldEditor configurationSuffixEditor = 
-			new StringFieldEditor(ComponentPreferenceManager.Generate_Configuration_Suffix,
-					IPreferenceMessageConstants.PORT_LBL_SUFFIX, configGroup);
-		addField(configurationSuffixEditor);
 	}
 
 	private void createComponentPart(Composite composite) {
@@ -164,21 +115,6 @@ public class CodeGeneratePreferencePage extends AbstarctFieldEditorPreferencePag
 		addField(commonSuffixEditor);
 	}
 	
-	private void storeBackupInitialSetting(IPreferenceStore store) {
-		store.setDefault(ComponentPreferenceManager.Generate_Backup_Num, ComponentPreferenceManager.DEFAULT_BACKUP_NUM);
-	}
-
-	private void storeConfigurationSetInitialSetting(IPreferenceStore store) {
-		store.setDefault(ComponentPreferenceManager.Generate_Configuration_Name, ComponentPreferenceManager.DEFAULT_CONFIGURATION_NAME);
-		store.setDefault(ComponentPreferenceManager.Generate_Configuration_Type, ComponentPreferenceManager.DEFAULT_CONFIGURATION_TYPE);
-		store.setDefault(ComponentPreferenceManager.Generate_Configuration_VarName, ComponentPreferenceManager.DEFAULT_CONFIGURATION_VARNAME);
-		store.setDefault(ComponentPreferenceManager.Generate_Configuration_Default, ComponentPreferenceManager.DEFAULT_CONFIGURATION_DEFAULT);
-		store.setDefault(ComponentPreferenceManager.Generate_Configuration_Constraint, ComponentPreferenceManager.DEFAULT_CONFIGURATION_CONSTRAINT);
-		store.setDefault(ComponentPreferenceManager.Generate_Configuration_Unit, ComponentPreferenceManager.DEFAULT_CONFIGURATION_UNIT);
-		store.setDefault(ComponentPreferenceManager.Generate_Configuration_Prefix, ComponentPreferenceManager.DEFAULT_CONFIGURATION_PREFIX);
-		store.setDefault(ComponentPreferenceManager.Generate_Configuration_Suffix, ComponentPreferenceManager.DEFAULT_CONFIGURATION_SUFFIX);
-	}
-
 	private void storeComponentInitialSetting(IPreferenceStore store) {
 		store.setDefault(ComponentPreferenceManager.Generate_Basic_Name, ComponentPreferenceManager.DEFAULT_COMPONENT_NAME);
 		store.setDefault(ComponentPreferenceManager.Generate_Basic_Description, ComponentPreferenceManager.DEFAULT_DESCRIPTION);

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/preference/IPreferenceMessageConstants.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/preference/IPreferenceMessageConstants.java
@@ -4,10 +4,6 @@ import jp.go.aist.rtm.rtcbuilder.nl.Messages;
 import jp.go.aist.rtm.rtcbuilder.util.StringUtil;
 
 public interface IPreferenceMessageConstants {
-	public static final String LBL_HOME_DIR = Messages.getString("IPreferenceMessageConstants.HOME_DIR"); //$NON-NLS-1$
-	public static final String DATA_TYPE_BTN_ADD = Messages.getString("IPreferenceMessageConstants.DATA_TYPE_BTN_ADD"); //$NON-NLS-1$
-	public static final String DATA_TYPE_BTN_DELETE = Messages.getString("IPreferenceMessageConstants.DATA_TYPE_BTN_DELETE"); //$NON-NLS-1$
-
 	public static final String CODE_GEN_TITLE_BASIC = Messages.getString("IPreferenceMessageConstants.CODE_GEN_TITLE_BASIC"); //$NON-NLS-1$
 	public static final String CODE_GEN_TITLE_DOCUMENT = Messages.getString("IPreferenceMessageConstants.CODE_GEN_TITLE_DOCUMENT"); //$NON-NLS-1$
 	public static final String CODE_GEN_TITLE_CONFIG = Messages.getString("IPreferenceMessageConstants.CODE_GEN_TITLE_CONFIG"); //$NON-NLS-1$

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/preference/RtcBuilderPreferencePage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/preference/RtcBuilderPreferencePage.java
@@ -1,10 +1,7 @@
 package jp.go.aist.rtm.rtcbuilder.ui.preference;
 
-import jp.go.aist.rtm.rtcbuilder.RtcBuilderPlugin;
-
-import org.eclipse.jface.preference.DirectoryFieldEditor;
-import org.eclipse.jface.preference.FieldEditorPreferencePage;
-import org.eclipse.jface.preference.PathEditor;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.IntegerFieldEditor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -12,27 +9,40 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
-public class RtcBuilderPreferencePage extends FieldEditorPreferencePage implements
+import jp.go.aist.rtm.rtcbuilder.RtcBuilderPlugin;
+import jp.go.aist.rtm.rtcbuilder.ui.editors.IMessageConstants;
+
+public class RtcBuilderPreferencePage extends AbstarctFieldEditorPreferencePage implements
 		IWorkbenchPreferencePage {
 	public RtcBuilderPreferencePage(){
-		super(GRID);
 		setPreferenceStore(RtcBuilderPlugin.getDefault().getPreferenceStore());
 	}
 	
 	@Override
 	public void init(IWorkbench workbench) {
+		IPreferenceStore store = RtcBuilderPlugin.getDefault().getPreferenceStore();
+		storeBackupInitialSetting(store);
 	}
 
 	@Override
 	protected void createFieldEditors() {
-		Composite composite = new Composite(getFieldEditorParent(), SWT.NONE);
-		composite.setLayout(new GridLayout(1,false));
-		
-		GridData gd = new GridData(GridData.FILL_BOTH);
+		Composite composite = new Composite(getFieldEditorParent(), SWT.NULL);
+		composite.setLayout(new GridLayout());
+		GridData gd = new GridData(GridData.FILL_HORIZONTAL);
+		gd.grabExcessHorizontalSpace = true;
 		composite.setLayoutData(gd);
-		//
-		DirectoryFieldEditor dirEditor = new DirectoryFieldEditor(RTCBuilderPreferenceManager.HOME_DIRECTORY,
-				IPreferenceMessageConstants.LBL_HOME_DIR, composite);
-		addField(dirEditor);
+		createBackupParts(composite);
 	}
+	
+	private void createBackupParts(Composite composite) {
+		Composite backupGroup = createGroup(composite, IPreferenceMessageConstants.CODE_GEN_TITLE_BACKUP);
+		IntegerFieldEditor moduleMaxInstanceTextEditor = new IntegerFieldEditor(ComponentPreferenceManager.Generate_Backup_Num,
+				IMessageConstants.BACKUP_FILE_NUM, backupGroup);
+		addField(moduleMaxInstanceTextEditor);
+	}
+
+	private void storeBackupInitialSetting(IPreferenceStore store) {
+		store.setDefault(ComponentPreferenceManager.Generate_Backup_Num, ComponentPreferenceManager.DEFAULT_BACKUP_NUM);
+	}
+
 }

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/util/RTCUtil.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/util/RTCUtil.java
@@ -1,6 +1,5 @@
 package jp.go.aist.rtm.rtcbuilder.util;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -12,11 +11,9 @@ import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.swt.graphics.RGB;
 
-import jp.go.aist.rtm.rtcbuilder.RtcBuilderPlugin;
 import jp.go.aist.rtm.rtcbuilder.generator.param.DataTypeParam;
 import jp.go.aist.rtm.rtcbuilder.generator.param.RtcParam;
 import jp.go.aist.rtm.rtcbuilder.generator.param.idl.IdlPathParam;
-import jp.go.aist.rtm.rtcbuilder.ui.preference.RTCBuilderPreferenceManager;
 
 public class RTCUtil {
 
@@ -61,34 +58,6 @@ public class RTCUtil {
 		return result;
 	}
 
-	public static void setDefaultUserDir() {
-		if(RtcBuilderPlugin.getDefault()!=null) {
-			String resultTemp = RtcBuilderPlugin.getDefault().getPreferenceStore().getString(RTCBuilderPreferenceManager.HOME_DIRECTORY);
-			if(resultTemp==null || resultTemp.isEmpty()) {
-				boolean isWindows = false;
-				String targetOS = System.getProperty("os.name").toLowerCase();
-				if(targetOS.toLowerCase().startsWith("windows")) {
-					isWindows = true;
-				}
-				String dirName = "";
-				String FS = System.getProperty("file.separator");
-				if(isWindows) {
-					dirName = System.getenv("APPDATA");
-				} else {
-					dirName = System.getProperty("user.home");
-				}
-				String userHome = dirName + FS + ".openrtp";
-				dirName += FS + ".openrtp" + FS + "idl";
-				File newdir = new File(dirName);
-				try {
-					newdir.mkdirs();
-				} catch (Exception ex) {
-				}
-				RtcBuilderPlugin.getDefault().getPreferenceStore().setValue(RTCBuilderPreferenceManager.HOME_DIRECTORY, userHome);
-			}
-		}
-	}
-
 	public static void getIDLPathes(RtcParam target) {
 		target.getIdlSearchPathList().clear();
 		List<String> added = new ArrayList<String>();
@@ -102,16 +71,6 @@ public class RTCUtil {
 			}
 			target.getIdlSearchPathList().add(new IdlPathParam(defaultPath + "rtm" + FS + "idl", true));
 			added.add(defaultPath + "rtm" + FS + "idl");
-		}
-		//
-		if(RtcBuilderPlugin.getDefault()!=null) {
-			RtcBuilderPlugin.getDefault().getPreferenceStore().setDefault(RTCBuilderPreferenceManager.HOME_DIRECTORY, "");
-			String userHome = RtcBuilderPlugin.getDefault().getPreferenceStore().getString(RTCBuilderPreferenceManager.HOME_DIRECTORY);
-			String userDir = userHome + FS + "idl";
-			if(added.contains(userDir)==false) {
-				target.getIdlSearchPathList().add(new IdlPathParam(userDir, false));
-				added.add(userDir);
-			}
 		}
 		//
 		if(target!=null && target.getOutputProject()!=null && 0<target.getOutputProject().length()) {


### PR DESCRIPTION
## Identify the Bug

Link to #214

## Description of the Change

ホームディレクトリの機能を削除させて頂きました．
 - 設定画面からホームディレクトリを削除
 - 設定画面の構成を整理
 - ｢データポート｣タブ，｢サービスポート｣タブでIDLの情報を検索する対象からホームディレクトリを削除

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests? ユニットテストなし