### PR TITLE
SCXMLエディタのライセンス表記を復活

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/editor/editor/scxml/SCXMLEditorActions.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/editor/editor/scxml/SCXMLEditorActions.java
@@ -1,3 +1,12 @@
+/*
+ * $Id: EditorActions.java,v 1.6 2009/12/08 19:52:50 gaudenz Exp $
+ * Copyright (c) 2001-2009, JGraph Ltd
+ * 
+ * All rights reserved.
+ * 
+ * See LICENSE file for license details. If you are unable to locate
+ * this file please contact info (at) jgraph (dot) com.
+ */
 package jp.go.aist.rtm.rtcbuilder.fsm.editor.editor.scxml;
 
 import java.awt.Component;


### PR DESCRIPTION
## Identify the Bug

Link to #223

## Description of the Change

SCXMLエディタについて，参照元のソースと比較し，ソースファイル中にライセンス表記がある部分を元に戻させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [x] Have you passed the unit tests? ユニットテストなし