### PR TITLE
ライセンス情報を追加

### DIFF
--- a/jp.go.aist.rtm.nameserviceview.nl1/COPYRIGHT
+++ b/jp.go.aist.rtm.nameserviceview.nl1/COPYRIGHT
@@ -1,0 +1,77 @@
+Copyright (C) 2003-2019
+     Noriaki Ando and the OpenRTM-aist Project team
+     Intelligent Systems Research Institute,
+     National Institute of Advanced Industrial Science and Technology (AIST),
+     Tsukuba, Japan, All rights reserved.
+
+
+NOTICE
+------
+THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.
+
+
+LICENSE
+-------
+The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.
+
+1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+
+2) Individual Licnese
+You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.
+
+
+SUBMISSIONS
+-----------
+The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.
+
+
+DISCLAIMER
+----------
+THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+CONTACT INFORMATION
+-------------------
+Noriaki Ando <n-ando@aist.go.jp>
+National Institute of Advanced Industrial Science and Technology
+Intelligent Systems Research Institute
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. 
+TEL: +81-29-861-5981 FAX: +81-29-861-6631

--- a/jp.go.aist.rtm.nameserviceview.nl1/META-INF/MANIFEST.MF
+++ b/jp.go.aist.rtm.nameserviceview.nl1/META-INF/MANIFEST.MF
@@ -2,10 +2,11 @@ Manifest-Version: 1.0
 Ant-Version: Apache Ant 1.7.1
 Created-By: 20.0-b12 (Sun Microsystems Inc.)
 Bundle-ManifestVersion: 2
-Bundle-Name: Nl Fragment
+Bundle-Name: NameServiceView Nl Fragment
 Bundle-SymbolicName: jp.go.aist.rtm.nameserviceview.nl1
 Bundle-Version: 2.0.0
 Fragment-Host: jp.go.aist.rtm.nameserviceview;bundle-version="2.0.0"
 Built-By: ngd
 Built-Date: 2015/06/18 20:00:09
+Bundle-Vendor: AIST
 

--- a/jp.go.aist.rtm.nameserviceview.nl1/about.html
+++ b/jp.go.aist.rtm.nameserviceview.nl1/about.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<h3>NOTICE</h3>
+
+<p>THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.</p>
+
+<h3>License</h3>
+
+<p>The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.</p>
+
+<p>1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+</p>
+<p>2) Individual Licnese</p>
+<p>You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.</p>
+
+<h3>SUBMISSIONS</h3>
+<p>The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.</p>
+
+<h3>DISCLAIMER</h3>
+<p>THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</p>
+
+<h3>CONTACT INFORMATION</h3>
+<p>
+Noriaki Ando <n-ando@aist.go.jp> <BR>
+National Institute of Advanced Industrial Science and Technology<BR>
+Intelligent Systems Research Institute<BR>
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. <BR>
+TEL: +81-29-861-5981 FAX: +81-29-861-6631<BR>
+</p>
+
+</body>
+</html>

--- a/jp.go.aist.rtm.nameserviceview.nl1/build.properties
+++ b/jp.go.aist.rtm.nameserviceview.nl1/build.properties
@@ -2,5 +2,11 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin_ja.properties
+               plugin_ja.properties,\
+               about.html,\
+               COPYRIGHT,\
+               epl-1.0.txt
 javacDefaultEncoding.. = UTF-8
+src.includes = COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt

--- a/jp.go.aist.rtm.nameserviceview.nl1/epl-1.0.txt
+++ b/jp.go.aist.rtm.nameserviceview.nl1/epl-1.0.txt
@@ -1,0 +1,235 @@
+---
+title: Eclipse Public License 1.0
+spdx-id: EPL-1.0
+
+description: This commercially-friendly copyleft license provides the ability to commercially license binaries; a modern royalty-free patent license grant; and the ability for linked works to use other licenses, including commercial ones.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
+
+using:
+  - Eclipse hawkBit: https://github.com/eclipse/hawkbit/blob/master/LICENSE
+  - JUnit: https://github.com/junit-team/junit4/blob/master/LICENSE-junit.txt
+  - Quil: https://github.com/quil/quil/blob/master/LICENSE
+
+permissions:
+  - commercial-use
+  - distribution
+  - modifications
+  - patent-use
+  - private-use
+
+conditions:
+  - disclose-source
+  - include-copyright
+  - same-license
+
+limitations:
+  - liability
+  - warranty
+
+---
+
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+     a) in the case of the initial Contributor, the initial code and
+     documentation distributed under this Agreement, and
+     b) in the case of each subsequent Contributor:
+          i) changes to the Program, and
+          ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from a
+Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license agreement,
+and (ii) are not derivative works of the Program.
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+     a) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free copyright license to
+     reproduce, prepare derivative works of, publicly display, publicly
+     perform, distribute and sublicense the Contribution of such Contributor,
+     if any, and such derivative works, in source code and object code form.
+
+     b) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free patent license under
+     Licensed Patents to make, use, sell, offer to sell, import and otherwise
+     transfer the Contribution of such Contributor, if any, in source code and
+     object code form. This patent license shall apply to the combination of
+     the Contribution and the Program if, at the time the Contribution is
+     added by the Contributor, such addition of the Contribution causes such
+     combination to be covered by the Licensed Patents. The patent license
+     shall not apply to any other combinations which include the Contribution.
+     No hardware per se is licensed hereunder.
+
+     c) Recipient understands that although each Contributor grants the
+     licenses to its Contributions set forth herein, no assurances are
+     provided by any Contributor that the Program does not infringe the patent
+     or other intellectual property rights of any other entity. Each
+     Contributor disclaims any liability to Recipient for claims brought by
+     any other entity based on infringement of intellectual property rights or
+     otherwise. As a condition to exercising the rights and licenses granted
+     hereunder, each Recipient hereby assumes sole responsibility to secure
+     any other intellectual property rights needed, if any. For example, if a
+     third party patent license is required to allow Recipient to distribute
+     the Program, it is Recipient's responsibility to acquire that license
+     before distributing the Program.
+
+     d) Each Contributor represents that to its knowledge it has sufficient
+     copyright rights in its Contribution, if any, to grant the copyright
+     license set forth in this Agreement.
+
+3. REQUIREMENTS
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+     a) it complies with the terms and conditions of this Agreement; and
+
+     b) its license agreement:
+          i) effectively disclaims on behalf of all Contributors all
+          warranties and conditions, express and implied, including warranties
+          or conditions of title and non-infringement, and implied warranties
+          or conditions of merchantability and fitness for a particular
+          purpose;
+          ii) effectively excludes on behalf of all Contributors all liability
+          for damages, including direct, indirect, special, incidental and
+          consequential damages, such as lost profits;
+          iii) states that any provisions which differ from this Agreement are
+          offered by that Contributor alone and not by any other party; and
+          iv) states that source code for the Program is available from such
+          Contributor, and informs licensees how to obtain it in a reasonable
+          manner on or through a medium customarily used for software
+          exchange.
+
+When the Program is made available in source code form:
+
+     a) it must be made available under this Agreement; and
+
+     b) a copy of this Agreement must be included with each copy of the
+     Program.
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a manner
+which does not create potential liability for other Contributors. Therefore,
+if a Contributor includes the Program in a commercial product offering, such
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
+every other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits and
+other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such Commercial
+Contributor in connection with its distribution of the Program in a commercial
+product offering. The obligations in this section do not apply to any claims
+or Losses relating to any actual or alleged intellectual property
+infringement. In order to qualify, an Indemnified Contributor must: a)
+promptly notify the Commercial Contributor in writing of such claim, and b)
+allow the Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
+Recipient is solely responsible for determining the appropriateness of using
+and distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to the
+risks and costs of program errors, compliance with applicable laws, damage to
+or loss of data, programs or equipment, and unavailability or interruption of
+operations.
+
+6. DISCLAIMER OF LIABILITY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient's rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient's obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of the
+Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this Agreement,
+whether expressly, by implication, estoppel or otherwise. All rights in the
+Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/jp.go.aist.rtm.nameserviceview/COPYRIGHT
+++ b/jp.go.aist.rtm.nameserviceview/COPYRIGHT
@@ -1,0 +1,77 @@
+Copyright (C) 2003-2019
+     Noriaki Ando and the OpenRTM-aist Project team
+     Intelligent Systems Research Institute,
+     National Institute of Advanced Industrial Science and Technology (AIST),
+     Tsukuba, Japan, All rights reserved.
+
+
+NOTICE
+------
+THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.
+
+
+LICENSE
+-------
+The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.
+
+1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+
+2) Individual Licnese
+You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.
+
+
+SUBMISSIONS
+-----------
+The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.
+
+
+DISCLAIMER
+----------
+THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+CONTACT INFORMATION
+-------------------
+Noriaki Ando <n-ando@aist.go.jp>
+National Institute of Advanced Industrial Science and Technology
+Intelligent Systems Research Institute
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. 
+TEL: +81-29-861-5981 FAX: +81-29-861-6631

--- a/jp.go.aist.rtm.nameserviceview/about.html
+++ b/jp.go.aist.rtm.nameserviceview/about.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<h3>NOTICE</h3>
+
+<p>THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.</p>
+
+<h3>License</h3>
+
+<p>The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.</p>
+
+<p>1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+</p>
+<p>2) Individual Licnese</p>
+<p>You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.</p>
+
+<h3>SUBMISSIONS</h3>
+<p>The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.</p>
+
+<h3>DISCLAIMER</h3>
+<p>THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</p>
+
+<h3>CONTACT INFORMATION</h3>
+<p>
+Noriaki Ando <n-ando@aist.go.jp> <BR>
+National Institute of Advanced Industrial Science and Technology<BR>
+Intelligent Systems Research Institute<BR>
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. <BR>
+TEL: +81-29-861-5981 FAX: +81-29-861-6631<BR>
+</p>
+
+</body>
+</html>

--- a/jp.go.aist.rtm.nameserviceview/build.properties
+++ b/jp.go.aist.rtm.nameserviceview/build.properties
@@ -8,8 +8,14 @@ bin.includes = .,\
                META-INF/,\
                plugin.xml,\
                plugin.properties,\
-               icons/
+               icons/,\
+               about.html,\
+               epl-1.0.txt,\
+               COPYRIGHT
 jars.compile.order = .
 source.. = src/
 output.. = bin/
 javacDefaultEncoding.. = UTF-8
+src.includes = about.html,\
+               epl-1.0.txt,\
+               COPYRIGHT

--- a/jp.go.aist.rtm.nameserviceview/epl-1.0.txt
+++ b/jp.go.aist.rtm.nameserviceview/epl-1.0.txt
@@ -1,0 +1,235 @@
+---
+title: Eclipse Public License 1.0
+spdx-id: EPL-1.0
+
+description: This commercially-friendly copyleft license provides the ability to commercially license binaries; a modern royalty-free patent license grant; and the ability for linked works to use other licenses, including commercial ones.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
+
+using:
+  - Eclipse hawkBit: https://github.com/eclipse/hawkbit/blob/master/LICENSE
+  - JUnit: https://github.com/junit-team/junit4/blob/master/LICENSE-junit.txt
+  - Quil: https://github.com/quil/quil/blob/master/LICENSE
+
+permissions:
+  - commercial-use
+  - distribution
+  - modifications
+  - patent-use
+  - private-use
+
+conditions:
+  - disclose-source
+  - include-copyright
+  - same-license
+
+limitations:
+  - liability
+  - warranty
+
+---
+
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+     a) in the case of the initial Contributor, the initial code and
+     documentation distributed under this Agreement, and
+     b) in the case of each subsequent Contributor:
+          i) changes to the Program, and
+          ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from a
+Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license agreement,
+and (ii) are not derivative works of the Program.
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+     a) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free copyright license to
+     reproduce, prepare derivative works of, publicly display, publicly
+     perform, distribute and sublicense the Contribution of such Contributor,
+     if any, and such derivative works, in source code and object code form.
+
+     b) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free patent license under
+     Licensed Patents to make, use, sell, offer to sell, import and otherwise
+     transfer the Contribution of such Contributor, if any, in source code and
+     object code form. This patent license shall apply to the combination of
+     the Contribution and the Program if, at the time the Contribution is
+     added by the Contributor, such addition of the Contribution causes such
+     combination to be covered by the Licensed Patents. The patent license
+     shall not apply to any other combinations which include the Contribution.
+     No hardware per se is licensed hereunder.
+
+     c) Recipient understands that although each Contributor grants the
+     licenses to its Contributions set forth herein, no assurances are
+     provided by any Contributor that the Program does not infringe the patent
+     or other intellectual property rights of any other entity. Each
+     Contributor disclaims any liability to Recipient for claims brought by
+     any other entity based on infringement of intellectual property rights or
+     otherwise. As a condition to exercising the rights and licenses granted
+     hereunder, each Recipient hereby assumes sole responsibility to secure
+     any other intellectual property rights needed, if any. For example, if a
+     third party patent license is required to allow Recipient to distribute
+     the Program, it is Recipient's responsibility to acquire that license
+     before distributing the Program.
+
+     d) Each Contributor represents that to its knowledge it has sufficient
+     copyright rights in its Contribution, if any, to grant the copyright
+     license set forth in this Agreement.
+
+3. REQUIREMENTS
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+     a) it complies with the terms and conditions of this Agreement; and
+
+     b) its license agreement:
+          i) effectively disclaims on behalf of all Contributors all
+          warranties and conditions, express and implied, including warranties
+          or conditions of title and non-infringement, and implied warranties
+          or conditions of merchantability and fitness for a particular
+          purpose;
+          ii) effectively excludes on behalf of all Contributors all liability
+          for damages, including direct, indirect, special, incidental and
+          consequential damages, such as lost profits;
+          iii) states that any provisions which differ from this Agreement are
+          offered by that Contributor alone and not by any other party; and
+          iv) states that source code for the Program is available from such
+          Contributor, and informs licensees how to obtain it in a reasonable
+          manner on or through a medium customarily used for software
+          exchange.
+
+When the Program is made available in source code form:
+
+     a) it must be made available under this Agreement; and
+
+     b) a copy of this Agreement must be included with each copy of the
+     Program.
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a manner
+which does not create potential liability for other Contributors. Therefore,
+if a Contributor includes the Program in a commercial product offering, such
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
+every other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits and
+other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such Commercial
+Contributor in connection with its distribution of the Program in a commercial
+product offering. The obligations in this section do not apply to any claims
+or Losses relating to any actual or alleged intellectual property
+infringement. In order to qualify, an Indemnified Contributor must: a)
+promptly notify the Commercial Contributor in writing of such claim, and b)
+allow the Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
+Recipient is solely responsible for determining the appropriateness of using
+and distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to the
+risks and costs of program errors, compliance with applicable laws, damage to
+or loss of data, programs or equipment, and unavailability or interruption of
+operations.
+
+6. DISCLAIMER OF LIABILITY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient's rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient's obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of the
+Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this Agreement,
+whether expressly, by implication, estoppel or otherwise. All rights in the
+Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/jp.go.aist.rtm.repositoryView.nl1/COPYRIGHT
+++ b/jp.go.aist.rtm.repositoryView.nl1/COPYRIGHT
@@ -1,0 +1,77 @@
+Copyright (C) 2003-2019
+     Noriaki Ando and the OpenRTM-aist Project team
+     Intelligent Systems Research Institute,
+     National Institute of Advanced Industrial Science and Technology (AIST),
+     Tsukuba, Japan, All rights reserved.
+
+
+NOTICE
+------
+THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.
+
+
+LICENSE
+-------
+The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.
+
+1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+
+2) Individual Licnese
+You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.
+
+
+SUBMISSIONS
+-----------
+The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.
+
+
+DISCLAIMER
+----------
+THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+CONTACT INFORMATION
+-------------------
+Noriaki Ando <n-ando@aist.go.jp>
+National Institute of Advanced Industrial Science and Technology
+Intelligent Systems Research Institute
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. 
+TEL: +81-29-861-5981 FAX: +81-29-861-6631

--- a/jp.go.aist.rtm.repositoryView.nl1/about.html
+++ b/jp.go.aist.rtm.repositoryView.nl1/about.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<h3>NOTICE</h3>
+
+<p>THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.</p>
+
+<h3>License</h3>
+
+<p>The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.</p>
+
+<p>1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+</p>
+<p>2) Individual Licnese</p>
+<p>You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.</p>
+
+<h3>SUBMISSIONS</h3>
+<p>The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.</p>
+
+<h3>DISCLAIMER</h3>
+<p>THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</p>
+
+<h3>CONTACT INFORMATION</h3>
+<p>
+Noriaki Ando <n-ando@aist.go.jp> <BR>
+National Institute of Advanced Industrial Science and Technology<BR>
+Intelligent Systems Research Institute<BR>
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. <BR>
+TEL: +81-29-861-5981 FAX: +81-29-861-6631<BR>
+</p>
+
+</body>
+</html>

--- a/jp.go.aist.rtm.repositoryView.nl1/build.properties
+++ b/jp.go.aist.rtm.repositoryView.nl1/build.properties
@@ -2,5 +2,11 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin_ja.properties
+               plugin_ja.properties,\
+               COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt
 javacDefaultEncoding.. = UTF-8
+src.includes = COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt

--- a/jp.go.aist.rtm.repositoryView.nl1/epl-1.0.txt
+++ b/jp.go.aist.rtm.repositoryView.nl1/epl-1.0.txt
@@ -1,0 +1,235 @@
+---
+title: Eclipse Public License 1.0
+spdx-id: EPL-1.0
+
+description: This commercially-friendly copyleft license provides the ability to commercially license binaries; a modern royalty-free patent license grant; and the ability for linked works to use other licenses, including commercial ones.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
+
+using:
+  - Eclipse hawkBit: https://github.com/eclipse/hawkbit/blob/master/LICENSE
+  - JUnit: https://github.com/junit-team/junit4/blob/master/LICENSE-junit.txt
+  - Quil: https://github.com/quil/quil/blob/master/LICENSE
+
+permissions:
+  - commercial-use
+  - distribution
+  - modifications
+  - patent-use
+  - private-use
+
+conditions:
+  - disclose-source
+  - include-copyright
+  - same-license
+
+limitations:
+  - liability
+  - warranty
+
+---
+
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+     a) in the case of the initial Contributor, the initial code and
+     documentation distributed under this Agreement, and
+     b) in the case of each subsequent Contributor:
+          i) changes to the Program, and
+          ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from a
+Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license agreement,
+and (ii) are not derivative works of the Program.
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+     a) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free copyright license to
+     reproduce, prepare derivative works of, publicly display, publicly
+     perform, distribute and sublicense the Contribution of such Contributor,
+     if any, and such derivative works, in source code and object code form.
+
+     b) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free patent license under
+     Licensed Patents to make, use, sell, offer to sell, import and otherwise
+     transfer the Contribution of such Contributor, if any, in source code and
+     object code form. This patent license shall apply to the combination of
+     the Contribution and the Program if, at the time the Contribution is
+     added by the Contributor, such addition of the Contribution causes such
+     combination to be covered by the Licensed Patents. The patent license
+     shall not apply to any other combinations which include the Contribution.
+     No hardware per se is licensed hereunder.
+
+     c) Recipient understands that although each Contributor grants the
+     licenses to its Contributions set forth herein, no assurances are
+     provided by any Contributor that the Program does not infringe the patent
+     or other intellectual property rights of any other entity. Each
+     Contributor disclaims any liability to Recipient for claims brought by
+     any other entity based on infringement of intellectual property rights or
+     otherwise. As a condition to exercising the rights and licenses granted
+     hereunder, each Recipient hereby assumes sole responsibility to secure
+     any other intellectual property rights needed, if any. For example, if a
+     third party patent license is required to allow Recipient to distribute
+     the Program, it is Recipient's responsibility to acquire that license
+     before distributing the Program.
+
+     d) Each Contributor represents that to its knowledge it has sufficient
+     copyright rights in its Contribution, if any, to grant the copyright
+     license set forth in this Agreement.
+
+3. REQUIREMENTS
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+     a) it complies with the terms and conditions of this Agreement; and
+
+     b) its license agreement:
+          i) effectively disclaims on behalf of all Contributors all
+          warranties and conditions, express and implied, including warranties
+          or conditions of title and non-infringement, and implied warranties
+          or conditions of merchantability and fitness for a particular
+          purpose;
+          ii) effectively excludes on behalf of all Contributors all liability
+          for damages, including direct, indirect, special, incidental and
+          consequential damages, such as lost profits;
+          iii) states that any provisions which differ from this Agreement are
+          offered by that Contributor alone and not by any other party; and
+          iv) states that source code for the Program is available from such
+          Contributor, and informs licensees how to obtain it in a reasonable
+          manner on or through a medium customarily used for software
+          exchange.
+
+When the Program is made available in source code form:
+
+     a) it must be made available under this Agreement; and
+
+     b) a copy of this Agreement must be included with each copy of the
+     Program.
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a manner
+which does not create potential liability for other Contributors. Therefore,
+if a Contributor includes the Program in a commercial product offering, such
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
+every other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits and
+other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such Commercial
+Contributor in connection with its distribution of the Program in a commercial
+product offering. The obligations in this section do not apply to any claims
+or Losses relating to any actual or alleged intellectual property
+infringement. In order to qualify, an Indemnified Contributor must: a)
+promptly notify the Commercial Contributor in writing of such claim, and b)
+allow the Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
+Recipient is solely responsible for determining the appropriateness of using
+and distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to the
+risks and costs of program errors, compliance with applicable laws, damage to
+or loss of data, programs or equipment, and unavailability or interruption of
+operations.
+
+6. DISCLAIMER OF LIABILITY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient's rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient's obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of the
+Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this Agreement,
+whether expressly, by implication, estoppel or otherwise. All rights in the
+Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/jp.go.aist.rtm.repositoryView/COPYRIGHT
+++ b/jp.go.aist.rtm.repositoryView/COPYRIGHT
@@ -1,0 +1,77 @@
+Copyright (C) 2003-2019
+     Noriaki Ando and the OpenRTM-aist Project team
+     Intelligent Systems Research Institute,
+     National Institute of Advanced Industrial Science and Technology (AIST),
+     Tsukuba, Japan, All rights reserved.
+
+
+NOTICE
+------
+THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.
+
+
+LICENSE
+-------
+The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.
+
+1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+
+2) Individual Licnese
+You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.
+
+
+SUBMISSIONS
+-----------
+The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.
+
+
+DISCLAIMER
+----------
+THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+CONTACT INFORMATION
+-------------------
+Noriaki Ando <n-ando@aist.go.jp>
+National Institute of Advanced Industrial Science and Technology
+Intelligent Systems Research Institute
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. 
+TEL: +81-29-861-5981 FAX: +81-29-861-6631

--- a/jp.go.aist.rtm.repositoryView/about.html
+++ b/jp.go.aist.rtm.repositoryView/about.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<h3>NOTICE</h3>
+
+<p>THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.</p>
+
+<h3>License</h3>
+
+<p>The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.</p>
+
+<p>1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+</p>
+<p>2) Individual Licnese</p>
+<p>You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.</p>
+
+<h3>SUBMISSIONS</h3>
+<p>The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.</p>
+
+<h3>DISCLAIMER</h3>
+<p>THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</p>
+
+<h3>CONTACT INFORMATION</h3>
+<p>
+Noriaki Ando <n-ando@aist.go.jp> <BR>
+National Institute of Advanced Industrial Science and Technology<BR>
+Intelligent Systems Research Institute<BR>
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. <BR>
+TEL: +81-29-861-5981 FAX: +81-29-861-6631<BR>
+</p>
+
+</body>
+</html>

--- a/jp.go.aist.rtm.repositoryView/build.properties
+++ b/jp.go.aist.rtm.repositoryView/build.properties
@@ -6,5 +6,11 @@ bin.includes = META-INF/,\
                icon/,\
                lib/rtrepository_local-1.0.jar,\
                bin/log4j.properties,\
-               plugin.properties
+               plugin.properties,\
+               COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt
 javacDefaultEncoding.. = UTF-8
+src.includes = COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt

--- a/jp.go.aist.rtm.repositoryView/epl-1.0.txt
+++ b/jp.go.aist.rtm.repositoryView/epl-1.0.txt
@@ -1,0 +1,235 @@
+---
+title: Eclipse Public License 1.0
+spdx-id: EPL-1.0
+
+description: This commercially-friendly copyleft license provides the ability to commercially license binaries; a modern royalty-free patent license grant; and the ability for linked works to use other licenses, including commercial ones.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
+
+using:
+  - Eclipse hawkBit: https://github.com/eclipse/hawkbit/blob/master/LICENSE
+  - JUnit: https://github.com/junit-team/junit4/blob/master/LICENSE-junit.txt
+  - Quil: https://github.com/quil/quil/blob/master/LICENSE
+
+permissions:
+  - commercial-use
+  - distribution
+  - modifications
+  - patent-use
+  - private-use
+
+conditions:
+  - disclose-source
+  - include-copyright
+  - same-license
+
+limitations:
+  - liability
+  - warranty
+
+---
+
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+     a) in the case of the initial Contributor, the initial code and
+     documentation distributed under this Agreement, and
+     b) in the case of each subsequent Contributor:
+          i) changes to the Program, and
+          ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from a
+Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license agreement,
+and (ii) are not derivative works of the Program.
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+     a) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free copyright license to
+     reproduce, prepare derivative works of, publicly display, publicly
+     perform, distribute and sublicense the Contribution of such Contributor,
+     if any, and such derivative works, in source code and object code form.
+
+     b) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free patent license under
+     Licensed Patents to make, use, sell, offer to sell, import and otherwise
+     transfer the Contribution of such Contributor, if any, in source code and
+     object code form. This patent license shall apply to the combination of
+     the Contribution and the Program if, at the time the Contribution is
+     added by the Contributor, such addition of the Contribution causes such
+     combination to be covered by the Licensed Patents. The patent license
+     shall not apply to any other combinations which include the Contribution.
+     No hardware per se is licensed hereunder.
+
+     c) Recipient understands that although each Contributor grants the
+     licenses to its Contributions set forth herein, no assurances are
+     provided by any Contributor that the Program does not infringe the patent
+     or other intellectual property rights of any other entity. Each
+     Contributor disclaims any liability to Recipient for claims brought by
+     any other entity based on infringement of intellectual property rights or
+     otherwise. As a condition to exercising the rights and licenses granted
+     hereunder, each Recipient hereby assumes sole responsibility to secure
+     any other intellectual property rights needed, if any. For example, if a
+     third party patent license is required to allow Recipient to distribute
+     the Program, it is Recipient's responsibility to acquire that license
+     before distributing the Program.
+
+     d) Each Contributor represents that to its knowledge it has sufficient
+     copyright rights in its Contribution, if any, to grant the copyright
+     license set forth in this Agreement.
+
+3. REQUIREMENTS
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+     a) it complies with the terms and conditions of this Agreement; and
+
+     b) its license agreement:
+          i) effectively disclaims on behalf of all Contributors all
+          warranties and conditions, express and implied, including warranties
+          or conditions of title and non-infringement, and implied warranties
+          or conditions of merchantability and fitness for a particular
+          purpose;
+          ii) effectively excludes on behalf of all Contributors all liability
+          for damages, including direct, indirect, special, incidental and
+          consequential damages, such as lost profits;
+          iii) states that any provisions which differ from this Agreement are
+          offered by that Contributor alone and not by any other party; and
+          iv) states that source code for the Program is available from such
+          Contributor, and informs licensees how to obtain it in a reasonable
+          manner on or through a medium customarily used for software
+          exchange.
+
+When the Program is made available in source code form:
+
+     a) it must be made available under this Agreement; and
+
+     b) a copy of this Agreement must be included with each copy of the
+     Program.
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a manner
+which does not create potential liability for other Contributors. Therefore,
+if a Contributor includes the Program in a commercial product offering, such
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
+every other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits and
+other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such Commercial
+Contributor in connection with its distribution of the Program in a commercial
+product offering. The obligations in this section do not apply to any claims
+or Losses relating to any actual or alleged intellectual property
+infringement. In order to qualify, an Indemnified Contributor must: a)
+promptly notify the Commercial Contributor in writing of such claim, and b)
+allow the Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
+Recipient is solely responsible for determining the appropriateness of using
+and distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to the
+risks and costs of program errors, compliance with applicable laws, damage to
+or loss of data, programs or equipment, and unavailability or interruption of
+operations.
+
+6. DISCLAIMER OF LIABILITY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient's rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient's obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of the
+Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this Agreement,
+whether expressly, by implication, estoppel or otherwise. All rights in the
+Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/jp.go.aist.rtm.rtcbuilder.java/COPYRIGHT
+++ b/jp.go.aist.rtm.rtcbuilder.java/COPYRIGHT
@@ -1,0 +1,77 @@
+Copyright (C) 2003-2019
+     Noriaki Ando and the OpenRTM-aist Project team
+     Intelligent Systems Research Institute,
+     National Institute of Advanced Industrial Science and Technology (AIST),
+     Tsukuba, Japan, All rights reserved.
+
+
+NOTICE
+------
+THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.
+
+
+LICENSE
+-------
+The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.
+
+1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+
+2) Individual Licnese
+You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.
+
+
+SUBMISSIONS
+-----------
+The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.
+
+
+DISCLAIMER
+----------
+THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+CONTACT INFORMATION
+-------------------
+Noriaki Ando <n-ando@aist.go.jp>
+National Institute of Advanced Industrial Science and Technology
+Intelligent Systems Research Institute
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. 
+TEL: +81-29-861-5981 FAX: +81-29-861-6631

--- a/jp.go.aist.rtm.rtcbuilder.java/about.html
+++ b/jp.go.aist.rtm.rtcbuilder.java/about.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<h3>NOTICE</h3>
+
+<p>THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.</p>
+
+<h3>License</h3>
+
+<p>The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.</p>
+
+<p>1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+</p>
+<p>2) Individual Licnese</p>
+<p>You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.</p>
+
+<h3>SUBMISSIONS</h3>
+<p>The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.</p>
+
+<h3>DISCLAIMER</h3>
+<p>THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</p>
+
+<h3>CONTACT INFORMATION</h3>
+<p>
+Noriaki Ando <n-ando@aist.go.jp> <BR>
+National Institute of Advanced Industrial Science and Technology<BR>
+Intelligent Systems Research Institute<BR>
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. <BR>
+TEL: +81-29-861-5981 FAX: +81-29-861-6631<BR>
+</p>
+
+</body>
+</html>

--- a/jp.go.aist.rtm.rtcbuilder.java/build.properties
+++ b/jp.go.aist.rtm.rtcbuilder.java/build.properties
@@ -3,5 +3,11 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.properties,\
-               plugin.xml
+               plugin.xml,\
+               COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt
 javacDefaultEncoding.. = UTF-8
+src.includes = COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt

--- a/jp.go.aist.rtm.rtcbuilder.java/epl-1.0.txt
+++ b/jp.go.aist.rtm.rtcbuilder.java/epl-1.0.txt
@@ -1,0 +1,235 @@
+---
+title: Eclipse Public License 1.0
+spdx-id: EPL-1.0
+
+description: This commercially-friendly copyleft license provides the ability to commercially license binaries; a modern royalty-free patent license grant; and the ability for linked works to use other licenses, including commercial ones.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
+
+using:
+  - Eclipse hawkBit: https://github.com/eclipse/hawkbit/blob/master/LICENSE
+  - JUnit: https://github.com/junit-team/junit4/blob/master/LICENSE-junit.txt
+  - Quil: https://github.com/quil/quil/blob/master/LICENSE
+
+permissions:
+  - commercial-use
+  - distribution
+  - modifications
+  - patent-use
+  - private-use
+
+conditions:
+  - disclose-source
+  - include-copyright
+  - same-license
+
+limitations:
+  - liability
+  - warranty
+
+---
+
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+     a) in the case of the initial Contributor, the initial code and
+     documentation distributed under this Agreement, and
+     b) in the case of each subsequent Contributor:
+          i) changes to the Program, and
+          ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from a
+Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license agreement,
+and (ii) are not derivative works of the Program.
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+     a) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free copyright license to
+     reproduce, prepare derivative works of, publicly display, publicly
+     perform, distribute and sublicense the Contribution of such Contributor,
+     if any, and such derivative works, in source code and object code form.
+
+     b) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free patent license under
+     Licensed Patents to make, use, sell, offer to sell, import and otherwise
+     transfer the Contribution of such Contributor, if any, in source code and
+     object code form. This patent license shall apply to the combination of
+     the Contribution and the Program if, at the time the Contribution is
+     added by the Contributor, such addition of the Contribution causes such
+     combination to be covered by the Licensed Patents. The patent license
+     shall not apply to any other combinations which include the Contribution.
+     No hardware per se is licensed hereunder.
+
+     c) Recipient understands that although each Contributor grants the
+     licenses to its Contributions set forth herein, no assurances are
+     provided by any Contributor that the Program does not infringe the patent
+     or other intellectual property rights of any other entity. Each
+     Contributor disclaims any liability to Recipient for claims brought by
+     any other entity based on infringement of intellectual property rights or
+     otherwise. As a condition to exercising the rights and licenses granted
+     hereunder, each Recipient hereby assumes sole responsibility to secure
+     any other intellectual property rights needed, if any. For example, if a
+     third party patent license is required to allow Recipient to distribute
+     the Program, it is Recipient's responsibility to acquire that license
+     before distributing the Program.
+
+     d) Each Contributor represents that to its knowledge it has sufficient
+     copyright rights in its Contribution, if any, to grant the copyright
+     license set forth in this Agreement.
+
+3. REQUIREMENTS
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+     a) it complies with the terms and conditions of this Agreement; and
+
+     b) its license agreement:
+          i) effectively disclaims on behalf of all Contributors all
+          warranties and conditions, express and implied, including warranties
+          or conditions of title and non-infringement, and implied warranties
+          or conditions of merchantability and fitness for a particular
+          purpose;
+          ii) effectively excludes on behalf of all Contributors all liability
+          for damages, including direct, indirect, special, incidental and
+          consequential damages, such as lost profits;
+          iii) states that any provisions which differ from this Agreement are
+          offered by that Contributor alone and not by any other party; and
+          iv) states that source code for the Program is available from such
+          Contributor, and informs licensees how to obtain it in a reasonable
+          manner on or through a medium customarily used for software
+          exchange.
+
+When the Program is made available in source code form:
+
+     a) it must be made available under this Agreement; and
+
+     b) a copy of this Agreement must be included with each copy of the
+     Program.
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a manner
+which does not create potential liability for other Contributors. Therefore,
+if a Contributor includes the Program in a commercial product offering, such
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
+every other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits and
+other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such Commercial
+Contributor in connection with its distribution of the Program in a commercial
+product offering. The obligations in this section do not apply to any claims
+or Losses relating to any actual or alleged intellectual property
+infringement. In order to qualify, an Indemnified Contributor must: a)
+promptly notify the Commercial Contributor in writing of such claim, and b)
+allow the Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
+Recipient is solely responsible for determining the appropriateness of using
+and distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to the
+risks and costs of program errors, compliance with applicable laws, damage to
+or loss of data, programs or equipment, and unavailability or interruption of
+operations.
+
+6. DISCLAIMER OF LIABILITY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient's rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient's obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of the
+Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this Agreement,
+whether expressly, by implication, estoppel or otherwise. All rights in the
+Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/jp.go.aist.rtm.rtcbuilder.nl1/COPYRIGHT
+++ b/jp.go.aist.rtm.rtcbuilder.nl1/COPYRIGHT
@@ -1,0 +1,77 @@
+Copyright (C) 2003-2019
+     Noriaki Ando and the OpenRTM-aist Project team
+     Intelligent Systems Research Institute,
+     National Institute of Advanced Industrial Science and Technology (AIST),
+     Tsukuba, Japan, All rights reserved.
+
+
+NOTICE
+------
+THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.
+
+
+LICENSE
+-------
+The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.
+
+1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+
+2) Individual Licnese
+You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.
+
+
+SUBMISSIONS
+-----------
+The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.
+
+
+DISCLAIMER
+----------
+THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+CONTACT INFORMATION
+-------------------
+Noriaki Ando <n-ando@aist.go.jp>
+National Institute of Advanced Industrial Science and Technology
+Intelligent Systems Research Institute
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. 
+TEL: +81-29-861-5981 FAX: +81-29-861-6631

--- a/jp.go.aist.rtm.rtcbuilder.nl1/about.html
+++ b/jp.go.aist.rtm.rtcbuilder.nl1/about.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<h3>NOTICE</h3>
+
+<p>THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.</p>
+
+<h3>License</h3>
+
+<p>The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.</p>
+
+<p>1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+</p>
+<p>2) Individual Licnese</p>
+<p>You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.</p>
+
+<h3>SUBMISSIONS</h3>
+<p>The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.</p>
+
+<h3>DISCLAIMER</h3>
+<p>THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</p>
+
+<h3>CONTACT INFORMATION</h3>
+<p>
+Noriaki Ando <n-ando@aist.go.jp> <BR>
+National Institute of Advanced Industrial Science and Technology<BR>
+Intelligent Systems Research Institute<BR>
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. <BR>
+TEL: +81-29-861-5981 FAX: +81-29-861-6631<BR>
+</p>
+
+</body>
+</html>

--- a/jp.go.aist.rtm.rtcbuilder.nl1/build.properties
+++ b/jp.go.aist.rtm.rtcbuilder.nl1/build.properties
@@ -1,5 +1,11 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
-               .
+               .,\
+               COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt
 javacDefaultEncoding.. = UTF-8
+src.includes = COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt

--- a/jp.go.aist.rtm.rtcbuilder.nl1/epl-1.0.txt
+++ b/jp.go.aist.rtm.rtcbuilder.nl1/epl-1.0.txt
@@ -1,0 +1,235 @@
+---
+title: Eclipse Public License 1.0
+spdx-id: EPL-1.0
+
+description: This commercially-friendly copyleft license provides the ability to commercially license binaries; a modern royalty-free patent license grant; and the ability for linked works to use other licenses, including commercial ones.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
+
+using:
+  - Eclipse hawkBit: https://github.com/eclipse/hawkbit/blob/master/LICENSE
+  - JUnit: https://github.com/junit-team/junit4/blob/master/LICENSE-junit.txt
+  - Quil: https://github.com/quil/quil/blob/master/LICENSE
+
+permissions:
+  - commercial-use
+  - distribution
+  - modifications
+  - patent-use
+  - private-use
+
+conditions:
+  - disclose-source
+  - include-copyright
+  - same-license
+
+limitations:
+  - liability
+  - warranty
+
+---
+
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+     a) in the case of the initial Contributor, the initial code and
+     documentation distributed under this Agreement, and
+     b) in the case of each subsequent Contributor:
+          i) changes to the Program, and
+          ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from a
+Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license agreement,
+and (ii) are not derivative works of the Program.
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+     a) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free copyright license to
+     reproduce, prepare derivative works of, publicly display, publicly
+     perform, distribute and sublicense the Contribution of such Contributor,
+     if any, and such derivative works, in source code and object code form.
+
+     b) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free patent license under
+     Licensed Patents to make, use, sell, offer to sell, import and otherwise
+     transfer the Contribution of such Contributor, if any, in source code and
+     object code form. This patent license shall apply to the combination of
+     the Contribution and the Program if, at the time the Contribution is
+     added by the Contributor, such addition of the Contribution causes such
+     combination to be covered by the Licensed Patents. The patent license
+     shall not apply to any other combinations which include the Contribution.
+     No hardware per se is licensed hereunder.
+
+     c) Recipient understands that although each Contributor grants the
+     licenses to its Contributions set forth herein, no assurances are
+     provided by any Contributor that the Program does not infringe the patent
+     or other intellectual property rights of any other entity. Each
+     Contributor disclaims any liability to Recipient for claims brought by
+     any other entity based on infringement of intellectual property rights or
+     otherwise. As a condition to exercising the rights and licenses granted
+     hereunder, each Recipient hereby assumes sole responsibility to secure
+     any other intellectual property rights needed, if any. For example, if a
+     third party patent license is required to allow Recipient to distribute
+     the Program, it is Recipient's responsibility to acquire that license
+     before distributing the Program.
+
+     d) Each Contributor represents that to its knowledge it has sufficient
+     copyright rights in its Contribution, if any, to grant the copyright
+     license set forth in this Agreement.
+
+3. REQUIREMENTS
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+     a) it complies with the terms and conditions of this Agreement; and
+
+     b) its license agreement:
+          i) effectively disclaims on behalf of all Contributors all
+          warranties and conditions, express and implied, including warranties
+          or conditions of title and non-infringement, and implied warranties
+          or conditions of merchantability and fitness for a particular
+          purpose;
+          ii) effectively excludes on behalf of all Contributors all liability
+          for damages, including direct, indirect, special, incidental and
+          consequential damages, such as lost profits;
+          iii) states that any provisions which differ from this Agreement are
+          offered by that Contributor alone and not by any other party; and
+          iv) states that source code for the Program is available from such
+          Contributor, and informs licensees how to obtain it in a reasonable
+          manner on or through a medium customarily used for software
+          exchange.
+
+When the Program is made available in source code form:
+
+     a) it must be made available under this Agreement; and
+
+     b) a copy of this Agreement must be included with each copy of the
+     Program.
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a manner
+which does not create potential liability for other Contributors. Therefore,
+if a Contributor includes the Program in a commercial product offering, such
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
+every other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits and
+other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such Commercial
+Contributor in connection with its distribution of the Program in a commercial
+product offering. The obligations in this section do not apply to any claims
+or Losses relating to any actual or alleged intellectual property
+infringement. In order to qualify, an Indemnified Contributor must: a)
+promptly notify the Commercial Contributor in writing of such claim, and b)
+allow the Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
+Recipient is solely responsible for determining the appropriateness of using
+and distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to the
+risks and costs of program errors, compliance with applicable laws, damage to
+or loss of data, programs or equipment, and unavailability or interruption of
+operations.
+
+6. DISCLAIMER OF LIABILITY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient's rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient's obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of the
+Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this Agreement,
+whether expressly, by implication, estoppel or otherwise. All rights in the
+Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/jp.go.aist.rtm.rtcbuilder.python/COPYRIGHT
+++ b/jp.go.aist.rtm.rtcbuilder.python/COPYRIGHT
@@ -1,0 +1,77 @@
+Copyright (C) 2003-2019
+     Noriaki Ando and the OpenRTM-aist Project team
+     Intelligent Systems Research Institute,
+     National Institute of Advanced Industrial Science and Technology (AIST),
+     Tsukuba, Japan, All rights reserved.
+
+
+NOTICE
+------
+THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.
+
+
+LICENSE
+-------
+The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.
+
+1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+
+2) Individual Licnese
+You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.
+
+
+SUBMISSIONS
+-----------
+The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.
+
+
+DISCLAIMER
+----------
+THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+CONTACT INFORMATION
+-------------------
+Noriaki Ando <n-ando@aist.go.jp>
+National Institute of Advanced Industrial Science and Technology
+Intelligent Systems Research Institute
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. 
+TEL: +81-29-861-5981 FAX: +81-29-861-6631

--- a/jp.go.aist.rtm.rtcbuilder.python/about.html
+++ b/jp.go.aist.rtm.rtcbuilder.python/about.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<h3>NOTICE</h3>
+
+<p>THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.</p>
+
+<h3>License</h3>
+
+<p>The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.</p>
+
+<p>1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+</p>
+<p>2) Individual Licnese</p>
+<p>You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.</p>
+
+<h3>SUBMISSIONS</h3>
+<p>The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.</p>
+
+<h3>DISCLAIMER</h3>
+<p>THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</p>
+
+<h3>CONTACT INFORMATION</h3>
+<p>
+Noriaki Ando <n-ando@aist.go.jp> <BR>
+National Institute of Advanced Industrial Science and Technology<BR>
+Intelligent Systems Research Institute<BR>
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. <BR>
+TEL: +81-29-861-5981 FAX: +81-29-861-6631<BR>
+</p>
+
+</body>
+</html>

--- a/jp.go.aist.rtm.rtcbuilder.python/build.properties
+++ b/jp.go.aist.rtm.rtcbuilder.python/build.properties
@@ -3,5 +3,11 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
-               plugin.properties
+               plugin.properties,\
+               COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt
 javacDefaultEncoding.. = UTF-8
+src.includes = COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt

--- a/jp.go.aist.rtm.rtcbuilder.python/epl-1.0.txt
+++ b/jp.go.aist.rtm.rtcbuilder.python/epl-1.0.txt
@@ -1,0 +1,235 @@
+---
+title: Eclipse Public License 1.0
+spdx-id: EPL-1.0
+
+description: This commercially-friendly copyleft license provides the ability to commercially license binaries; a modern royalty-free patent license grant; and the ability for linked works to use other licenses, including commercial ones.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
+
+using:
+  - Eclipse hawkBit: https://github.com/eclipse/hawkbit/blob/master/LICENSE
+  - JUnit: https://github.com/junit-team/junit4/blob/master/LICENSE-junit.txt
+  - Quil: https://github.com/quil/quil/blob/master/LICENSE
+
+permissions:
+  - commercial-use
+  - distribution
+  - modifications
+  - patent-use
+  - private-use
+
+conditions:
+  - disclose-source
+  - include-copyright
+  - same-license
+
+limitations:
+  - liability
+  - warranty
+
+---
+
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+     a) in the case of the initial Contributor, the initial code and
+     documentation distributed under this Agreement, and
+     b) in the case of each subsequent Contributor:
+          i) changes to the Program, and
+          ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from a
+Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license agreement,
+and (ii) are not derivative works of the Program.
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+     a) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free copyright license to
+     reproduce, prepare derivative works of, publicly display, publicly
+     perform, distribute and sublicense the Contribution of such Contributor,
+     if any, and such derivative works, in source code and object code form.
+
+     b) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free patent license under
+     Licensed Patents to make, use, sell, offer to sell, import and otherwise
+     transfer the Contribution of such Contributor, if any, in source code and
+     object code form. This patent license shall apply to the combination of
+     the Contribution and the Program if, at the time the Contribution is
+     added by the Contributor, such addition of the Contribution causes such
+     combination to be covered by the Licensed Patents. The patent license
+     shall not apply to any other combinations which include the Contribution.
+     No hardware per se is licensed hereunder.
+
+     c) Recipient understands that although each Contributor grants the
+     licenses to its Contributions set forth herein, no assurances are
+     provided by any Contributor that the Program does not infringe the patent
+     or other intellectual property rights of any other entity. Each
+     Contributor disclaims any liability to Recipient for claims brought by
+     any other entity based on infringement of intellectual property rights or
+     otherwise. As a condition to exercising the rights and licenses granted
+     hereunder, each Recipient hereby assumes sole responsibility to secure
+     any other intellectual property rights needed, if any. For example, if a
+     third party patent license is required to allow Recipient to distribute
+     the Program, it is Recipient's responsibility to acquire that license
+     before distributing the Program.
+
+     d) Each Contributor represents that to its knowledge it has sufficient
+     copyright rights in its Contribution, if any, to grant the copyright
+     license set forth in this Agreement.
+
+3. REQUIREMENTS
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+     a) it complies with the terms and conditions of this Agreement; and
+
+     b) its license agreement:
+          i) effectively disclaims on behalf of all Contributors all
+          warranties and conditions, express and implied, including warranties
+          or conditions of title and non-infringement, and implied warranties
+          or conditions of merchantability and fitness for a particular
+          purpose;
+          ii) effectively excludes on behalf of all Contributors all liability
+          for damages, including direct, indirect, special, incidental and
+          consequential damages, such as lost profits;
+          iii) states that any provisions which differ from this Agreement are
+          offered by that Contributor alone and not by any other party; and
+          iv) states that source code for the Program is available from such
+          Contributor, and informs licensees how to obtain it in a reasonable
+          manner on or through a medium customarily used for software
+          exchange.
+
+When the Program is made available in source code form:
+
+     a) it must be made available under this Agreement; and
+
+     b) a copy of this Agreement must be included with each copy of the
+     Program.
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a manner
+which does not create potential liability for other Contributors. Therefore,
+if a Contributor includes the Program in a commercial product offering, such
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
+every other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits and
+other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such Commercial
+Contributor in connection with its distribution of the Program in a commercial
+product offering. The obligations in this section do not apply to any claims
+or Losses relating to any actual or alleged intellectual property
+infringement. In order to qualify, an Indemnified Contributor must: a)
+promptly notify the Commercial Contributor in writing of such claim, and b)
+allow the Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
+Recipient is solely responsible for determining the appropriateness of using
+and distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to the
+risks and costs of program errors, compliance with applicable laws, damage to
+or loss of data, programs or equipment, and unavailability or interruption of
+operations.
+
+6. DISCLAIMER OF LIABILITY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient's rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient's obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of the
+Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this Agreement,
+whether expressly, by implication, estoppel or otherwise. All rights in the
+Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/jp.go.aist.rtm.rtcbuilder/COPYRIGHT
+++ b/jp.go.aist.rtm.rtcbuilder/COPYRIGHT
@@ -1,0 +1,77 @@
+Copyright (C) 2003-2019
+     Noriaki Ando and the OpenRTM-aist Project team
+     Intelligent Systems Research Institute,
+     National Institute of Advanced Industrial Science and Technology (AIST),
+     Tsukuba, Japan, All rights reserved.
+
+
+NOTICE
+------
+THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.
+
+
+LICENSE
+-------
+The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.
+
+1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+
+2) Individual Licnese
+You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.
+
+
+SUBMISSIONS
+-----------
+The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.
+
+
+DISCLAIMER
+----------
+THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+CONTACT INFORMATION
+-------------------
+Noriaki Ando <n-ando@aist.go.jp>
+National Institute of Advanced Industrial Science and Technology
+Intelligent Systems Research Institute
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. 
+TEL: +81-29-861-5981 FAX: +81-29-861-6631

--- a/jp.go.aist.rtm.rtcbuilder/LICENSE.txt
+++ b/jp.go.aist.rtm.rtcbuilder/LICENSE.txt
@@ -1,0 +1,14 @@
+Copyright 2017 Fabrizio Morbini
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+

--- a/jp.go.aist.rtm.rtcbuilder/about.html
+++ b/jp.go.aist.rtm.rtcbuilder/about.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<h3>NOTICE</h3>
+
+<p>THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.</p>
+
+<h3>License</h3>
+
+<p>The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.</p>
+
+<p>1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+</p>
+<p>2) Individual Licnese</p>
+<p>You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.</p>
+
+<h3>SUBMISSIONS</h3>
+<p>The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.</p>
+
+<h3>DISCLAIMER</h3>
+<p>THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</p>
+
+<h3>CONTACT INFORMATION</h3>
+<p>
+Noriaki Ando <n-ando@aist.go.jp> <BR>
+National Institute of Advanced Industrial Science and Technology<BR>
+Intelligent Systems Research Institute<BR>
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. <BR>
+TEL: +81-29-861-5981 FAX: +81-29-861-6631<BR>
+</p>
+
+</body>
+</html>

--- a/jp.go.aist.rtm.rtcbuilder/build.properties
+++ b/jp.go.aist.rtm.rtcbuilder/build.properties
@@ -15,8 +15,16 @@ bin.includes = .,\
                lib/commons-logging-1.2.jar,\
                lib/commons-scxml-0.9.jar,\
                lib/jgraphx.jar,\
-               lib/rsyntaxtextarea.jar
+               lib/rsyntaxtextarea.jar,\
+               COPYRIGHT,\
+               LICENSE.txt,\
+               about.html,\
+               epl-1.0.txt
 jars.compile.order = .
 source.. = src/
 output.. = bin/
 javacDefaultEncoding.. = UTF-8
+src.includes = COPYRIGHT,\
+               LICENSE.txt,\
+               about.html,\
+               epl-1.0.txt

--- a/jp.go.aist.rtm.rtcbuilder/epl-1.0.txt
+++ b/jp.go.aist.rtm.rtcbuilder/epl-1.0.txt
@@ -1,0 +1,235 @@
+---
+title: Eclipse Public License 1.0
+spdx-id: EPL-1.0
+
+description: This commercially-friendly copyleft license provides the ability to commercially license binaries; a modern royalty-free patent license grant; and the ability for linked works to use other licenses, including commercial ones.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
+
+using:
+  - Eclipse hawkBit: https://github.com/eclipse/hawkbit/blob/master/LICENSE
+  - JUnit: https://github.com/junit-team/junit4/blob/master/LICENSE-junit.txt
+  - Quil: https://github.com/quil/quil/blob/master/LICENSE
+
+permissions:
+  - commercial-use
+  - distribution
+  - modifications
+  - patent-use
+  - private-use
+
+conditions:
+  - disclose-source
+  - include-copyright
+  - same-license
+
+limitations:
+  - liability
+  - warranty
+
+---
+
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+     a) in the case of the initial Contributor, the initial code and
+     documentation distributed under this Agreement, and
+     b) in the case of each subsequent Contributor:
+          i) changes to the Program, and
+          ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from a
+Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license agreement,
+and (ii) are not derivative works of the Program.
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+     a) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free copyright license to
+     reproduce, prepare derivative works of, publicly display, publicly
+     perform, distribute and sublicense the Contribution of such Contributor,
+     if any, and such derivative works, in source code and object code form.
+
+     b) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free patent license under
+     Licensed Patents to make, use, sell, offer to sell, import and otherwise
+     transfer the Contribution of such Contributor, if any, in source code and
+     object code form. This patent license shall apply to the combination of
+     the Contribution and the Program if, at the time the Contribution is
+     added by the Contributor, such addition of the Contribution causes such
+     combination to be covered by the Licensed Patents. The patent license
+     shall not apply to any other combinations which include the Contribution.
+     No hardware per se is licensed hereunder.
+
+     c) Recipient understands that although each Contributor grants the
+     licenses to its Contributions set forth herein, no assurances are
+     provided by any Contributor that the Program does not infringe the patent
+     or other intellectual property rights of any other entity. Each
+     Contributor disclaims any liability to Recipient for claims brought by
+     any other entity based on infringement of intellectual property rights or
+     otherwise. As a condition to exercising the rights and licenses granted
+     hereunder, each Recipient hereby assumes sole responsibility to secure
+     any other intellectual property rights needed, if any. For example, if a
+     third party patent license is required to allow Recipient to distribute
+     the Program, it is Recipient's responsibility to acquire that license
+     before distributing the Program.
+
+     d) Each Contributor represents that to its knowledge it has sufficient
+     copyright rights in its Contribution, if any, to grant the copyright
+     license set forth in this Agreement.
+
+3. REQUIREMENTS
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+     a) it complies with the terms and conditions of this Agreement; and
+
+     b) its license agreement:
+          i) effectively disclaims on behalf of all Contributors all
+          warranties and conditions, express and implied, including warranties
+          or conditions of title and non-infringement, and implied warranties
+          or conditions of merchantability and fitness for a particular
+          purpose;
+          ii) effectively excludes on behalf of all Contributors all liability
+          for damages, including direct, indirect, special, incidental and
+          consequential damages, such as lost profits;
+          iii) states that any provisions which differ from this Agreement are
+          offered by that Contributor alone and not by any other party; and
+          iv) states that source code for the Program is available from such
+          Contributor, and informs licensees how to obtain it in a reasonable
+          manner on or through a medium customarily used for software
+          exchange.
+
+When the Program is made available in source code form:
+
+     a) it must be made available under this Agreement; and
+
+     b) a copy of this Agreement must be included with each copy of the
+     Program.
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a manner
+which does not create potential liability for other Contributors. Therefore,
+if a Contributor includes the Program in a commercial product offering, such
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
+every other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits and
+other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such Commercial
+Contributor in connection with its distribution of the Program in a commercial
+product offering. The obligations in this section do not apply to any claims
+or Losses relating to any actual or alleged intellectual property
+infringement. In order to qualify, an Indemnified Contributor must: a)
+promptly notify the Commercial Contributor in writing of such claim, and b)
+allow the Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
+Recipient is solely responsible for determining the appropriateness of using
+and distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to the
+risks and costs of program errors, compliance with applicable laws, damage to
+or loss of data, programs or equipment, and unavailability or interruption of
+operations.
+
+6. DISCLAIMER OF LIABILITY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient's rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient's obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of the
+Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this Agreement,
+whether expressly, by implication, estoppel or otherwise. All rights in the
+Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/jp.go.aist.rtm.systemeditor.nl1/COPYRIGHT
+++ b/jp.go.aist.rtm.systemeditor.nl1/COPYRIGHT
@@ -1,0 +1,77 @@
+Copyright (C) 2003-2019
+     Noriaki Ando and the OpenRTM-aist Project team
+     Intelligent Systems Research Institute,
+     National Institute of Advanced Industrial Science and Technology (AIST),
+     Tsukuba, Japan, All rights reserved.
+
+
+NOTICE
+------
+THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.
+
+
+LICENSE
+-------
+The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.
+
+1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+
+2) Individual Licnese
+You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.
+
+
+SUBMISSIONS
+-----------
+The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.
+
+
+DISCLAIMER
+----------
+THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+CONTACT INFORMATION
+-------------------
+Noriaki Ando <n-ando@aist.go.jp>
+National Institute of Advanced Industrial Science and Technology
+Intelligent Systems Research Institute
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. 
+TEL: +81-29-861-5981 FAX: +81-29-861-6631

--- a/jp.go.aist.rtm.systemeditor.nl1/about.html
+++ b/jp.go.aist.rtm.systemeditor.nl1/about.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<h3>NOTICE</h3>
+
+<p>THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.</p>
+
+<h3>License</h3>
+
+<p>The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.</p>
+
+<p>1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+</p>
+<p>2) Individual Licnese</p>
+<p>You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.</p>
+
+<h3>SUBMISSIONS</h3>
+<p>The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.</p>
+
+<h3>DISCLAIMER</h3>
+<p>THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</p>
+
+<h3>CONTACT INFORMATION</h3>
+<p>
+Noriaki Ando <n-ando@aist.go.jp> <BR>
+National Institute of Advanced Industrial Science and Technology<BR>
+Intelligent Systems Research Institute<BR>
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. <BR>
+TEL: +81-29-861-5981 FAX: +81-29-861-6631<BR>
+</p>
+
+</body>
+</html>

--- a/jp.go.aist.rtm.systemeditor.nl1/build.properties
+++ b/jp.go.aist.rtm.systemeditor.nl1/build.properties
@@ -2,5 +2,11 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin_ja.properties
+               plugin_ja.properties,\
+               COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt
 javacDefaultEncoding.. = UTF-8
+src.includes = COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt

--- a/jp.go.aist.rtm.systemeditor.nl1/epl-1.0.txt
+++ b/jp.go.aist.rtm.systemeditor.nl1/epl-1.0.txt
@@ -1,0 +1,235 @@
+---
+title: Eclipse Public License 1.0
+spdx-id: EPL-1.0
+
+description: This commercially-friendly copyleft license provides the ability to commercially license binaries; a modern royalty-free patent license grant; and the ability for linked works to use other licenses, including commercial ones.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
+
+using:
+  - Eclipse hawkBit: https://github.com/eclipse/hawkbit/blob/master/LICENSE
+  - JUnit: https://github.com/junit-team/junit4/blob/master/LICENSE-junit.txt
+  - Quil: https://github.com/quil/quil/blob/master/LICENSE
+
+permissions:
+  - commercial-use
+  - distribution
+  - modifications
+  - patent-use
+  - private-use
+
+conditions:
+  - disclose-source
+  - include-copyright
+  - same-license
+
+limitations:
+  - liability
+  - warranty
+
+---
+
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+     a) in the case of the initial Contributor, the initial code and
+     documentation distributed under this Agreement, and
+     b) in the case of each subsequent Contributor:
+          i) changes to the Program, and
+          ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from a
+Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license agreement,
+and (ii) are not derivative works of the Program.
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+     a) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free copyright license to
+     reproduce, prepare derivative works of, publicly display, publicly
+     perform, distribute and sublicense the Contribution of such Contributor,
+     if any, and such derivative works, in source code and object code form.
+
+     b) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free patent license under
+     Licensed Patents to make, use, sell, offer to sell, import and otherwise
+     transfer the Contribution of such Contributor, if any, in source code and
+     object code form. This patent license shall apply to the combination of
+     the Contribution and the Program if, at the time the Contribution is
+     added by the Contributor, such addition of the Contribution causes such
+     combination to be covered by the Licensed Patents. The patent license
+     shall not apply to any other combinations which include the Contribution.
+     No hardware per se is licensed hereunder.
+
+     c) Recipient understands that although each Contributor grants the
+     licenses to its Contributions set forth herein, no assurances are
+     provided by any Contributor that the Program does not infringe the patent
+     or other intellectual property rights of any other entity. Each
+     Contributor disclaims any liability to Recipient for claims brought by
+     any other entity based on infringement of intellectual property rights or
+     otherwise. As a condition to exercising the rights and licenses granted
+     hereunder, each Recipient hereby assumes sole responsibility to secure
+     any other intellectual property rights needed, if any. For example, if a
+     third party patent license is required to allow Recipient to distribute
+     the Program, it is Recipient's responsibility to acquire that license
+     before distributing the Program.
+
+     d) Each Contributor represents that to its knowledge it has sufficient
+     copyright rights in its Contribution, if any, to grant the copyright
+     license set forth in this Agreement.
+
+3. REQUIREMENTS
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+     a) it complies with the terms and conditions of this Agreement; and
+
+     b) its license agreement:
+          i) effectively disclaims on behalf of all Contributors all
+          warranties and conditions, express and implied, including warranties
+          or conditions of title and non-infringement, and implied warranties
+          or conditions of merchantability and fitness for a particular
+          purpose;
+          ii) effectively excludes on behalf of all Contributors all liability
+          for damages, including direct, indirect, special, incidental and
+          consequential damages, such as lost profits;
+          iii) states that any provisions which differ from this Agreement are
+          offered by that Contributor alone and not by any other party; and
+          iv) states that source code for the Program is available from such
+          Contributor, and informs licensees how to obtain it in a reasonable
+          manner on or through a medium customarily used for software
+          exchange.
+
+When the Program is made available in source code form:
+
+     a) it must be made available under this Agreement; and
+
+     b) a copy of this Agreement must be included with each copy of the
+     Program.
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a manner
+which does not create potential liability for other Contributors. Therefore,
+if a Contributor includes the Program in a commercial product offering, such
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
+every other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits and
+other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such Commercial
+Contributor in connection with its distribution of the Program in a commercial
+product offering. The obligations in this section do not apply to any claims
+or Losses relating to any actual or alleged intellectual property
+infringement. In order to qualify, an Indemnified Contributor must: a)
+promptly notify the Commercial Contributor in writing of such claim, and b)
+allow the Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
+Recipient is solely responsible for determining the appropriateness of using
+and distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to the
+risks and costs of program errors, compliance with applicable laws, damage to
+or loss of data, programs or equipment, and unavailability or interruption of
+operations.
+
+6. DISCLAIMER OF LIABILITY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient's rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient's obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of the
+Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this Agreement,
+whether expressly, by implication, estoppel or otherwise. All rights in the
+Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/jp.go.aist.rtm.systemeditor/COPYRIGHT
+++ b/jp.go.aist.rtm.systemeditor/COPYRIGHT
@@ -1,0 +1,77 @@
+Copyright (C) 2003-2019
+     Noriaki Ando and the OpenRTM-aist Project team
+     Intelligent Systems Research Institute,
+     National Institute of Advanced Industrial Science and Technology (AIST),
+     Tsukuba, Japan, All rights reserved.
+
+
+NOTICE
+------
+THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.
+
+
+LICENSE
+-------
+The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.
+
+1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+
+2) Individual Licnese
+You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.
+
+
+SUBMISSIONS
+-----------
+The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.
+
+
+DISCLAIMER
+----------
+THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+CONTACT INFORMATION
+-------------------
+Noriaki Ando <n-ando@aist.go.jp>
+National Institute of Advanced Industrial Science and Technology
+Intelligent Systems Research Institute
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. 
+TEL: +81-29-861-5981 FAX: +81-29-861-6631

--- a/jp.go.aist.rtm.systemeditor/about.html
+++ b/jp.go.aist.rtm.systemeditor/about.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<h3>NOTICE</h3>
+
+<p>THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.</p>
+
+<h3>License</h3>
+
+<p>The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.</p>
+
+<p>1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+</p>
+<p>2) Individual Licnese</p>
+<p>You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.</p>
+
+<h3>SUBMISSIONS</h3>
+<p>The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.</p>
+
+<h3>DISCLAIMER</h3>
+<p>THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</p>
+
+<h3>CONTACT INFORMATION</h3>
+<p>
+Noriaki Ando <n-ando@aist.go.jp> <BR>
+National Institute of Advanced Industrial Science and Technology<BR>
+Intelligent Systems Research Institute<BR>
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. <BR>
+TEL: +81-29-861-5981 FAX: +81-29-861-6631<BR>
+</p>
+
+</body>
+</html>

--- a/jp.go.aist.rtm.systemeditor/build.properties
+++ b/jp.go.aist.rtm.systemeditor/build.properties
@@ -6,6 +6,14 @@ bin.includes = META-INF/,\
                icons/,\
                lib/,\
                schema/,\
-               plugin.properties
-src.includes = lib/
+               plugin.properties,\
+               COPYRIGHT,\
+               about.html,\
+               NOTICE.txt,\
+               epl-1.0.txt
+src.includes = lib/,\
+               COPYRIGHT,\
+               NOTICE.txt,\
+               about.html,\
+               epl-1.0.txt
 javacDefaultEncoding.. = UTF-8

--- a/jp.go.aist.rtm.systemeditor/epl-1.0.txt
+++ b/jp.go.aist.rtm.systemeditor/epl-1.0.txt
@@ -1,0 +1,235 @@
+---
+title: Eclipse Public License 1.0
+spdx-id: EPL-1.0
+
+description: This commercially-friendly copyleft license provides the ability to commercially license binaries; a modern royalty-free patent license grant; and the ability for linked works to use other licenses, including commercial ones.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
+
+using:
+  - Eclipse hawkBit: https://github.com/eclipse/hawkbit/blob/master/LICENSE
+  - JUnit: https://github.com/junit-team/junit4/blob/master/LICENSE-junit.txt
+  - Quil: https://github.com/quil/quil/blob/master/LICENSE
+
+permissions:
+  - commercial-use
+  - distribution
+  - modifications
+  - patent-use
+  - private-use
+
+conditions:
+  - disclose-source
+  - include-copyright
+  - same-license
+
+limitations:
+  - liability
+  - warranty
+
+---
+
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+     a) in the case of the initial Contributor, the initial code and
+     documentation distributed under this Agreement, and
+     b) in the case of each subsequent Contributor:
+          i) changes to the Program, and
+          ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from a
+Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license agreement,
+and (ii) are not derivative works of the Program.
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+     a) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free copyright license to
+     reproduce, prepare derivative works of, publicly display, publicly
+     perform, distribute and sublicense the Contribution of such Contributor,
+     if any, and such derivative works, in source code and object code form.
+
+     b) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free patent license under
+     Licensed Patents to make, use, sell, offer to sell, import and otherwise
+     transfer the Contribution of such Contributor, if any, in source code and
+     object code form. This patent license shall apply to the combination of
+     the Contribution and the Program if, at the time the Contribution is
+     added by the Contributor, such addition of the Contribution causes such
+     combination to be covered by the Licensed Patents. The patent license
+     shall not apply to any other combinations which include the Contribution.
+     No hardware per se is licensed hereunder.
+
+     c) Recipient understands that although each Contributor grants the
+     licenses to its Contributions set forth herein, no assurances are
+     provided by any Contributor that the Program does not infringe the patent
+     or other intellectual property rights of any other entity. Each
+     Contributor disclaims any liability to Recipient for claims brought by
+     any other entity based on infringement of intellectual property rights or
+     otherwise. As a condition to exercising the rights and licenses granted
+     hereunder, each Recipient hereby assumes sole responsibility to secure
+     any other intellectual property rights needed, if any. For example, if a
+     third party patent license is required to allow Recipient to distribute
+     the Program, it is Recipient's responsibility to acquire that license
+     before distributing the Program.
+
+     d) Each Contributor represents that to its knowledge it has sufficient
+     copyright rights in its Contribution, if any, to grant the copyright
+     license set forth in this Agreement.
+
+3. REQUIREMENTS
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+     a) it complies with the terms and conditions of this Agreement; and
+
+     b) its license agreement:
+          i) effectively disclaims on behalf of all Contributors all
+          warranties and conditions, express and implied, including warranties
+          or conditions of title and non-infringement, and implied warranties
+          or conditions of merchantability and fitness for a particular
+          purpose;
+          ii) effectively excludes on behalf of all Contributors all liability
+          for damages, including direct, indirect, special, incidental and
+          consequential damages, such as lost profits;
+          iii) states that any provisions which differ from this Agreement are
+          offered by that Contributor alone and not by any other party; and
+          iv) states that source code for the Program is available from such
+          Contributor, and informs licensees how to obtain it in a reasonable
+          manner on or through a medium customarily used for software
+          exchange.
+
+When the Program is made available in source code form:
+
+     a) it must be made available under this Agreement; and
+
+     b) a copy of this Agreement must be included with each copy of the
+     Program.
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a manner
+which does not create potential liability for other Contributors. Therefore,
+if a Contributor includes the Program in a commercial product offering, such
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
+every other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits and
+other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such Commercial
+Contributor in connection with its distribution of the Program in a commercial
+product offering. The obligations in this section do not apply to any claims
+or Losses relating to any actual or alleged intellectual property
+infringement. In order to qualify, an Indemnified Contributor must: a)
+promptly notify the Commercial Contributor in writing of such claim, and b)
+allow the Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
+Recipient is solely responsible for determining the appropriateness of using
+and distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to the
+risks and costs of program errors, compliance with applicable laws, damage to
+or loss of data, programs or equipment, and unavailability or interruption of
+operations.
+
+6. DISCLAIMER OF LIABILITY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient's rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient's obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of the
+Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this Agreement,
+whether expressly, by implication, estoppel or otherwise. All rights in the
+Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/jp.go.aist.rtm.toolscommon.nl1/COPYRIGHT
+++ b/jp.go.aist.rtm.toolscommon.nl1/COPYRIGHT
@@ -1,0 +1,77 @@
+Copyright (C) 2003-2019
+     Noriaki Ando and the OpenRTM-aist Project team
+     Intelligent Systems Research Institute,
+     National Institute of Advanced Industrial Science and Technology (AIST),
+     Tsukuba, Japan, All rights reserved.
+
+
+NOTICE
+------
+THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.
+
+
+LICENSE
+-------
+The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.
+
+1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+
+2) Individual Licnese
+You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.
+
+
+SUBMISSIONS
+-----------
+The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.
+
+
+DISCLAIMER
+----------
+THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+CONTACT INFORMATION
+-------------------
+Noriaki Ando <n-ando@aist.go.jp>
+National Institute of Advanced Industrial Science and Technology
+Intelligent Systems Research Institute
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. 
+TEL: +81-29-861-5981 FAX: +81-29-861-6631

--- a/jp.go.aist.rtm.toolscommon.nl1/META-INF/MANIFEST.MF
+++ b/jp.go.aist.rtm.toolscommon.nl1/META-INF/MANIFEST.MF
@@ -2,10 +2,11 @@ Manifest-Version: 1.0
 Ant-Version: Apache Ant 1.7.1
 Created-By: 20.0-b12 (Sun Microsystems Inc.)
 Bundle-ManifestVersion: 2
-Bundle-Name: Nl1 Fragment
+Bundle-Name: RT Tools Common Nl1 Fragment
 Bundle-SymbolicName: jp.go.aist.rtm.toolscommon.nl1
 Bundle-Version: 2.0.0
 Fragment-Host: jp.go.aist.rtm.toolscommon;bundle-version="2.0.0"
 Built-By: ngd
 Built-Date: 2015/06/18 19:54:52
+Bundle-Vendor: AIST
 

--- a/jp.go.aist.rtm.toolscommon.nl1/about.html
+++ b/jp.go.aist.rtm.toolscommon.nl1/about.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<h3>NOTICE</h3>
+
+<p>THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.</p>
+
+<h3>License</h3>
+
+<p>The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.</p>
+
+<p>1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+</p>
+<p>2) Individual Licnese</p>
+<p>You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.</p>
+
+<h3>SUBMISSIONS</h3>
+<p>The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.</p>
+
+<h3>DISCLAIMER</h3>
+<p>THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</p>
+
+<h3>CONTACT INFORMATION</h3>
+<p>
+Noriaki Ando <n-ando@aist.go.jp> <BR>
+National Institute of Advanced Industrial Science and Technology<BR>
+Intelligent Systems Research Institute<BR>
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. <BR>
+TEL: +81-29-861-5981 FAX: +81-29-861-6631<BR>
+</p>
+
+</body>
+</html>

--- a/jp.go.aist.rtm.toolscommon.nl1/build.properties
+++ b/jp.go.aist.rtm.toolscommon.nl1/build.properties
@@ -2,5 +2,11 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin_ja.properties
+               plugin_ja.properties,\
+               COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt
 javacDefaultEncoding.. = UTF-8
+src.includes = COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt

--- a/jp.go.aist.rtm.toolscommon.nl1/epl-1.0.txt
+++ b/jp.go.aist.rtm.toolscommon.nl1/epl-1.0.txt
@@ -1,0 +1,235 @@
+---
+title: Eclipse Public License 1.0
+spdx-id: EPL-1.0
+
+description: This commercially-friendly copyleft license provides the ability to commercially license binaries; a modern royalty-free patent license grant; and the ability for linked works to use other licenses, including commercial ones.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
+
+using:
+  - Eclipse hawkBit: https://github.com/eclipse/hawkbit/blob/master/LICENSE
+  - JUnit: https://github.com/junit-team/junit4/blob/master/LICENSE-junit.txt
+  - Quil: https://github.com/quil/quil/blob/master/LICENSE
+
+permissions:
+  - commercial-use
+  - distribution
+  - modifications
+  - patent-use
+  - private-use
+
+conditions:
+  - disclose-source
+  - include-copyright
+  - same-license
+
+limitations:
+  - liability
+  - warranty
+
+---
+
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+     a) in the case of the initial Contributor, the initial code and
+     documentation distributed under this Agreement, and
+     b) in the case of each subsequent Contributor:
+          i) changes to the Program, and
+          ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from a
+Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license agreement,
+and (ii) are not derivative works of the Program.
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+     a) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free copyright license to
+     reproduce, prepare derivative works of, publicly display, publicly
+     perform, distribute and sublicense the Contribution of such Contributor,
+     if any, and such derivative works, in source code and object code form.
+
+     b) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free patent license under
+     Licensed Patents to make, use, sell, offer to sell, import and otherwise
+     transfer the Contribution of such Contributor, if any, in source code and
+     object code form. This patent license shall apply to the combination of
+     the Contribution and the Program if, at the time the Contribution is
+     added by the Contributor, such addition of the Contribution causes such
+     combination to be covered by the Licensed Patents. The patent license
+     shall not apply to any other combinations which include the Contribution.
+     No hardware per se is licensed hereunder.
+
+     c) Recipient understands that although each Contributor grants the
+     licenses to its Contributions set forth herein, no assurances are
+     provided by any Contributor that the Program does not infringe the patent
+     or other intellectual property rights of any other entity. Each
+     Contributor disclaims any liability to Recipient for claims brought by
+     any other entity based on infringement of intellectual property rights or
+     otherwise. As a condition to exercising the rights and licenses granted
+     hereunder, each Recipient hereby assumes sole responsibility to secure
+     any other intellectual property rights needed, if any. For example, if a
+     third party patent license is required to allow Recipient to distribute
+     the Program, it is Recipient's responsibility to acquire that license
+     before distributing the Program.
+
+     d) Each Contributor represents that to its knowledge it has sufficient
+     copyright rights in its Contribution, if any, to grant the copyright
+     license set forth in this Agreement.
+
+3. REQUIREMENTS
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+     a) it complies with the terms and conditions of this Agreement; and
+
+     b) its license agreement:
+          i) effectively disclaims on behalf of all Contributors all
+          warranties and conditions, express and implied, including warranties
+          or conditions of title and non-infringement, and implied warranties
+          or conditions of merchantability and fitness for a particular
+          purpose;
+          ii) effectively excludes on behalf of all Contributors all liability
+          for damages, including direct, indirect, special, incidental and
+          consequential damages, such as lost profits;
+          iii) states that any provisions which differ from this Agreement are
+          offered by that Contributor alone and not by any other party; and
+          iv) states that source code for the Program is available from such
+          Contributor, and informs licensees how to obtain it in a reasonable
+          manner on or through a medium customarily used for software
+          exchange.
+
+When the Program is made available in source code form:
+
+     a) it must be made available under this Agreement; and
+
+     b) a copy of this Agreement must be included with each copy of the
+     Program.
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a manner
+which does not create potential liability for other Contributors. Therefore,
+if a Contributor includes the Program in a commercial product offering, such
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
+every other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits and
+other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such Commercial
+Contributor in connection with its distribution of the Program in a commercial
+product offering. The obligations in this section do not apply to any claims
+or Losses relating to any actual or alleged intellectual property
+infringement. In order to qualify, an Indemnified Contributor must: a)
+promptly notify the Commercial Contributor in writing of such claim, and b)
+allow the Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
+Recipient is solely responsible for determining the appropriateness of using
+and distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to the
+risks and costs of program errors, compliance with applicable laws, damage to
+or loss of data, programs or equipment, and unavailability or interruption of
+operations.
+
+6. DISCLAIMER OF LIABILITY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient's rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient's obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of the
+Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this Agreement,
+whether expressly, by implication, estoppel or otherwise. All rights in the
+Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/jp.go.aist.rtm.toolscommon.profiles.nl1/COPYRIGHT
+++ b/jp.go.aist.rtm.toolscommon.profiles.nl1/COPYRIGHT
@@ -1,0 +1,77 @@
+Copyright (C) 2003-2019
+     Noriaki Ando and the OpenRTM-aist Project team
+     Intelligent Systems Research Institute,
+     National Institute of Advanced Industrial Science and Technology (AIST),
+     Tsukuba, Japan, All rights reserved.
+
+
+NOTICE
+------
+THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.
+
+
+LICENSE
+-------
+The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.
+
+1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+
+2) Individual Licnese
+You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.
+
+
+SUBMISSIONS
+-----------
+The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.
+
+
+DISCLAIMER
+----------
+THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+CONTACT INFORMATION
+-------------------
+Noriaki Ando <n-ando@aist.go.jp>
+National Institute of Advanced Industrial Science and Technology
+Intelligent Systems Research Institute
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. 
+TEL: +81-29-861-5981 FAX: +81-29-861-6631

--- a/jp.go.aist.rtm.toolscommon.profiles.nl1/META-INF/MANIFEST.MF
+++ b/jp.go.aist.rtm.toolscommon.profiles.nl1/META-INF/MANIFEST.MF
@@ -2,10 +2,11 @@ Manifest-Version: 1.0
 Ant-Version: Apache Ant 1.7.1
 Created-By: 20.0-b12 (Sun Microsystems Inc.)
 Bundle-ManifestVersion: 2
-Bundle-Name: Nl1 Fragment
+Bundle-Name: RtcProfile_ext Model Nl1 Fragment
 Bundle-SymbolicName: jp.go.aist.rtm.toolscommon.profiles.nl1
 Bundle-Version: 2.0.0
 Fragment-Host: jp.go.aist.rtm.toolscommon.profiles;bundle-version="2.0.0"
 Built-By: ngd
 Built-Date: 2015/06/18 19:34:27
+Bundle-Vendor: AIST
 

--- a/jp.go.aist.rtm.toolscommon.profiles.nl1/about.html
+++ b/jp.go.aist.rtm.toolscommon.profiles.nl1/about.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<h3>NOTICE</h3>
+
+<p>THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.</p>
+
+<h3>License</h3>
+
+<p>The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.</p>
+
+<p>1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+</p>
+<p>2) Individual Licnese</p>
+<p>You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.</p>
+
+<h3>SUBMISSIONS</h3>
+<p>The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.</p>
+
+<h3>DISCLAIMER</h3>
+<p>THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</p>
+
+<h3>CONTACT INFORMATION</h3>
+<p>
+Noriaki Ando <n-ando@aist.go.jp> <BR>
+National Institute of Advanced Industrial Science and Technology<BR>
+Intelligent Systems Research Institute<BR>
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. <BR>
+TEL: +81-29-861-5981 FAX: +81-29-861-6631<BR>
+</p>
+
+</body>
+</html>

--- a/jp.go.aist.rtm.toolscommon.profiles.nl1/build.properties
+++ b/jp.go.aist.rtm.toolscommon.profiles.nl1/build.properties
@@ -2,5 +2,11 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin_ja.properties
+               plugin_ja.properties,\
+               COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt
 javacDefaultEncoding.. = UTF-8
+src.includes = COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt

--- a/jp.go.aist.rtm.toolscommon.profiles.nl1/epl-1.0.txt
+++ b/jp.go.aist.rtm.toolscommon.profiles.nl1/epl-1.0.txt
@@ -1,0 +1,235 @@
+---
+title: Eclipse Public License 1.0
+spdx-id: EPL-1.0
+
+description: This commercially-friendly copyleft license provides the ability to commercially license binaries; a modern royalty-free patent license grant; and the ability for linked works to use other licenses, including commercial ones.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
+
+using:
+  - Eclipse hawkBit: https://github.com/eclipse/hawkbit/blob/master/LICENSE
+  - JUnit: https://github.com/junit-team/junit4/blob/master/LICENSE-junit.txt
+  - Quil: https://github.com/quil/quil/blob/master/LICENSE
+
+permissions:
+  - commercial-use
+  - distribution
+  - modifications
+  - patent-use
+  - private-use
+
+conditions:
+  - disclose-source
+  - include-copyright
+  - same-license
+
+limitations:
+  - liability
+  - warranty
+
+---
+
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+     a) in the case of the initial Contributor, the initial code and
+     documentation distributed under this Agreement, and
+     b) in the case of each subsequent Contributor:
+          i) changes to the Program, and
+          ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from a
+Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license agreement,
+and (ii) are not derivative works of the Program.
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+     a) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free copyright license to
+     reproduce, prepare derivative works of, publicly display, publicly
+     perform, distribute and sublicense the Contribution of such Contributor,
+     if any, and such derivative works, in source code and object code form.
+
+     b) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free patent license under
+     Licensed Patents to make, use, sell, offer to sell, import and otherwise
+     transfer the Contribution of such Contributor, if any, in source code and
+     object code form. This patent license shall apply to the combination of
+     the Contribution and the Program if, at the time the Contribution is
+     added by the Contributor, such addition of the Contribution causes such
+     combination to be covered by the Licensed Patents. The patent license
+     shall not apply to any other combinations which include the Contribution.
+     No hardware per se is licensed hereunder.
+
+     c) Recipient understands that although each Contributor grants the
+     licenses to its Contributions set forth herein, no assurances are
+     provided by any Contributor that the Program does not infringe the patent
+     or other intellectual property rights of any other entity. Each
+     Contributor disclaims any liability to Recipient for claims brought by
+     any other entity based on infringement of intellectual property rights or
+     otherwise. As a condition to exercising the rights and licenses granted
+     hereunder, each Recipient hereby assumes sole responsibility to secure
+     any other intellectual property rights needed, if any. For example, if a
+     third party patent license is required to allow Recipient to distribute
+     the Program, it is Recipient's responsibility to acquire that license
+     before distributing the Program.
+
+     d) Each Contributor represents that to its knowledge it has sufficient
+     copyright rights in its Contribution, if any, to grant the copyright
+     license set forth in this Agreement.
+
+3. REQUIREMENTS
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+     a) it complies with the terms and conditions of this Agreement; and
+
+     b) its license agreement:
+          i) effectively disclaims on behalf of all Contributors all
+          warranties and conditions, express and implied, including warranties
+          or conditions of title and non-infringement, and implied warranties
+          or conditions of merchantability and fitness for a particular
+          purpose;
+          ii) effectively excludes on behalf of all Contributors all liability
+          for damages, including direct, indirect, special, incidental and
+          consequential damages, such as lost profits;
+          iii) states that any provisions which differ from this Agreement are
+          offered by that Contributor alone and not by any other party; and
+          iv) states that source code for the Program is available from such
+          Contributor, and informs licensees how to obtain it in a reasonable
+          manner on or through a medium customarily used for software
+          exchange.
+
+When the Program is made available in source code form:
+
+     a) it must be made available under this Agreement; and
+
+     b) a copy of this Agreement must be included with each copy of the
+     Program.
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a manner
+which does not create potential liability for other Contributors. Therefore,
+if a Contributor includes the Program in a commercial product offering, such
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
+every other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits and
+other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such Commercial
+Contributor in connection with its distribution of the Program in a commercial
+product offering. The obligations in this section do not apply to any claims
+or Losses relating to any actual or alleged intellectual property
+infringement. In order to qualify, an Indemnified Contributor must: a)
+promptly notify the Commercial Contributor in writing of such claim, and b)
+allow the Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
+Recipient is solely responsible for determining the appropriateness of using
+and distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to the
+risks and costs of program errors, compliance with applicable laws, damage to
+or loss of data, programs or equipment, and unavailability or interruption of
+operations.
+
+6. DISCLAIMER OF LIABILITY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient's rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient's obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of the
+Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this Agreement,
+whether expressly, by implication, estoppel or otherwise. All rights in the
+Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/jp.go.aist.rtm.toolscommon.profiles/COPYRIGHT
+++ b/jp.go.aist.rtm.toolscommon.profiles/COPYRIGHT
@@ -1,0 +1,77 @@
+Copyright (C) 2003-2019
+     Noriaki Ando and the OpenRTM-aist Project team
+     Intelligent Systems Research Institute,
+     National Institute of Advanced Industrial Science and Technology (AIST),
+     Tsukuba, Japan, All rights reserved.
+
+
+NOTICE
+------
+THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.
+
+
+LICENSE
+-------
+The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.
+
+1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+
+2) Individual Licnese
+You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.
+
+
+SUBMISSIONS
+-----------
+The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.
+
+
+DISCLAIMER
+----------
+THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+CONTACT INFORMATION
+-------------------
+Noriaki Ando <n-ando@aist.go.jp>
+National Institute of Advanced Industrial Science and Technology
+Intelligent Systems Research Institute
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. 
+TEL: +81-29-861-5981 FAX: +81-29-861-6631

--- a/jp.go.aist.rtm.toolscommon.profiles/about.html
+++ b/jp.go.aist.rtm.toolscommon.profiles/about.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<h3>NOTICE</h3>
+
+<p>THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.</p>
+
+<h3>License</h3>
+
+<p>The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.</p>
+
+<p>1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+</p>
+<p>2) Individual Licnese</p>
+<p>You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.</p>
+
+<h3>SUBMISSIONS</h3>
+<p>The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.</p>
+
+<h3>DISCLAIMER</h3>
+<p>THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</p>
+
+<h3>CONTACT INFORMATION</h3>
+<p>
+Noriaki Ando <n-ando@aist.go.jp> <BR>
+National Institute of Advanced Industrial Science and Technology<BR>
+Intelligent Systems Research Institute<BR>
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. <BR>
+TEL: +81-29-861-5981 FAX: +81-29-861-6631<BR>
+</p>
+
+</body>
+</html>

--- a/jp.go.aist.rtm.toolscommon.profiles/build.properties
+++ b/jp.go.aist.rtm.toolscommon.profiles/build.properties
@@ -16,8 +16,14 @@ bin.includes = .,\
                lib/logback-core-1.1.3.jar,\
                lib/jackson-annotations-2.9.5.jar,\
                lib/jackson-core-2.9.5.jar,\
-               lib/jackson-databind-2.9.5.jar
+               lib/jackson-databind-2.9.5.jar,\
+               COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt
 jars.compile.order = .
 source.. = src/
 output.. = bin/
 javacDefaultEncoding.. = UTF-8
+src.includes = COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt

--- a/jp.go.aist.rtm.toolscommon.profiles/epl-1.0.txt
+++ b/jp.go.aist.rtm.toolscommon.profiles/epl-1.0.txt
@@ -1,0 +1,235 @@
+---
+title: Eclipse Public License 1.0
+spdx-id: EPL-1.0
+
+description: This commercially-friendly copyleft license provides the ability to commercially license binaries; a modern royalty-free patent license grant; and the ability for linked works to use other licenses, including commercial ones.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
+
+using:
+  - Eclipse hawkBit: https://github.com/eclipse/hawkbit/blob/master/LICENSE
+  - JUnit: https://github.com/junit-team/junit4/blob/master/LICENSE-junit.txt
+  - Quil: https://github.com/quil/quil/blob/master/LICENSE
+
+permissions:
+  - commercial-use
+  - distribution
+  - modifications
+  - patent-use
+  - private-use
+
+conditions:
+  - disclose-source
+  - include-copyright
+  - same-license
+
+limitations:
+  - liability
+  - warranty
+
+---
+
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+     a) in the case of the initial Contributor, the initial code and
+     documentation distributed under this Agreement, and
+     b) in the case of each subsequent Contributor:
+          i) changes to the Program, and
+          ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from a
+Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license agreement,
+and (ii) are not derivative works of the Program.
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+     a) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free copyright license to
+     reproduce, prepare derivative works of, publicly display, publicly
+     perform, distribute and sublicense the Contribution of such Contributor,
+     if any, and such derivative works, in source code and object code form.
+
+     b) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free patent license under
+     Licensed Patents to make, use, sell, offer to sell, import and otherwise
+     transfer the Contribution of such Contributor, if any, in source code and
+     object code form. This patent license shall apply to the combination of
+     the Contribution and the Program if, at the time the Contribution is
+     added by the Contributor, such addition of the Contribution causes such
+     combination to be covered by the Licensed Patents. The patent license
+     shall not apply to any other combinations which include the Contribution.
+     No hardware per se is licensed hereunder.
+
+     c) Recipient understands that although each Contributor grants the
+     licenses to its Contributions set forth herein, no assurances are
+     provided by any Contributor that the Program does not infringe the patent
+     or other intellectual property rights of any other entity. Each
+     Contributor disclaims any liability to Recipient for claims brought by
+     any other entity based on infringement of intellectual property rights or
+     otherwise. As a condition to exercising the rights and licenses granted
+     hereunder, each Recipient hereby assumes sole responsibility to secure
+     any other intellectual property rights needed, if any. For example, if a
+     third party patent license is required to allow Recipient to distribute
+     the Program, it is Recipient's responsibility to acquire that license
+     before distributing the Program.
+
+     d) Each Contributor represents that to its knowledge it has sufficient
+     copyright rights in its Contribution, if any, to grant the copyright
+     license set forth in this Agreement.
+
+3. REQUIREMENTS
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+     a) it complies with the terms and conditions of this Agreement; and
+
+     b) its license agreement:
+          i) effectively disclaims on behalf of all Contributors all
+          warranties and conditions, express and implied, including warranties
+          or conditions of title and non-infringement, and implied warranties
+          or conditions of merchantability and fitness for a particular
+          purpose;
+          ii) effectively excludes on behalf of all Contributors all liability
+          for damages, including direct, indirect, special, incidental and
+          consequential damages, such as lost profits;
+          iii) states that any provisions which differ from this Agreement are
+          offered by that Contributor alone and not by any other party; and
+          iv) states that source code for the Program is available from such
+          Contributor, and informs licensees how to obtain it in a reasonable
+          manner on or through a medium customarily used for software
+          exchange.
+
+When the Program is made available in source code form:
+
+     a) it must be made available under this Agreement; and
+
+     b) a copy of this Agreement must be included with each copy of the
+     Program.
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a manner
+which does not create potential liability for other Contributors. Therefore,
+if a Contributor includes the Program in a commercial product offering, such
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
+every other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits and
+other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such Commercial
+Contributor in connection with its distribution of the Program in a commercial
+product offering. The obligations in this section do not apply to any claims
+or Losses relating to any actual or alleged intellectual property
+infringement. In order to qualify, an Indemnified Contributor must: a)
+promptly notify the Commercial Contributor in writing of such claim, and b)
+allow the Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
+Recipient is solely responsible for determining the appropriateness of using
+and distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to the
+risks and costs of program errors, compliance with applicable laws, damage to
+or loss of data, programs or equipment, and unavailability or interruption of
+operations.
+
+6. DISCLAIMER OF LIABILITY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient's rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient's obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of the
+Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this Agreement,
+whether expressly, by implication, estoppel or otherwise. All rights in the
+Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/jp.go.aist.rtm.toolscommon/COPYRIGHT
+++ b/jp.go.aist.rtm.toolscommon/COPYRIGHT
@@ -1,0 +1,77 @@
+Copyright (C) 2003-2019
+     Noriaki Ando and the OpenRTM-aist Project team
+     Intelligent Systems Research Institute,
+     National Institute of Advanced Industrial Science and Technology (AIST),
+     Tsukuba, Japan, All rights reserved.
+
+
+NOTICE
+------
+THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.
+
+
+LICENSE
+-------
+The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.
+
+1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+
+2) Individual Licnese
+You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.
+
+
+SUBMISSIONS
+-----------
+The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.
+
+
+DISCLAIMER
+----------
+THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+CONTACT INFORMATION
+-------------------
+Noriaki Ando <n-ando@aist.go.jp>
+National Institute of Advanced Industrial Science and Technology
+Intelligent Systems Research Institute
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. 
+TEL: +81-29-861-5981 FAX: +81-29-861-6631

--- a/jp.go.aist.rtm.toolscommon/about.html
+++ b/jp.go.aist.rtm.toolscommon/about.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<h3>NOTICE</h3>
+
+<p>THIS IS A LEGAL CONTRACT BETWEEN YOU AND THE COPYRIGHT HOLDER.  YOU
+SHOULD CAREFULLY READ AND ACCEPT ALL THE TERMS AND CONDITIONS SET
+FORTH IN THIS DOCUMENT BEFORE USING ALL OR ANY PORTION OF THIS
+SOFTWARE. BY USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY ALL
+OF THE TERMS AND CONDITION OF THIS LICENSE AND ALSO AGREE THAT THIS
+AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN NEGOTIATED AGREEMENT SIGNED
+BY YOU.</p>
+
+<h3>License</h3>
+
+<p>The OpenRTP-aist (H26PRO-1627, H26PRO-1628) is the dual-licensed open source
+software. You can use, copy, distribute and/or modify this library
+under the terms and conditions of either of the licenses below.</p>
+
+<p>1) EPL (ECLIPSE PUBLIC LICENSE)
+See COPYING.LIB.
+</p>
+<p>2) Individual Licnese</p>
+<p>You can purchase license from AIST and/or AIST's TLO to copy,
+distribute, modify and/or sublicense the library without any
+limitation in the terms of LGPL. The individual license should be
+concluded with a negotiated agreement between you and AIST and/or AIST
+TLO. To conclude individual license, contact the person responsible of
+AIST.</p>
+
+<h3>SUBMISSIONS</h3>
+<p>The OpenRTP-aist is maintained by the National Institute of Advanced
+Industrial Science and Technology (AIST), Tsukuba, Japan for the
+development of open-source software as part of the open-source
+software community.  By submitting comments, suggestions, code, code
+snippets, techniques (including that of usage) and algorithms
+(collectively ``Submissions''), submitters acknowledge that they have
+the right to do so, that any such Submissions are given freely and
+unreservedly, and that they waive any claims to copyright or
+ownership. In addition, submitters acknowledge that any such
+Submission might become part of the copyright maintained on the
+overall body of code that comprises the OpenRTP-aist. By making a
+Submission, submitter agree to these terms. Moreover, submitters
+acknowledge that the incorporation or modification of such Submissions
+is entirely at the discretion of the moderators of the open-source
+software projects or their designees.</p>
+
+<h3>DISCLAIMER</h3>
+<p>THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</p>
+
+<h3>CONTACT INFORMATION</h3>
+<p>
+Noriaki Ando <n-ando@aist.go.jp> <BR>
+National Institute of Advanced Industrial Science and Technology<BR>
+Intelligent Systems Research Institute<BR>
+Tsukuba Central 2, 1-1-1 Umezono, Tsukuba, Ibaraki 305-8568 JAPAN. <BR>
+TEL: +81-29-861-5981 FAX: +81-29-861-6631<BR>
+</p>
+
+</body>
+</html>

--- a/jp.go.aist.rtm.toolscommon/build.properties
+++ b/jp.go.aist.rtm.toolscommon/build.properties
@@ -10,8 +10,14 @@ bin.includes = .,\
                plugin.properties,\
                icons/,\
                schema/,\
-               lib/
+               lib/,\
+               COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt
 jars.compile.order = .
 source.. = src/
 output.. = bin/
 javacDefaultEncoding.. = UTF-8
+src.includes = COPYRIGHT,\
+               about.html,\
+               epl-1.0.txt

--- a/jp.go.aist.rtm.toolscommon/epl-1.0.txt
+++ b/jp.go.aist.rtm.toolscommon/epl-1.0.txt
@@ -1,0 +1,235 @@
+---
+title: Eclipse Public License 1.0
+spdx-id: EPL-1.0
+
+description: This commercially-friendly copyleft license provides the ability to commercially license binaries; a modern royalty-free patent license grant; and the ability for linked works to use other licenses, including commercial ones.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
+
+using:
+  - Eclipse hawkBit: https://github.com/eclipse/hawkbit/blob/master/LICENSE
+  - JUnit: https://github.com/junit-team/junit4/blob/master/LICENSE-junit.txt
+  - Quil: https://github.com/quil/quil/blob/master/LICENSE
+
+permissions:
+  - commercial-use
+  - distribution
+  - modifications
+  - patent-use
+  - private-use
+
+conditions:
+  - disclose-source
+  - include-copyright
+  - same-license
+
+limitations:
+  - liability
+  - warranty
+
+---
+
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+     a) in the case of the initial Contributor, the initial code and
+     documentation distributed under this Agreement, and
+     b) in the case of each subsequent Contributor:
+          i) changes to the Program, and
+          ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from a
+Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license agreement,
+and (ii) are not derivative works of the Program.
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+     a) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free copyright license to
+     reproduce, prepare derivative works of, publicly display, publicly
+     perform, distribute and sublicense the Contribution of such Contributor,
+     if any, and such derivative works, in source code and object code form.
+
+     b) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free patent license under
+     Licensed Patents to make, use, sell, offer to sell, import and otherwise
+     transfer the Contribution of such Contributor, if any, in source code and
+     object code form. This patent license shall apply to the combination of
+     the Contribution and the Program if, at the time the Contribution is
+     added by the Contributor, such addition of the Contribution causes such
+     combination to be covered by the Licensed Patents. The patent license
+     shall not apply to any other combinations which include the Contribution.
+     No hardware per se is licensed hereunder.
+
+     c) Recipient understands that although each Contributor grants the
+     licenses to its Contributions set forth herein, no assurances are
+     provided by any Contributor that the Program does not infringe the patent
+     or other intellectual property rights of any other entity. Each
+     Contributor disclaims any liability to Recipient for claims brought by
+     any other entity based on infringement of intellectual property rights or
+     otherwise. As a condition to exercising the rights and licenses granted
+     hereunder, each Recipient hereby assumes sole responsibility to secure
+     any other intellectual property rights needed, if any. For example, if a
+     third party patent license is required to allow Recipient to distribute
+     the Program, it is Recipient's responsibility to acquire that license
+     before distributing the Program.
+
+     d) Each Contributor represents that to its knowledge it has sufficient
+     copyright rights in its Contribution, if any, to grant the copyright
+     license set forth in this Agreement.
+
+3. REQUIREMENTS
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+     a) it complies with the terms and conditions of this Agreement; and
+
+     b) its license agreement:
+          i) effectively disclaims on behalf of all Contributors all
+          warranties and conditions, express and implied, including warranties
+          or conditions of title and non-infringement, and implied warranties
+          or conditions of merchantability and fitness for a particular
+          purpose;
+          ii) effectively excludes on behalf of all Contributors all liability
+          for damages, including direct, indirect, special, incidental and
+          consequential damages, such as lost profits;
+          iii) states that any provisions which differ from this Agreement are
+          offered by that Contributor alone and not by any other party; and
+          iv) states that source code for the Program is available from such
+          Contributor, and informs licensees how to obtain it in a reasonable
+          manner on or through a medium customarily used for software
+          exchange.
+
+When the Program is made available in source code form:
+
+     a) it must be made available under this Agreement; and
+
+     b) a copy of this Agreement must be included with each copy of the
+     Program.
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a manner
+which does not create potential liability for other Contributors. Therefore,
+if a Contributor includes the Program in a commercial product offering, such
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
+every other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits and
+other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such Commercial
+Contributor in connection with its distribution of the Program in a commercial
+product offering. The obligations in this section do not apply to any claims
+or Losses relating to any actual or alleged intellectual property
+infringement. In order to qualify, an Indemnified Contributor must: a)
+promptly notify the Commercial Contributor in writing of such claim, and b)
+allow the Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
+Recipient is solely responsible for determining the appropriateness of using
+and distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to the
+risks and costs of program errors, compliance with applicable laws, damage to
+or loss of data, programs or equipment, and unavailability or interruption of
+operations.
+
+6. DISCLAIMER OF LIABILITY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient's rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient's obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of the
+Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this Agreement,
+whether expressly, by implication, estoppel or otherwise. All rights in the
+Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.


### PR DESCRIPTION
## Identify the Bug

Link to #241

## Description of the Change

各プラグインに，ライセンスに関係したファイルを同梱するように修正させて頂きました．
また，以下の操作でライセンス情報が表示されるように修正させて頂きました．
　上部メニューの｢Help｣-｢About Eclipse Platform｣を選択し，｢About Eclipse Platform｣を表示
　｢About Eclipse Platform｣の｢Install Details｣ボタンをクリック
　｢Plug-ins｣タブを選択し，｢Provider｣が｢AIST｣となっているプラグインを選択し，｢Legal Info.｣ボタンをクリック

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests? ユニットテストなし