### PR TITLE
[RTCB]BuildViewのデータポートの表示を修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editpart/InPortEditPart.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editpart/InPortEditPart.java
@@ -1,18 +1,12 @@
 package jp.go.aist.rtm.rtcbuilder.ui.editpart;
 
-import jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants;
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Point;
+
 import jp.go.aist.rtm.rtcbuilder.model.component.DataInPort;
 import jp.go.aist.rtm.rtcbuilder.ui.figure.ComponentFigure;
+import jp.go.aist.rtm.rtcbuilder.ui.figure.InPortBaseFigure;
 import jp.go.aist.rtm.rtcbuilder.ui.figure.InPortFigure;
-import jp.go.aist.rtm.rtcbuilder.ui.figure.PortFigureBase;
-import jp.go.aist.rtm.rtcbuilder.util.RTCUtil;
-
-import java.util.List;
-
-import org.eclipse.draw2d.IFigure;
-import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.RGB;
-import org.eclipse.ui.PlatformUI;
 
 /**
  * InPortのEditPartクラス
@@ -26,19 +20,17 @@ public class InPortEditPart extends PortEditPartBase {
 	protected IFigure createFigure() {
 		ComponentFigure parentFigure = (ComponentFigure)((ComponentEditPart)this.getParent()).getFigure();
 		int direction = this.getModel().getDirection().getValue();
-		int portType = this.getModel().getPort_Type();
-		RGB color = null;
-		if(portType==IRtcBuilderConstants.Type_Event) {
-			color = RTCUtil.defaultRGBMap.get(RTCUtil.COLOR_EVENTPORT);
-		} else {
-			color = RTCUtil.defaultRGBMap.get(RTCUtil.COLOR_DATAPORT);
-		}
-		PortFigureBase result = new InPortFigure(getModel(), direction, 
-				new Color(PlatformUI.getWorkbench().getDisplay(), color));
+		
+		InPortBaseFigure result = new InPortBaseFigure(getModel(), direction);
 
 		int index = this.getModel().getIndex();
+		result.setSize(Integer.MAX_VALUE, Integer.MAX_VALUE);
+		result.setLocation(new Point(0,0));
 
-		return modifyPosition(parentFigure, direction, index, result);
+		InPortFigure innerFigure = (InPortFigure)modifyPosition(parentFigure, direction, index, result.getInnerFigure());
+		result.setInnerFigure(innerFigure);
+
+		return result;
 	}
 
 	@Override
@@ -54,7 +46,7 @@ public class InPortEditPart extends PortEditPartBase {
 	 * {@inheritDoc}
 	 */
 	protected void refreshVisuals() {
-		InPortFigure inport = (InPortFigure)getFigure();
+		InPortBaseFigure inport = (InPortBaseFigure)getFigure();
 		originalChildren = inport.getParent().getChildren();
 		super.refreshVisuals();
 	}

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editpart/OutPortEditPart.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editpart/OutPortEditPart.java
@@ -1,13 +1,12 @@
 package jp.go.aist.rtm.rtcbuilder.ui.editpart;
 
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Point;
+
 import jp.go.aist.rtm.rtcbuilder.model.component.DataOutPort;
 import jp.go.aist.rtm.rtcbuilder.ui.figure.ComponentFigure;
+import jp.go.aist.rtm.rtcbuilder.ui.figure.OutPortBaseFigure;
 import jp.go.aist.rtm.rtcbuilder.ui.figure.OutPortFigure;
-import jp.go.aist.rtm.rtcbuilder.util.RTCUtil;
-
-import org.eclipse.draw2d.IFigure;
-import org.eclipse.swt.graphics.Color;
-import org.eclipse.ui.PlatformUI;
 
 /**
  * OutPortのEditPartクラス
@@ -21,11 +20,17 @@ public class OutPortEditPart extends PortEditPartBase {
 	protected IFigure createFigure() {
 		ComponentFigure parentFigure = (ComponentFigure)((ComponentEditPart)this.getParent()).getFigure();
 		int direction = this.getModel().getDirection().getValue();
-		OutPortFigure result = new OutPortFigure(getModel(), direction,
-				new Color(PlatformUI.getWorkbench().getDisplay(), RTCUtil.defaultRGBMap.get(RTCUtil.COLOR_DATAPORT)));
+		
+		OutPortBaseFigure result = new OutPortBaseFigure(getModel(), direction);
+		
 		int index = this.getModel().getIndex();
+		result.setSize(Integer.MAX_VALUE, Integer.MAX_VALUE);
+		result.setLocation(new Point(0,0));
 
-		return modifyPosition(parentFigure, direction, index, result);
+		OutPortFigure innerFigure = (OutPortFigure)modifyPosition(parentFigure, direction, index, result.getInnerFigure());
+		result.setInnerFigure(innerFigure);
+
+		return result;
 	}
 
 	@Override
@@ -41,7 +46,7 @@ public class OutPortEditPart extends PortEditPartBase {
 	 * {@inheritDoc}
 	 */
 	protected void refreshVisuals() {
-		OutPortFigure outport = (OutPortFigure)getFigure();
+		OutPortBaseFigure outport = (OutPortBaseFigure)getFigure();
 		originalChildren = outport.getParent().getChildren();
 		super.refreshVisuals();
 	}

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/figure/InPortBaseFigure.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/figure/InPortBaseFigure.java
@@ -1,0 +1,37 @@
+package jp.go.aist.rtm.rtcbuilder.ui.figure;
+
+import org.eclipse.draw2d.XYLayout;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.RGB;
+import org.eclipse.ui.PlatformUI;
+
+import jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants;
+import jp.go.aist.rtm.rtcbuilder.model.component.DataInPort;
+import jp.go.aist.rtm.rtcbuilder.util.RTCUtil;
+
+public class InPortBaseFigure extends PortFigureBase {
+	private InPortFigure inPortFig;
+
+	public InPortBaseFigure(DataInPort inPort, int direction) {
+		int portType = inPort.getPort_Type();
+		RGB color = null;
+		if(portType==IRtcBuilderConstants.Type_Event) {
+			color = RTCUtil.defaultRGBMap.get(RTCUtil.COLOR_EVENTPORT);
+		} else {
+			color = RTCUtil.defaultRGBMap.get(RTCUtil.COLOR_DATAPORT);
+		}
+		
+		inPortFig = new InPortFigure(inPort, direction,
+				new Color(PlatformUI.getWorkbench().getDisplay(), color));
+		setLayoutManager(new XYLayout());
+		add(inPortFig);
+	}
+	
+	public InPortFigure getInnerFigure() {
+		return this.inPortFig;
+	}
+
+	public void setInnerFigure(InPortFigure figure) {
+		this.inPortFig = figure;
+	}
+}

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/figure/InPortFigure.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/figure/InPortFigure.java
@@ -1,11 +1,11 @@
 package jp.go.aist.rtm.rtcbuilder.ui.figure;
 
-import jp.go.aist.rtm.rtcbuilder.model.component.DataInPort;
-import jp.go.aist.rtm.rtcbuilder.model.component.PortDirection;
-
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.swt.graphics.Color;
+
+import jp.go.aist.rtm.rtcbuilder.model.component.DataInPort;
+import jp.go.aist.rtm.rtcbuilder.model.component.PortDirection;
 
 /**
  * InPortのFigure

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/figure/OutPortBaseFigure.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/figure/OutPortBaseFigure.java
@@ -1,0 +1,28 @@
+package jp.go.aist.rtm.rtcbuilder.ui.figure;
+
+import org.eclipse.draw2d.XYLayout;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.ui.PlatformUI;
+
+import jp.go.aist.rtm.rtcbuilder.model.component.DataOutPort;
+import jp.go.aist.rtm.rtcbuilder.util.RTCUtil;
+
+public class OutPortBaseFigure extends PortFigureBase {
+	private OutPortFigure outPortFig;
+
+	public OutPortBaseFigure(DataOutPort outPort, int direction) {
+		outPortFig = new OutPortFigure(outPort, direction,
+				new Color(PlatformUI.getWorkbench().getDisplay(), RTCUtil.defaultRGBMap.get(RTCUtil.COLOR_DATAPORT)));
+		setLayoutManager(new XYLayout());
+		add(outPortFig);
+	}
+	
+	public OutPortFigure getInnerFigure() {
+		return this.outPortFig;
+	}
+
+	public void setInnerFigure(OutPortFigure figure) {
+		this.outPortFig = figure;
+	}
+
+}


### PR DESCRIPTION
## Identify the Bug

Link to #224

## Description of the Change

RTCBuilderでInPortもしくはOutPortのみを追加した場合でも，BuildView内のポートの背景色が正しく表示されるように修正しました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests? ユニットテストなし