### PR TITLE
FSMコンポーネントのデータ型指定のイベントで引数の名前を記述するように修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/EventParam.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/EventParam.java
@@ -36,6 +36,10 @@ public class EventParam {
 	public void setDataType(String dataType) {
 		this.dataType = dataType;
 	}
+	public String getDataTypeStr() {
+		if(dataType==null || dataType.length()==0 ) return "";
+		return dataType + " data";
+	}
 	
 	
 	public String getCondition() {

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/fsm/CXX_FSM.cpp.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/fsm/CXX_FSM.cpp.vsl
@@ -44,7 +44,7 @@ RTC::ReturnCode_t ${eachState.name}::onExit() {
 #foreach($eachTrans in ${eachState.getTransList()})
 #if( ${eachTrans.event.length()} > 0 )
 #if( ${eachTrans.existEventParam()} )
-void ${eachState.name}::${eachTrans.event}(${eachTrans.eventParam.dataType}) {
+void ${eachState.name}::${eachTrans.event}(${eachTrans.eventParam.dataTypeStr}) {
   setState<${eachTrans.target}>();
 }
 

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/fsm/CXX_FSM.h.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/fsm/CXX_FSM.h.vsl
@@ -49,7 +49,7 @@ namespace ${rtcParam.name}Fsm {
 #if(${eachTrans.eventParam.doc_operation.length()}>0)     * - Operation Cycle: ${tmpltHelper.convertCycleDoc(${eachTrans.eventParam.doc_operation})}
 #end
      */
-    virtual void ${eachTrans.event}(${eachTrans.eventParam.dataType}) {}
+    virtual void ${eachTrans.event}(${eachTrans.eventParam.dataTypeStr}) {}
     
 #end
 #end
@@ -70,7 +70,7 @@ ${tmpltHelper.getHistory(${eachState})}
 #foreach($eachTrans in ${eachState.getTransList()})
 #if( ${eachTrans.event.length()} > 0 )
 #if( ${eachTrans.existEventParam()} )
-    void ${eachTrans.event}(${eachTrans.eventParam.dataType}) override;
+    void ${eachTrans.event}(${eachTrans.eventParam.dataTypeStr}) override;
 #end
 #end
 #end


### PR DESCRIPTION
## Identify the Bug

Link to #226

## Description of the Change

C++版FSMコンポーネントにおいて，イベントのデータ型が指定されている場合に，｢data｣という名前固定で，引数を追加させて頂きました．
なお，Python版FSMコンポーネントにつきましては，同様な修正を#207で行わせて頂いております．


## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [x] Have you passed the unit tests? 既存のユニットテストが正常に実行されることを確認