### PR TITLE
サービスインターフェースがRequired/Providedの場合のテスト用コードを修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/manager/PythonGenerateManager.java
+++ b/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/manager/PythonGenerateManager.java
@@ -156,8 +156,6 @@ public class PythonGenerateManager extends GenerateManager {
 		//////////
 		result.add(generatePythonTestSource(contextMap));
 		for (IdlFileParam idlFileParam : rtcParam.getConsumerIdlPathes()) {
-			if(idlFileParam.isDataPort()) continue;
-			if(RTCUtil.checkDefault(idlFileParam.getIdlPath(), rtcParam.getParent().getDataTypeParams())) continue;
 			contextMap.put("idlFileParam", idlFileParam);
 			result.add(generateTestSVCIDLExampleSource(contextMap));
 		}
@@ -227,6 +225,8 @@ public class PythonGenerateManager extends GenerateManager {
 	public GeneratedResult generateTestSVCIDLExampleSource(
 			Map<String, Object> contextMap) {
 		IdlFileParam idlParam = (IdlFileParam) contextMap.get("idlFileParam");
+		idlParam.getServiceClassParams().clear();
+		idlParam.getServiceClassParams().addAll(idlParam.getTestServiceClassParams());
 		String outfile = "test/" + idlParam.getIdlFileNoExt() + "_idl_example.py";
 		String infile = "python/Py_SVC_idl_example.py.vsl";
 		return generate(infile, outfile, contextMap);

--- a/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/manager/PythonGenerateManager.java
+++ b/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/manager/PythonGenerateManager.java
@@ -102,7 +102,8 @@ public class PythonGenerateManager extends GenerateManager {
 		List<IdlFileParam> allFileParams = new ArrayList<IdlFileParam>();
 		allFileParams.addAll(rtcParam.getProviderIdlPathes());
 		allFileParams.addAll(rtcParam.getConsumerIdlPathes());
-		List<String> moduleList = RTCUtilPy.checkDefaultModuile(allFileParams, rtcParam.getParent().getDataTypeParams());
+		List<String> moduleList = RTCUtilPy.checkDefaultModuile(allFileParams, true, rtcParam.getParent().getDataTypeParams());
+		List<String> testModuleList = RTCUtilPy.checkDefaultModuile(allFileParams, false, rtcParam.getParent().getDataTypeParams());
 
 		Map<String, Object> contextMap = new HashMap<String, Object>();
 		contextMap.put("template", TEMPLATE_PATH);
@@ -114,6 +115,7 @@ public class PythonGenerateManager extends GenerateManager {
 		contextMap.put("idlPathes", rtcParam.getIdlPathes());
 		contextMap.put("allIdlFileParamBuild", allIdlFileParamsForBuild);
 		contextMap.put("defaultModule", moduleList);
+		contextMap.put("defaultTestModule", testModuleList);
 
 		return generateTemplateCode10(contextMap);
 	}

--- a/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/test/Py_Test_RTC.py.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/test/Py_Test_RTC.py.vsl
@@ -38,7 +38,7 @@ import OpenRTM_aist
 
 # Import Service implementation class
 # <rtc-template block="service_impl">
-#foreach($providerIdlFile in ${rtcParam.providerIdlPathes})
+#foreach($providerIdlFile in ${rtcParam.consumerIdlPathes})
 from ${tmpltHelper.getFilenameNoExt(${providerIdlFile.idlFile})}_idl_example import *
 #end
 

--- a/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/test/Py_Test_RTC.py.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/test/Py_Test_RTC.py.vsl
@@ -23,8 +23,10 @@ import time
 sys.path.append(".")
 
 # Import RTM module
-import OpenRTM_aist
 import RTC
+import OpenRTM_aist
+#foreach($idlModule in ${defaultModule})import ${idlModule}
+#end
 
 #foreach($IdlFile in ${allIdlFileParam})#if(!${IdlFile.dataPort})import ${tmpltHelper.getFilenameNoExt(${IdlFile.IdlFile})}_idl
 #end

--- a/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/test/Py_Test_RTC.py.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/test/Py_Test_RTC.py.vsl
@@ -25,7 +25,7 @@ sys.path.append(".")
 # Import RTM module
 import RTC
 import OpenRTM_aist
-#foreach($idlModule in ${defaultModule})import ${idlModule}
+#foreach($idlModule in ${defaultTestModule})import ${idlModule}
 #end
 
 #foreach($IdlFile in ${allIdlFileParam})#if(!${IdlFile.dataPort})import ${tmpltHelper.getFilenameNoExt(${IdlFile.IdlFile})}_idl

--- a/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/util/RTCUtilPy.java
+++ b/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/util/RTCUtilPy.java
@@ -26,7 +26,7 @@ public class RTCUtilPy {
 		return false;
 	}
 	
-	public static List<String> checkDefaultModuile(List<IdlFileParam> targetFiles, List<DataTypeParam> typeList) {
+	public static List<String> checkDefaultModuile(List<IdlFileParam> targetFiles, boolean isProvided, List<DataTypeParam> typeList) {
 		List<String> result = new ArrayList<String>();
 		List<String> check = new ArrayList<String>();
 		check.add("RTC");
@@ -49,20 +49,23 @@ public class RTCUtilPy {
 				}
 			} else {
 				String targetType = "";
-				for(ServiceClassParam targetTypes : target.getServiceClassParams()) {
-					targetType = targetTypes.getModule();
-					targetType = targetType.replace("::", "");
-					if(check.contains(targetType)==false) {
-						check.add(targetType);
-						result.add(targetType);
+				if(isProvided) {
+					for(ServiceClassParam targetTypes : target.getTestServiceClassParams()) {
+						targetType = targetTypes.getModule();
+						targetType = targetType.replace("::", "");
+						if(check.contains(targetType)==false) {
+							check.add(targetType);
+							result.add(targetType);
+						}
 					}
-				}
-				for(ServiceClassParam targetTypes : target.getTestServiceClassParams()) {
-					targetType = targetTypes.getModule();
-					targetType = targetType.replace("::", "");
-					if(check.contains(targetType)==false) {
-						check.add(targetType);
-						result.add(targetType);
+				} else {
+					for(ServiceClassParam targetTypes : target.getServiceClassParams()) {
+						targetType = targetTypes.getModule();
+						targetType = targetType.replace("::", "");
+						if(check.contains(targetType)==false) {
+							check.add(targetType);
+							result.add(targetType);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Identify the Bug

Link to #243, #245

## Description of the Change

サービスインターフェースがRequiredの場合に，`test`フォルダ以下に`***_idl_example.py`を生成するように修正させて頂きました．
また，`test/***Test.py`でRTC本体と同様に`***_idl_example`のインポート文を追加させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests? 既存のユニットテストが正常に実行されることを確認