### PR TITLE
RTCのテスト用PythonスクリプトでRTCの生成に失敗した場合にFalseを返すように修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/test/Py_Test_RTC.py.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/test/Py_Test_RTC.py.vsl
@@ -560,6 +560,7 @@ def RunTest():
     comp = manager.getComponent("${rtcParam.name}Test0")
     if comp is None:
         print('Component get failed.', file=sys.stderr)
+        return False
     return comp.runTest()
 
 def ${rtcParam.name}TestInit(manager):


### PR DESCRIPTION
## Identify the Bug

Link to #244

## Description of the Change

ご指摘を頂きました内容で，テスト用Pythonスクリプトを修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests? 既存のユニットテストが正常に実行されることを確認