### PR TITLE
FSM型RTC向けのユニットテストを追加

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/ModuleName.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/ModuleName.py
@@ -1,0 +1,277 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -*- Python -*-
+
+"""
+ @file ModuleName.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+import sys
+import time
+sys.path.append(".")
+
+# Import RTM module
+import RTC
+import OpenRTM_aist
+import OpenRTM_aist.StaticFSM as StaticFSM
+import OpenRTM_aist.EventPort as EventPort
+import ModuleNameFSM
+
+
+# Import Service implementation class
+# <rtc-template block="service_impl">
+
+# </rtc-template>
+
+# Import Service stub modules
+# <rtc-template block="consumer_import">
+# </rtc-template>
+
+
+# This module's spesification
+# <rtc-template block="module_spec">
+modulename_spec = ["implementation_id", "ModuleName", 
+         "type_name",         "ModuleName", 
+         "description",       "ModuleDescription", 
+         "version",           "1.0.0", 
+         "vendor",            "VenderName", 
+         "category",          "Category", 
+         "activity_type",     "STATIC", 
+         "max_instance",      "1", 
+         "language",          "Python", 
+         "lang_type",         "SCRIPT",
+         ""]
+# </rtc-template>
+
+##
+# @class ModuleName
+# @brief ModuleDescription
+# 
+# 
+class ModuleName(OpenRTM_aist.DataFlowComponentBase):
+	
+    ##
+    # @brief constructor
+    # @param manager Maneger Object
+    # 
+    def __init__(self, manager):
+        OpenRTM_aist.DataFlowComponentBase.__init__(self, manager)
+
+
+
+		
+
+
+        # initialize of configuration-data.
+        # <rtc-template block="init_conf_param">
+		
+        # </rtc-template>
+
+
+		 
+    ##
+    #
+    # The initialize action (on CREATED->ALIVE transition)
+    # 
+    # @return RTC::ReturnCode_t
+    # 
+    #
+    def onInitialize(self):
+        # Bind variables and configuration variable
+		
+        # Set InPort buffers
+		
+        # Set OutPort buffers
+		
+        # Set service provider to Ports
+		
+        # Set service consumers to Ports
+		
+        # Set CORBA Service Ports
+        self._fsm = StaticFSM.Machine(ModuleNameFSM.Top, self)
+        self._eventIn = EventPort.EventInPort("event", self._fsm)
+        self.addInPort("event", self._eventIn)
+		
+        return RTC.RTC_OK
+	
+    ###
+    ## 
+    ## The finalize action (on ALIVE->END transition)
+    ## 
+    ## @return RTC::ReturnCode_t
+    #
+    ## 
+    #def onFinalize(self):
+    #
+    #    self._fsm.shutdown()
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The startup action when ExecutionContext startup
+    ## 
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onStartup(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The shutdown action when ExecutionContext stop
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onShutdown(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The activated action (Active state entry action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ## 
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onActivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The deactivated action (Active state exit action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onDeactivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The execution action that is invoked periodically
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onExecute(self, ec_id):
+    #
+        self._fsm.run_event()
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The aborting action when main logic error occurred.
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onAborting(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The error action in ERROR state
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onError(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The reset action that is invoked resetting
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onReset(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The state update action that is invoked after onExecute() action
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+
+    ##
+    #def onStateUpdate(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The action that is invoked when execution context's rate is changed
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onRateChanged(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+
+
+
+def ModuleNameInit(manager):
+    profile = OpenRTM_aist.Properties(defaults_str=modulename_spec)
+    manager.registerFactory(profile,
+                            ModuleName,
+                            OpenRTM_aist.Delete)
+
+def MyModuleInit(manager):
+    ModuleNameInit(manager)
+
+    # create instance_name option for createComponent()
+    instance_name = [i for i in sys.argv if "--instance_name=" in i]
+    if instance_name:
+        args = instance_name[0].replace("--", "?")
+    else:
+        args = ""
+  
+    # Create a component
+    comp = manager.createComponent("ModuleName" + args)
+
+def main():
+    # remove --instance_name= option
+    argv = [i for i in sys.argv if not "--instance_name=" in i]
+    # Initialize manager
+    mgr = OpenRTM_aist.Manager.init(sys.argv)
+    mgr.setModuleInitProc(MyModuleInit)
+    mgr.activateManager()
+    mgr.runManager()
+
+if __name__ == "__main__":
+    main()
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/ModuleNameFSM.py
@@ -1,0 +1,29 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+ @file ModuleNameFSM.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+import sys
+
+import RTC
+import OpenRTM_aist.StaticFSM as StaticFSM
+
+@StaticFSM.FSM_TOPSTATE
+class Top(StaticFSM.Link):
+    def onInit(self):
+        self.set_state(StaticFSM.State(State01))
+        return RTC.RTC_OK
+        
+
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class State01(StaticFSM.Link):
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class State02(StaticFSM.Link):
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/ModuleNameFSM.scxml
@@ -1,0 +1,12 @@
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=854 h=400  -->
+ <state id="InitialState"><!--   node-size-and-position x=90 y=150 w=75 h=75  -->
+  <transition id="21" target="State01"></transition>
+ </state>
+ <state id="State01"><!--   node-size-and-position x=280 y=150 w=75 h=75  -->
+  <transition id="22" target="State02"></transition>
+ </state>
+ <state id="State02"><!--   node-size-and-position x=470 y=150 w=75 h=75  -->
+  <transition id="23" target="FinalState"></transition>
+ </state>
+ <final id="FinalState"><!--   node-size-and-position x=650 y=160 w=75 h=75  --></final>
+</scxml>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/README.md
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/README.md
@@ -1,0 +1,278 @@
+﻿# ModuleName
+
+## Overview
+
+ModuleDescription
+
+## Description
+
+
+
+### Input and Output
+
+
+
+### Algorithm etc
+
+
+
+### Basic Information
+
+|  |  |
+----|---- 
+| Module Name | ModuleName |
+| Description | ModuleDescription |
+| Version | 1.0.0 |
+| Vendor | VenderName |
+| Category | Category |
+| Comp. Type | STATIC |
+| Act. Type | PERIODIC |
+| Kind | DataFlowComponent |
+| MAX Inst. | 1 |
+
+### Activity definition
+
+<table>
+  <tr>
+    <td rowspan="4">on_initialize</td>
+    <td colspan="2">implemented</td>
+    <tr>
+      <td>Description</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PreCondition</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PostCondition</td>
+      <td></td>
+    </tr>
+  </tr>
+  <tr>
+    <td>on_finalize</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_startup</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_shutdown</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_activated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_deactivated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_execute</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_aborting</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_error</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_reset</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_state_update</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_rate_changed</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+### EventPorts definition
+
+|  |  |
+----|---- 
+| Port Name | FSMEvent |
+| FSM Type | StaticFSM |
+
+#### Node list
+
+<table>
+  <tr>
+    <td>State Name</td>
+    <td>Event Name</td>
+    <td>Target State</td>
+  </tr>
+  <tr>
+    <td>InitialState</td>
+    <td colspan="2">Initial State</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State01</td>
+    <td></td>
+    <td>State02</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State02</td>
+    <td></td>
+    <td>FinalState</td>
+  </tr>
+  <tr>
+    <td>FinalState</td>
+    <td colspan="2">Final State</td>
+  </tr>
+
+</table>
+
+#### Event list
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">InitialState</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">FinalState</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+
+
+### InPorts definition
+
+
+### OutPorts definition
+
+
+### Service Port definition
+
+
+### Configuration definition
+
+
+## Demo
+
+## Requirement
+
+## Setup
+
+### Windows
+
+### Ubuntu
+
+## Usage
+
+## Running the tests
+
+## LICENCE
+
+
+
+
+## References
+
+
+
+
+## Author
+
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/RTC.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<rtc:RtcProfile rtc:version="0.3" rtc:id="RTC:VenderName:Category:ModuleName:1.0.0" xmlns:rtc="http://www.openrtp.org/namespaces/rtc" xmlns:rtcExt="http://www.openrtp.org/namespaces/rtc_ext" xmlns:rtcDoc="http://www.openrtp.org/namespaces/rtc_doc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <rtc:BasicInfo xsi:type="rtcExt:basic_info_ext" rtcExt:saveProject="FSMTest" rtc:updateDate="2019-12-19T22:51:23.000+09:00" rtc:creationDate="2019-12-19T22:49:56.000+09:00" rtc:version="1.0.0" rtc:vendor="VenderName" rtc:maxInstances="1" rtc:executionType="PeriodicExecutionContext" rtc:executionRate="1000.0" rtc:description="ModuleDescription" rtc:category="Category" rtc:componentKind="DataFlowComponent" rtc:activityType="PERIODIC" rtc:componentType="STATIC" rtc:name="ModuleName">
+        <rtcExt:Properties rtcExt:value="true" rtcExt:name="FSM"/>
+        <rtcExt:Properties rtcExt:value="StaticFSM" rtcExt:name="FSMType"/>
+    </rtc:BasicInfo>
+    <rtc:Actions>
+        <rtc:OnInitialize xsi:type="rtcDoc:action_status_doc" rtc:implemented="true"/>
+        <rtc:OnFinalize xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStartup xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnShutdown xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnActivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnDeactivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAborting xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnError xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnReset xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnExecute xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStateUpdate xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnRateChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAction xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+    </rtc:Actions>
+    <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEvent" rtc:type="Any" rtc:name="FSMEvent" rtc:portType="EventPort">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="" rtc:name="">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="" rtc:name="">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State01" rtc:source="InitialState" rtc:condition="" rtc:name="">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+    </rtc:DataPorts>
+    <rtc:Language xsi:type="rtcExt:language_ext" rtc:kind="Python"/>
+</rtc:RtcProfile>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/test/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_test(NAME ${PROJECT_NAME}_test COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}Test.py -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+string(REPLACE ";" "\\;" PYTHONPATH "$ENV{PYTHONPATH}")
+if(UNIX)
+  set_tests_properties(${PROJECT_NAME}_test PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}:${PYTHONPATH}")
+else()
+  set_tests_properties(${PROJECT_NAME}_test PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}\;${PYTHONPATH}")
+endif()

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/test/ModuleNameTest.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/test/ModuleNameTest.py
@@ -1,0 +1,279 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -*- Python -*-
+
+"""
+ @file ModuleNameTest.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+from __future__ import print_function
+import sys
+import time
+sys.path.append(".")
+
+# Import RTM module
+import RTC
+import OpenRTM_aist
+
+
+# Import Service implementation class
+# <rtc-template block="service_impl">
+
+import ModuleName
+
+# </rtc-template>
+
+# Import Service stub modules
+# <rtc-template block="consumer_import">
+# </rtc-template>
+
+
+# This module's spesification
+# <rtc-template block="module_spec">
+modulenametest_spec = ["implementation_id", "ModuleNameTest", 
+         "type_name",         "ModuleNameTest", 
+         "description",       "ModuleDescription", 
+         "version",           "1.0.0", 
+         "vendor",            "VenderName", 
+         "category",          "Category", 
+         "activity_type",     "STATIC", 
+         "max_instance",      "1", 
+         "language",          "Python", 
+         "lang_type",         "SCRIPT",
+         ""]
+# </rtc-template>
+
+##
+# @class ModuleNameTest
+# @brief ModuleDescription
+# 
+# 
+class ModuleNameTest(OpenRTM_aist.DataFlowComponentBase):
+    
+    ##
+    # @brief constructor
+    # @param manager Maneger Object
+    # 
+    def __init__(self, manager):
+        OpenRTM_aist.DataFlowComponentBase.__init__(self, manager)
+
+
+
+        
+
+
+        # initialize of configuration-data.
+        # <rtc-template block="init_conf_param">
+        
+        # </rtc-template>
+
+
+         
+    ##
+    #
+    # The initialize action (on CREATED->ALIVE transition)
+    # 
+    # @return RTC::ReturnCode_t
+    # 
+    #
+    def onInitialize(self):
+        # Bind variables and configuration variable
+        
+        # Set InPort buffers
+        
+        # Set OutPort buffers
+        
+        # Set service provider to Ports
+        
+        # Set service consumers to Ports
+        
+        # Set CORBA Service Ports
+        
+        return RTC.RTC_OK
+    
+    ###
+    ## 
+    ## The finalize action (on ALIVE->END transition)
+    ## 
+    ## @return RTC::ReturnCode_t
+    #
+    ## 
+    #def onFinalize(self):
+    #
+    #    return RTC.RTC_OK
+    
+    #    ##
+    ##
+    ## The startup action when ExecutionContext startup
+    ## 
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onStartup(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The shutdown action when ExecutionContext stop
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onShutdown(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The activated action (Active state entry action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ## 
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onActivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    #    ##
+    ##
+    ## The deactivated action (Active state exit action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onDeactivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The execution action that is invoked periodically
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onExecute(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The aborting action when main logic error occurred.
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    #    #
+    ##
+    #def onAborting(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The error action in ERROR state
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onError(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The reset action that is invoked resetting
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onReset(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The state update action that is invoked after onExecute() action
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+
+    ##
+    #def onStateUpdate(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The action that is invoked when execution context's rate is changed
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onRateChanged(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    def runTest(self):
+        return True
+
+def RunTest():
+    manager = OpenRTM_aist.Manager.instance()
+    comp = manager.getComponent("ModuleNameTest0")
+    if comp is None:
+        print('Component get failed.', file=sys.stderr)
+        return False
+    return comp.runTest()
+
+def ModuleNameTestInit(manager):
+    profile = OpenRTM_aist.Properties(defaults_str=modulenametest_spec)
+    manager.registerFactory(profile,
+                            ModuleNameTest,
+                            OpenRTM_aist.Delete)
+
+def MyModuleInit(manager):
+    ModuleNameTestInit(manager)
+    ModuleName.ModuleNameInit(manager)
+
+    # Create a component
+    comp = manager.createComponent("ModuleNameTest")
+
+def main():
+    mgr = OpenRTM_aist.Manager.init(sys.argv)
+    mgr.setModuleInitProc(MyModuleInit)
+    mgr.activateManager()
+    mgr.runManager(True)
+
+    ret = RunTest()
+    mgr.shutdown()
+
+    if ret:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/ModuleName.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/ModuleName.py
@@ -1,0 +1,279 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -*- Python -*-
+
+"""
+ @file ModuleName.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+import sys
+import time
+sys.path.append(".")
+
+# Import RTM module
+import RTC
+import OpenRTM_aist
+import OpenRTM_aist.StaticFSM as StaticFSM
+import OpenRTM_aist.EventPort as EventPort
+import ModuleNameFSM
+
+
+# Import Service implementation class
+# <rtc-template block="service_impl">
+
+# </rtc-template>
+
+# Import Service stub modules
+# <rtc-template block="consumer_import">
+# </rtc-template>
+
+
+# This module's spesification
+# <rtc-template block="module_spec">
+modulename_spec = ["implementation_id", "ModuleName", 
+         "type_name",         "ModuleName", 
+         "description",       "ModuleDescription", 
+         "version",           "1.0.0", 
+         "vendor",            "VenderName", 
+         "category",          "Category", 
+         "activity_type",     "STATIC", 
+         "max_instance",      "1", 
+         "language",          "Python", 
+         "lang_type",         "SCRIPT",
+         ""]
+# </rtc-template>
+
+##
+# @class ModuleName
+# @brief ModuleDescription
+# 
+# 
+class ModuleName(OpenRTM_aist.DataFlowComponentBase):
+	
+    ##
+    # @brief constructor
+    # @param manager Maneger Object
+    # 
+    def __init__(self, manager):
+        OpenRTM_aist.DataFlowComponentBase.__init__(self, manager)
+
+
+
+		
+
+
+        # initialize of configuration-data.
+        # <rtc-template block="init_conf_param">
+		
+        # </rtc-template>
+
+
+		 
+    ##
+    #
+    # The initialize action (on CREATED->ALIVE transition)
+    # 
+    # @return RTC::ReturnCode_t
+    # 
+    #
+    def onInitialize(self):
+        # Bind variables and configuration variable
+		
+        # Set InPort buffers
+		
+        # Set OutPort buffers
+		
+        # Set service provider to Ports
+		
+        # Set service consumers to Ports
+		
+        # Set CORBA Service Ports
+        self._fsm = StaticFSM.Machine(ModuleNameFSM.Top, self)
+        self._eventIn = EventPort.EventInPort("event", self._fsm)
+        self.addInPort("event", self._eventIn)
+        self._eventIn.bindEvent0("Event01-02", ModuleNameFSM.Top.Event01-02)
+        self._eventIn.bindEvent0("Event02-Final", ModuleNameFSM.Top.Event02-Final)
+		
+        return RTC.RTC_OK
+	
+    ###
+    ## 
+    ## The finalize action (on ALIVE->END transition)
+    ## 
+    ## @return RTC::ReturnCode_t
+    #
+    ## 
+    #def onFinalize(self):
+    #
+    #    self._fsm.shutdown()
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The startup action when ExecutionContext startup
+    ## 
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onStartup(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The shutdown action when ExecutionContext stop
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onShutdown(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The activated action (Active state entry action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ## 
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onActivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The deactivated action (Active state exit action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onDeactivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The execution action that is invoked periodically
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onExecute(self, ec_id):
+    #
+        self._fsm.run_event()
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The aborting action when main logic error occurred.
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onAborting(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The error action in ERROR state
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onError(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The reset action that is invoked resetting
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onReset(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The state update action that is invoked after onExecute() action
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+
+    ##
+    #def onStateUpdate(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The action that is invoked when execution context's rate is changed
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onRateChanged(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+
+
+
+def ModuleNameInit(manager):
+    profile = OpenRTM_aist.Properties(defaults_str=modulename_spec)
+    manager.registerFactory(profile,
+                            ModuleName,
+                            OpenRTM_aist.Delete)
+
+def MyModuleInit(manager):
+    ModuleNameInit(manager)
+
+    # create instance_name option for createComponent()
+    instance_name = [i for i in sys.argv if "--instance_name=" in i]
+    if instance_name:
+        args = instance_name[0].replace("--", "?")
+    else:
+        args = ""
+  
+    # Create a component
+    comp = manager.createComponent("ModuleName" + args)
+
+def main():
+    # remove --instance_name= option
+    argv = [i for i in sys.argv if not "--instance_name=" in i]
+    # Initialize manager
+    mgr = OpenRTM_aist.Manager.init(sys.argv)
+    mgr.setModuleInitProc(MyModuleInit)
+    mgr.activateManager()
+    mgr.runManager()
+
+if __name__ == "__main__":
+    main()
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/ModuleNameFSM.py
@@ -1,0 +1,43 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+ @file ModuleNameFSM.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+import sys
+
+import RTC
+import OpenRTM_aist.StaticFSM as StaticFSM
+
+@StaticFSM.FSM_TOPSTATE
+class Top(StaticFSM.Link):
+    def onInit(self):
+        self.set_state(StaticFSM.State(State01))
+        return RTC.RTC_OK
+        
+    """
+    """
+    def Event01-02(self):
+        pass
+
+    """
+    """
+    def Event02-Final(self):
+        pass
+
+
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class State01(StaticFSM.Link):
+    def Event01-02(self):
+        self.set_state(StaticFSM.State(State02))
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class State02(StaticFSM.Link):
+    def Event02-Final(self):
+        self.set_state(StaticFSM.State(FinalState))
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/ModuleNameFSM.scxml
@@ -1,0 +1,12 @@
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=212 h=513  -->
+ <state id="InitialState"><!--   node-size-and-position x=55.86 y=43 w=100 h=75  -->
+  <transition id="13" target="State01"></transition>
+ </state>
+ <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->
+  <transition cond="Cond01" event="Event01-02" id="15" target="State02"></transition>
+ </state>
+ <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->
+  <transition cond="Cond02" event="Event02-Final" id="17" target="FinalState"></transition>
+ </state>
+ <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final>
+</scxml>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/README.md
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/README.md
@@ -1,0 +1,278 @@
+﻿# ModuleName
+
+## Overview
+
+ModuleDescription
+
+## Description
+
+
+
+### Input and Output
+
+
+
+### Algorithm etc
+
+
+
+### Basic Information
+
+|  |  |
+----|---- 
+| Module Name | ModuleName |
+| Description | ModuleDescription |
+| Version | 1.0.0 |
+| Vendor | VenderName |
+| Category | Category |
+| Comp. Type | STATIC |
+| Act. Type | PERIODIC |
+| Kind | DataFlowComponent |
+| MAX Inst. | 1 |
+
+### Activity definition
+
+<table>
+  <tr>
+    <td rowspan="4">on_initialize</td>
+    <td colspan="2">implemented</td>
+    <tr>
+      <td>Description</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PreCondition</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PostCondition</td>
+      <td></td>
+    </tr>
+  </tr>
+  <tr>
+    <td>on_finalize</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_startup</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_shutdown</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_activated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_deactivated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_execute</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_aborting</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_error</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_reset</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_state_update</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_rate_changed</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+### EventPorts definition
+
+|  |  |
+----|---- 
+| Port Name | FSMEventPort |
+| FSM Type | StaticFSM |
+
+#### Node list
+
+<table>
+  <tr>
+    <td>State Name</td>
+    <td>Event Name</td>
+    <td>Target State</td>
+  </tr>
+  <tr>
+    <td>InitialState</td>
+    <td colspan="2">Initial State</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State01</td>
+    <td>Event01-02</td>
+    <td>State02</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State02</td>
+    <td>Event02-Final</td>
+    <td>FinalState</td>
+  </tr>
+  <tr>
+    <td>FinalState</td>
+    <td colspan="2">Final State</td>
+  </tr>
+
+</table>
+
+#### Event list
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">InitialState</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### Event01-02
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### Event02-Final
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">FinalState</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+
+
+### InPorts definition
+
+
+### OutPorts definition
+
+
+### Service Port definition
+
+
+### Configuration definition
+
+
+## Demo
+
+## Requirement
+
+## Setup
+
+### Windows
+
+### Ubuntu
+
+## Usage
+
+## Running the tests
+
+## LICENCE
+
+
+
+
+## References
+
+
+
+
+## Author
+
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/RTC.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<rtc:RtcProfile rtc:version="0.3" rtc:id="RTC:VenderName:Category:ModuleName:1.0.0" xmlns:rtc="http://www.openrtp.org/namespaces/rtc" xmlns:rtcExt="http://www.openrtp.org/namespaces/rtc_ext" xmlns:rtcDoc="http://www.openrtp.org/namespaces/rtc_doc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <rtc:BasicInfo xsi:type="rtcExt:basic_info_ext" rtcExt:saveProject="FSMTest" rtc:updateDate="2019-12-19T22:51:23.000+09:00" rtc:creationDate="2019-12-19T22:49:56.000+09:00" rtc:version="1.0.0" rtc:vendor="VenderName" rtc:maxInstances="1" rtc:executionType="PeriodicExecutionContext" rtc:executionRate="1000.0" rtc:description="ModuleDescription" rtc:category="Category" rtc:componentKind="DataFlowComponent" rtc:activityType="PERIODIC" rtc:componentType="STATIC" rtc:name="ModuleName">
+        <rtcExt:Properties rtcExt:value="true" rtcExt:name="FSM"/>
+        <rtcExt:Properties rtcExt:value="StaticFSM" rtcExt:name="FSMType"/>
+    </rtc:BasicInfo>
+    <rtc:Actions>
+        <rtc:OnInitialize xsi:type="rtcDoc:action_status_doc" rtc:implemented="true"/>
+        <rtc:OnFinalize xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStartup xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnShutdown xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnActivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnDeactivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAborting xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnError xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnReset xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnExecute xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStateUpdate xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnRateChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAction xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+    </rtc:Actions>
+    <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="" rtc:name="Event01-02">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="" rtc:name="Event02-Final">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State01" rtc:source="InitialState" rtc:condition="" rtc:name="">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01-02">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02-Final">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+    </rtc:DataPorts>
+    <rtc:Language xsi:type="rtcExt:language_ext" rtc:kind="Python"/>
+</rtc:RtcProfile>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/test/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_test(NAME ${PROJECT_NAME}_test COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}Test.py -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event01-02&fsm_event_name=Event01-02,${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event02-Final&fsm_event_name=Event02-Final,${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event01-02&fsm_event_name=Event01-02,${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event02-Final&fsm_event_name=Event02-Final" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+string(REPLACE ";" "\\;" PYTHONPATH "$ENV{PYTHONPATH}")
+if(UNIX)
+  set_tests_properties(${PROJECT_NAME}_test PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}:${PYTHONPATH}")
+else()
+  set_tests_properties(${PROJECT_NAME}_test PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}\;${PYTHONPATH}")
+endif()

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/test/ModuleNameTest.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/test/ModuleNameTest.py
@@ -1,0 +1,291 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -*- Python -*-
+
+"""
+ @file ModuleNameTest.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+from __future__ import print_function
+import sys
+import time
+sys.path.append(".")
+
+# Import RTM module
+import RTC
+import OpenRTM_aist
+
+
+# Import Service implementation class
+# <rtc-template block="service_impl">
+
+import ModuleName
+
+# </rtc-template>
+
+# Import Service stub modules
+# <rtc-template block="consumer_import">
+# </rtc-template>
+
+
+# This module's spesification
+# <rtc-template block="module_spec">
+modulenametest_spec = ["implementation_id", "ModuleNameTest", 
+         "type_name",         "ModuleNameTest", 
+         "description",       "ModuleDescription", 
+         "version",           "1.0.0", 
+         "vendor",            "VenderName", 
+         "category",          "Category", 
+         "activity_type",     "STATIC", 
+         "max_instance",      "1", 
+         "language",          "Python", 
+         "lang_type",         "SCRIPT",
+         ""]
+# </rtc-template>
+
+##
+# @class ModuleNameTest
+# @brief ModuleDescription
+# 
+# 
+class ModuleNameTest(OpenRTM_aist.DataFlowComponentBase):
+    
+    ##
+    # @brief constructor
+    # @param manager Maneger Object
+    # 
+    def __init__(self, manager):
+        OpenRTM_aist.DataFlowComponentBase.__init__(self, manager)
+
+
+
+        
+
+        self._d_Event01-02 = OpenRTM_aist.instantiateDataType(RTC.TimedLong)
+        """
+        """
+        self._Event01-02Out = OpenRTM_aist.OutPort("Event01-02", self._d_Event01-02)
+
+        self._d_Event02-Final = OpenRTM_aist.instantiateDataType(RTC.TimedLong)
+        """
+        """
+        self._Event02-FinalOut = OpenRTM_aist.OutPort("Event02-Final", self._d_Event02-Final)
+
+
+        # initialize of configuration-data.
+        # <rtc-template block="init_conf_param">
+        
+        # </rtc-template>
+
+
+         
+    ##
+    #
+    # The initialize action (on CREATED->ALIVE transition)
+    # 
+    # @return RTC::ReturnCode_t
+    # 
+    #
+    def onInitialize(self):
+        # Bind variables and configuration variable
+        
+        # Set InPort buffers
+        
+        # Set OutPort buffers
+        self.addOutPort("Event01-02", self._Event01-02Out)
+        self.addOutPort("Event02-Final", self._Event02-FinalOut)
+        
+        # Set service provider to Ports
+        
+        # Set service consumers to Ports
+        
+        # Set CORBA Service Ports
+        
+        return RTC.RTC_OK
+    
+    ###
+    ## 
+    ## The finalize action (on ALIVE->END transition)
+    ## 
+    ## @return RTC::ReturnCode_t
+    #
+    ## 
+    #def onFinalize(self):
+    #
+    #    return RTC.RTC_OK
+    
+    #    ##
+    ##
+    ## The startup action when ExecutionContext startup
+    ## 
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onStartup(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The shutdown action when ExecutionContext stop
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onShutdown(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The activated action (Active state entry action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ## 
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onActivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    #    ##
+    ##
+    ## The deactivated action (Active state exit action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onDeactivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The execution action that is invoked periodically
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onExecute(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The aborting action when main logic error occurred.
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    #    #
+    ##
+    #def onAborting(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The error action in ERROR state
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onError(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The reset action that is invoked resetting
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onReset(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The state update action that is invoked after onExecute() action
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+
+    ##
+    #def onStateUpdate(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The action that is invoked when execution context's rate is changed
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onRateChanged(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    def runTest(self):
+        return True
+
+def RunTest():
+    manager = OpenRTM_aist.Manager.instance()
+    comp = manager.getComponent("ModuleNameTest0")
+    if comp is None:
+        print('Component get failed.', file=sys.stderr)
+        return False
+    return comp.runTest()
+
+def ModuleNameTestInit(manager):
+    profile = OpenRTM_aist.Properties(defaults_str=modulenametest_spec)
+    manager.registerFactory(profile,
+                            ModuleNameTest,
+                            OpenRTM_aist.Delete)
+
+def MyModuleInit(manager):
+    ModuleNameTestInit(manager)
+    ModuleName.ModuleNameInit(manager)
+
+    # Create a component
+    comp = manager.createComponent("ModuleNameTest")
+
+def main():
+    mgr = OpenRTM_aist.Manager.init(sys.argv)
+    mgr.setModuleInitProc(MyModuleInit)
+    mgr.activateManager()
+    mgr.runManager(True)
+
+    ret = RunTest()
+    mgr.shutdown()
+
+    if ret:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/ModuleName.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/ModuleName.py
@@ -1,0 +1,279 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -*- Python -*-
+
+"""
+ @file ModuleName.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+import sys
+import time
+sys.path.append(".")
+
+# Import RTM module
+import RTC
+import OpenRTM_aist
+import OpenRTM_aist.StaticFSM as StaticFSM
+import OpenRTM_aist.EventPort as EventPort
+import ModuleNameFSM
+
+
+# Import Service implementation class
+# <rtc-template block="service_impl">
+
+# </rtc-template>
+
+# Import Service stub modules
+# <rtc-template block="consumer_import">
+# </rtc-template>
+
+
+# This module's spesification
+# <rtc-template block="module_spec">
+modulename_spec = ["implementation_id", "ModuleName", 
+         "type_name",         "ModuleName", 
+         "description",       "ModuleDescription", 
+         "version",           "1.0.0", 
+         "vendor",            "VenderName", 
+         "category",          "Category", 
+         "activity_type",     "STATIC", 
+         "max_instance",      "1", 
+         "language",          "Python", 
+         "lang_type",         "SCRIPT",
+         ""]
+# </rtc-template>
+
+##
+# @class ModuleName
+# @brief ModuleDescription
+# 
+# 
+class ModuleName(OpenRTM_aist.DataFlowComponentBase):
+	
+    ##
+    # @brief constructor
+    # @param manager Maneger Object
+    # 
+    def __init__(self, manager):
+        OpenRTM_aist.DataFlowComponentBase.__init__(self, manager)
+
+
+
+		
+
+
+        # initialize of configuration-data.
+        # <rtc-template block="init_conf_param">
+		
+        # </rtc-template>
+
+
+		 
+    ##
+    #
+    # The initialize action (on CREATED->ALIVE transition)
+    # 
+    # @return RTC::ReturnCode_t
+    # 
+    #
+    def onInitialize(self):
+        # Bind variables and configuration variable
+		
+        # Set InPort buffers
+		
+        # Set OutPort buffers
+		
+        # Set service provider to Ports
+		
+        # Set service consumers to Ports
+		
+        # Set CORBA Service Ports
+        self._fsm = StaticFSM.Machine(ModuleNameFSM.Top, self)
+        self._eventIn = EventPort.EventInPort("event", self._fsm)
+        self.addInPort("event", self._eventIn)
+        self._eventIn.bindEvent1("Event01-02", ModuleNameFSM.Top.Event01-02, OpenRTM_aist.instantiateDataType(RTC.TimedLong))
+        self._eventIn.bindEvent1("Event02-Final", ModuleNameFSM.Top.Event02-Final, OpenRTM_aist.instantiateDataType(RTC.TimedString))
+		
+        return RTC.RTC_OK
+	
+    ###
+    ## 
+    ## The finalize action (on ALIVE->END transition)
+    ## 
+    ## @return RTC::ReturnCode_t
+    #
+    ## 
+    #def onFinalize(self):
+    #
+    #    self._fsm.shutdown()
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The startup action when ExecutionContext startup
+    ## 
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onStartup(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The shutdown action when ExecutionContext stop
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onShutdown(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The activated action (Active state entry action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ## 
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onActivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The deactivated action (Active state exit action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onDeactivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The execution action that is invoked periodically
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onExecute(self, ec_id):
+    #
+        self._fsm.run_event()
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The aborting action when main logic error occurred.
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onAborting(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The error action in ERROR state
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onError(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The reset action that is invoked resetting
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onReset(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The state update action that is invoked after onExecute() action
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+
+    ##
+    #def onStateUpdate(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The action that is invoked when execution context's rate is changed
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onRateChanged(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+
+
+
+def ModuleNameInit(manager):
+    profile = OpenRTM_aist.Properties(defaults_str=modulename_spec)
+    manager.registerFactory(profile,
+                            ModuleName,
+                            OpenRTM_aist.Delete)
+
+def MyModuleInit(manager):
+    ModuleNameInit(manager)
+
+    # create instance_name option for createComponent()
+    instance_name = [i for i in sys.argv if "--instance_name=" in i]
+    if instance_name:
+        args = instance_name[0].replace("--", "?")
+    else:
+        args = ""
+  
+    # Create a component
+    comp = manager.createComponent("ModuleName" + args)
+
+def main():
+    # remove --instance_name= option
+    argv = [i for i in sys.argv if not "--instance_name=" in i]
+    # Initialize manager
+    mgr = OpenRTM_aist.Manager.init(sys.argv)
+    mgr.setModuleInitProc(MyModuleInit)
+    mgr.activateManager()
+    mgr.runManager()
+
+if __name__ == "__main__":
+    main()
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/ModuleNameFSM.py
@@ -1,0 +1,55 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+ @file ModuleNameFSM.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+import sys
+
+import RTC
+import OpenRTM_aist.StaticFSM as StaticFSM
+
+@StaticFSM.FSM_TOPSTATE
+class Top(StaticFSM.Link):
+    def onInit(self):
+        self.set_state(StaticFSM.State(State01))
+        return RTC.RTC_OK
+        
+    """
+    Abst01-02
+    - Type: Type01-02
+     - Number: Num01-02
+     - Semantics: Detail01-02
+    - Unit: Unit01-02
+     - Operation Cycle: Period01-02
+    """
+    def Event01-02(self, data):
+        pass
+
+    """
+    Abst02-Final
+    - Type: Type02-Final
+     - Number: Num02-Final
+     - Semantics: Detail02-Final
+    - Unit: Unit02-Final
+     - Operation Cycle: Period02-Final
+    """
+    def Event02-Final(self, data):
+        pass
+
+
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class State01(StaticFSM.Link):
+    def Event01-02(self, data):
+        self.set_state(StaticFSM.State(State02))
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class State02(StaticFSM.Link):
+    def Event02-Final(self, data):
+        self.set_state(StaticFSM.State(FinalState))
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/ModuleNameFSM.scxml
@@ -1,0 +1,12 @@
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=212 h=513  -->
+ <state id="InitialState"><!--   node-size-and-position x=55.86 y=43 w=100 h=75  -->
+  <transition id="13" target="State01"></transition>
+ </state>
+ <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->
+  <transition cond="Cond01" event="Event01-02" id="15" target="State02"></transition>
+ </state>
+ <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->
+  <transition cond="Cond02" event="Event02-Final" id="17" target="FinalState"></transition>
+ </state>
+ <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final>
+</scxml>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/README.md
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/README.md
@@ -1,0 +1,278 @@
+﻿# ModuleName
+
+## Overview
+
+ModuleDescription
+
+## Description
+
+
+
+### Input and Output
+
+
+
+### Algorithm etc
+
+
+
+### Basic Information
+
+|  |  |
+----|---- 
+| Module Name | ModuleName |
+| Description | ModuleDescription |
+| Version | 1.0.0 |
+| Vendor | VenderName |
+| Category | Category |
+| Comp. Type | STATIC |
+| Act. Type | PERIODIC |
+| Kind | DataFlowComponent |
+| MAX Inst. | 1 |
+
+### Activity definition
+
+<table>
+  <tr>
+    <td rowspan="4">on_initialize</td>
+    <td colspan="2">implemented</td>
+    <tr>
+      <td>Description</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PreCondition</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PostCondition</td>
+      <td></td>
+    </tr>
+  </tr>
+  <tr>
+    <td>on_finalize</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_startup</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_shutdown</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_activated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_deactivated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_execute</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_aborting</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_error</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_reset</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_state_update</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_rate_changed</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+### EventPorts definition
+
+|  |  |
+----|---- 
+| Port Name | FSMEventPort |
+| FSM Type | StaticFSM |
+
+#### Node list
+
+<table>
+  <tr>
+    <td>State Name</td>
+    <td>Event Name</td>
+    <td>Target State</td>
+  </tr>
+  <tr>
+    <td>InitialState</td>
+    <td colspan="2">Initial State</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State01</td>
+    <td>Event01-02</td>
+    <td>State02</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State02</td>
+    <td>Event02-Final</td>
+    <td>FinalState</td>
+  </tr>
+  <tr>
+    <td>FinalState</td>
+    <td colspan="2">Final State</td>
+  </tr>
+
+</table>
+
+#### Event list
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">InitialState</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### Event01-02
+
+Abst01-02
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td>RTC::TimedLong</td>
+    <td>Type01-02</td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2">Num01-02</td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2">Unit01-02</td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2">Period01-02</td>
+  </tr>
+</table>
+
+Detail01-02
+
+##### Event02-Final
+
+Abst02-Final
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">FinalState</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td>RTC::TimedString</td>
+    <td>Type02-Final</td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2">Num02-Final</td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2">Unit02-Final</td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2">Period02-Final</td>
+  </tr>
+</table>
+
+Detail02-Final
+
+
+
+### InPorts definition
+
+
+### OutPorts definition
+
+
+### Service Port definition
+
+
+### Configuration definition
+
+
+## Demo
+
+## Requirement
+
+## Setup
+
+### Windows
+
+### Ubuntu
+
+## Usage
+
+## Running the tests
+
+## LICENCE
+
+
+
+
+## References
+
+
+
+
+## Author
+
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/RTC.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<rtc:RtcProfile rtc:version="0.3" rtc:id="RTC:VenderName:Category:ModuleName:1.0.0" xmlns:rtc="http://www.openrtp.org/namespaces/rtc" xmlns:rtcExt="http://www.openrtp.org/namespaces/rtc_ext" xmlns:rtcDoc="http://www.openrtp.org/namespaces/rtc_doc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <rtc:BasicInfo xsi:type="rtcExt:basic_info_ext" rtcExt:saveProject="FSMTest" rtc:updateDate="2019-12-20T00:07:52.000+09:00" rtc:creationDate="2019-12-19T22:49:56.000+09:00" rtc:version="1.0.0" rtc:vendor="VenderName" rtc:maxInstances="1" rtc:executionType="PeriodicExecutionContext" rtc:executionRate="1000.0" rtc:description="ModuleDescription" rtc:category="Category" rtc:componentKind="DataFlowComponent" rtc:activityType="PERIODIC" rtc:componentType="STATIC" rtc:name="ModuleName">
+        <rtcExt:Properties rtcExt:value="true" rtcExt:name="FSM"/>
+        <rtcExt:Properties rtcExt:value="StaticFSM" rtcExt:name="FSMType"/>
+    </rtc:BasicInfo>
+    <rtc:Actions>
+        <rtc:OnInitialize xsi:type="rtcDoc:action_status_doc" rtc:implemented="true"/>
+        <rtc:OnFinalize xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStartup xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnShutdown xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnActivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnDeactivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAborting xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnError xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnReset xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnExecute xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStateUpdate xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnRateChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAction xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+    </rtc:Actions>
+    <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedLong" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01-02">
+            <rtcDoc:Doc rtcDoc:operation="Period01-02" rtcDoc:unit="Unit01-02" rtcDoc:semantics="Detail01-02" rtcDoc:number="Num01-02" rtcDoc:type="Type01-02" rtcDoc:description="Abst01-02"/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedString" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02-Final">
+            <rtcDoc:Doc rtcDoc:operation="Period02-Final" rtcDoc:unit="Unit02-Final" rtcDoc:semantics="Detail02-Final" rtcDoc:number="Num02-Final" rtcDoc:type="Type02-Final" rtcDoc:description="Abst02-Final"/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State01" rtc:source="InitialState" rtc:condition="" rtc:name="">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+    </rtc:DataPorts>
+    <rtc:Language xsi:type="rtcExt:language_ext" rtc:kind="Python"/>
+</rtc:RtcProfile>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/test/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_test(NAME ${PROJECT_NAME}_test COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}Test.py -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event01-02&fsm_event_name=Event01-02,${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event02-Final&fsm_event_name=Event02-Final" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+string(REPLACE ";" "\\;" PYTHONPATH "$ENV{PYTHONPATH}")
+if(UNIX)
+  set_tests_properties(${PROJECT_NAME}_test PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}:${PYTHONPATH}")
+else()
+  set_tests_properties(${PROJECT_NAME}_test PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}\;${PYTHONPATH}")
+endif()

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/test/ModuleNameTest.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/test/ModuleNameTest.py
@@ -1,0 +1,291 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -*- Python -*-
+
+"""
+ @file ModuleNameTest.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+from __future__ import print_function
+import sys
+import time
+sys.path.append(".")
+
+# Import RTM module
+import RTC
+import OpenRTM_aist
+
+
+# Import Service implementation class
+# <rtc-template block="service_impl">
+
+import ModuleName
+
+# </rtc-template>
+
+# Import Service stub modules
+# <rtc-template block="consumer_import">
+# </rtc-template>
+
+
+# This module's spesification
+# <rtc-template block="module_spec">
+modulenametest_spec = ["implementation_id", "ModuleNameTest", 
+         "type_name",         "ModuleNameTest", 
+         "description",       "ModuleDescription", 
+         "version",           "1.0.0", 
+         "vendor",            "VenderName", 
+         "category",          "Category", 
+         "activity_type",     "STATIC", 
+         "max_instance",      "1", 
+         "language",          "Python", 
+         "lang_type",         "SCRIPT",
+         ""]
+# </rtc-template>
+
+##
+# @class ModuleNameTest
+# @brief ModuleDescription
+# 
+# 
+class ModuleNameTest(OpenRTM_aist.DataFlowComponentBase):
+    
+    ##
+    # @brief constructor
+    # @param manager Maneger Object
+    # 
+    def __init__(self, manager):
+        OpenRTM_aist.DataFlowComponentBase.__init__(self, manager)
+
+
+
+        
+
+        self._d_Event01-02 = OpenRTM_aist.instantiateDataType(RTC.TimedLong)
+        """
+        """
+        self._Event01-02Out = OpenRTM_aist.OutPort("Event01-02", self._d_Event01-02)
+
+        self._d_Event02-Final = OpenRTM_aist.instantiateDataType(RTC.TimedString)
+        """
+        """
+        self._Event02-FinalOut = OpenRTM_aist.OutPort("Event02-Final", self._d_Event02-Final)
+
+
+        # initialize of configuration-data.
+        # <rtc-template block="init_conf_param">
+        
+        # </rtc-template>
+
+
+         
+    ##
+    #
+    # The initialize action (on CREATED->ALIVE transition)
+    # 
+    # @return RTC::ReturnCode_t
+    # 
+    #
+    def onInitialize(self):
+        # Bind variables and configuration variable
+        
+        # Set InPort buffers
+        
+        # Set OutPort buffers
+        self.addOutPort("Event01-02", self._Event01-02Out)
+        self.addOutPort("Event02-Final", self._Event02-FinalOut)
+        
+        # Set service provider to Ports
+        
+        # Set service consumers to Ports
+        
+        # Set CORBA Service Ports
+        
+        return RTC.RTC_OK
+    
+    ###
+    ## 
+    ## The finalize action (on ALIVE->END transition)
+    ## 
+    ## @return RTC::ReturnCode_t
+    #
+    ## 
+    #def onFinalize(self):
+    #
+    #    return RTC.RTC_OK
+    
+    #    ##
+    ##
+    ## The startup action when ExecutionContext startup
+    ## 
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onStartup(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The shutdown action when ExecutionContext stop
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onShutdown(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The activated action (Active state entry action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ## 
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onActivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    #    ##
+    ##
+    ## The deactivated action (Active state exit action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onDeactivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The execution action that is invoked periodically
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onExecute(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The aborting action when main logic error occurred.
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    #    #
+    ##
+    #def onAborting(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The error action in ERROR state
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onError(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The reset action that is invoked resetting
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onReset(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The state update action that is invoked after onExecute() action
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+
+    ##
+    #def onStateUpdate(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The action that is invoked when execution context's rate is changed
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onRateChanged(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    def runTest(self):
+        return True
+
+def RunTest():
+    manager = OpenRTM_aist.Manager.instance()
+    comp = manager.getComponent("ModuleNameTest0")
+    if comp is None:
+        print('Component get failed.', file=sys.stderr)
+        return False
+    return comp.runTest()
+
+def ModuleNameTestInit(manager):
+    profile = OpenRTM_aist.Properties(defaults_str=modulenametest_spec)
+    manager.registerFactory(profile,
+                            ModuleNameTest,
+                            OpenRTM_aist.Delete)
+
+def MyModuleInit(manager):
+    ModuleNameTestInit(manager)
+    ModuleName.ModuleNameInit(manager)
+
+    # Create a component
+    comp = manager.createComponent("ModuleNameTest")
+
+def main():
+    mgr = OpenRTM_aist.Manager.init(sys.argv)
+    mgr.setModuleInitProc(MyModuleInit)
+    mgr.activateManager()
+    mgr.runManager(True)
+
+    ret = RunTest()
+    mgr.shutdown()
+
+    if ret:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/ModuleName.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/ModuleName.py
@@ -1,0 +1,279 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -*- Python -*-
+
+"""
+ @file ModuleName.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+import sys
+import time
+sys.path.append(".")
+
+# Import RTM module
+import RTC
+import OpenRTM_aist
+import OpenRTM_aist.StaticFSM as StaticFSM
+import OpenRTM_aist.EventPort as EventPort
+import ModuleNameFSM
+
+
+# Import Service implementation class
+# <rtc-template block="service_impl">
+
+# </rtc-template>
+
+# Import Service stub modules
+# <rtc-template block="consumer_import">
+# </rtc-template>
+
+
+# This module's spesification
+# <rtc-template block="module_spec">
+modulename_spec = ["implementation_id", "ModuleName", 
+         "type_name",         "ModuleName", 
+         "description",       "ModuleDescription", 
+         "version",           "1.0.0", 
+         "vendor",            "VenderName", 
+         "category",          "Category", 
+         "activity_type",     "STATIC", 
+         "max_instance",      "1", 
+         "language",          "Python", 
+         "lang_type",         "SCRIPT",
+         ""]
+# </rtc-template>
+
+##
+# @class ModuleName
+# @brief ModuleDescription
+# 
+# 
+class ModuleName(OpenRTM_aist.DataFlowComponentBase):
+	
+    ##
+    # @brief constructor
+    # @param manager Maneger Object
+    # 
+    def __init__(self, manager):
+        OpenRTM_aist.DataFlowComponentBase.__init__(self, manager)
+
+
+
+		
+
+
+        # initialize of configuration-data.
+        # <rtc-template block="init_conf_param">
+		
+        # </rtc-template>
+
+
+		 
+    ##
+    #
+    # The initialize action (on CREATED->ALIVE transition)
+    # 
+    # @return RTC::ReturnCode_t
+    # 
+    #
+    def onInitialize(self):
+        # Bind variables and configuration variable
+		
+        # Set InPort buffers
+		
+        # Set OutPort buffers
+		
+        # Set service provider to Ports
+		
+        # Set service consumers to Ports
+		
+        # Set CORBA Service Ports
+        self._fsm = StaticFSM.Machine(ModuleNameFSM.Top, self)
+        self._eventIn = EventPort.EventInPort("event", self._fsm)
+        self.addInPort("event", self._eventIn)
+        self._eventIn.bindEvent0("Event01-02", ModuleNameFSM.Top.Event01-02)
+        self._eventIn.bindEvent0("Event02-Final", ModuleNameFSM.Top.Event02-Final)
+		
+        return RTC.RTC_OK
+	
+    ###
+    ## 
+    ## The finalize action (on ALIVE->END transition)
+    ## 
+    ## @return RTC::ReturnCode_t
+    #
+    ## 
+    #def onFinalize(self):
+    #
+    #    self._fsm.shutdown()
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The startup action when ExecutionContext startup
+    ## 
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onStartup(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The shutdown action when ExecutionContext stop
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onShutdown(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The activated action (Active state entry action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ## 
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onActivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The deactivated action (Active state exit action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onDeactivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The execution action that is invoked periodically
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onExecute(self, ec_id):
+    #
+        self._fsm.run_event()
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The aborting action when main logic error occurred.
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onAborting(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The error action in ERROR state
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onError(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The reset action that is invoked resetting
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onReset(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The state update action that is invoked after onExecute() action
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+
+    ##
+    #def onStateUpdate(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The action that is invoked when execution context's rate is changed
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onRateChanged(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+
+
+
+def ModuleNameInit(manager):
+    profile = OpenRTM_aist.Properties(defaults_str=modulename_spec)
+    manager.registerFactory(profile,
+                            ModuleName,
+                            OpenRTM_aist.Delete)
+
+def MyModuleInit(manager):
+    ModuleNameInit(manager)
+
+    # create instance_name option for createComponent()
+    instance_name = [i for i in sys.argv if "--instance_name=" in i]
+    if instance_name:
+        args = instance_name[0].replace("--", "?")
+    else:
+        args = ""
+  
+    # Create a component
+    comp = manager.createComponent("ModuleName" + args)
+
+def main():
+    # remove --instance_name= option
+    argv = [i for i in sys.argv if not "--instance_name=" in i]
+    # Initialize manager
+    mgr = OpenRTM_aist.Manager.init(sys.argv)
+    mgr.setModuleInitProc(MyModuleInit)
+    mgr.activateManager()
+    mgr.runManager()
+
+if __name__ == "__main__":
+    main()
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/ModuleNameFSM.py
@@ -1,0 +1,43 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+ @file ModuleNameFSM.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+import sys
+
+import RTC
+import OpenRTM_aist.StaticFSM as StaticFSM
+
+@StaticFSM.FSM_TOPSTATE
+class Top(StaticFSM.Link):
+    def onInit(self):
+        self.set_state(StaticFSM.State(State01))
+        return RTC.RTC_OK
+        
+    """
+    """
+    def Event01-02(self):
+        pass
+
+    """
+    """
+    def Event02-Final(self):
+        pass
+
+
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class State01(StaticFSM.Link):
+    def Event01-02(self):
+        self.set_state(StaticFSM.State(State02))
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class State02(StaticFSM.Link):
+    def Event02-Final(self):
+        self.set_state(StaticFSM.State(FinalState))
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/ModuleNameFSM.scxml
@@ -1,0 +1,12 @@
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=140 h=513  -->
+ <state id="InitialState"><!--   node-size-and-position x=20 y=43 w=100 h=75  -->
+  <transition id="13" target="State01"></transition>
+ </state>
+ <state id="State01"><!--   node-size-and-position x=32.5 y=168 w=75 h=75  -->
+  <transition event="Event01-02" id="15" target="State02"></transition>
+ </state>
+ <state id="State02"><!--   node-size-and-position x=32.5 y=293 w=75 h=75  -->
+  <transition event="Event02-Final" id="17" target="FinalState"></transition>
+ </state>
+ <final id="FinalState"><!--   node-size-and-position x=30 y=418 w=80 h=75  --></final>
+</scxml>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/README.md
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/README.md
@@ -1,0 +1,278 @@
+﻿# ModuleName
+
+## Overview
+
+ModuleDescription
+
+## Description
+
+
+
+### Input and Output
+
+
+
+### Algorithm etc
+
+
+
+### Basic Information
+
+|  |  |
+----|---- 
+| Module Name | ModuleName |
+| Description | ModuleDescription |
+| Version | 1.0.0 |
+| Vendor | VenderName |
+| Category | Category |
+| Comp. Type | STATIC |
+| Act. Type | PERIODIC |
+| Kind | DataFlowComponent |
+| MAX Inst. | 1 |
+
+### Activity definition
+
+<table>
+  <tr>
+    <td rowspan="4">on_initialize</td>
+    <td colspan="2">implemented</td>
+    <tr>
+      <td>Description</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PreCondition</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PostCondition</td>
+      <td></td>
+    </tr>
+  </tr>
+  <tr>
+    <td>on_finalize</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_startup</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_shutdown</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_activated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_deactivated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_execute</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_aborting</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_error</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_reset</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_state_update</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_rate_changed</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+### EventPorts definition
+
+|  |  |
+----|---- 
+| Port Name | FSMEventPort |
+| FSM Type | StaticFSM |
+
+#### Node list
+
+<table>
+  <tr>
+    <td>State Name</td>
+    <td>Event Name</td>
+    <td>Target State</td>
+  </tr>
+  <tr>
+    <td>InitialState</td>
+    <td colspan="2">Initial State</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State01</td>
+    <td>Event01-02</td>
+    <td>State02</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State02</td>
+    <td>Event02-Final</td>
+    <td>FinalState</td>
+  </tr>
+  <tr>
+    <td>FinalState</td>
+    <td colspan="2">Final State</td>
+  </tr>
+
+</table>
+
+#### Event list
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">InitialState</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### Event01-02
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### Event02-Final
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">FinalState</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+
+
+### InPorts definition
+
+
+### OutPorts definition
+
+
+### Service Port definition
+
+
+### Configuration definition
+
+
+## Demo
+
+## Requirement
+
+## Setup
+
+### Windows
+
+### Ubuntu
+
+## Usage
+
+## Running the tests
+
+## LICENCE
+
+
+
+
+## References
+
+
+
+
+## Author
+
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/RTC.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<rtc:RtcProfile rtc:version="0.3" rtc:id="RTC:VenderName:Category:ModuleName:1.0.0" xmlns:rtc="http://www.openrtp.org/namespaces/rtc" xmlns:rtcExt="http://www.openrtp.org/namespaces/rtc_ext" xmlns:rtcDoc="http://www.openrtp.org/namespaces/rtc_doc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <rtc:BasicInfo xsi:type="rtcExt:basic_info_ext" rtcExt:saveProject="FSMTest" rtc:updateDate="2019-12-19T22:51:23.000+09:00" rtc:creationDate="2019-12-19T22:49:56.000+09:00" rtc:version="1.0.0" rtc:vendor="VenderName" rtc:maxInstances="1" rtc:executionType="PeriodicExecutionContext" rtc:executionRate="1000.0" rtc:description="ModuleDescription" rtc:category="Category" rtc:componentKind="DataFlowComponent" rtc:activityType="PERIODIC" rtc:componentType="STATIC" rtc:name="ModuleName">
+        <rtcExt:Properties rtcExt:value="true" rtcExt:name="FSM"/>
+        <rtcExt:Properties rtcExt:value="StaticFSM" rtcExt:name="FSMType"/>
+    </rtc:BasicInfo>
+    <rtc:Actions>
+        <rtc:OnInitialize xsi:type="rtcDoc:action_status_doc" rtc:implemented="true"/>
+        <rtc:OnFinalize xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStartup xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnShutdown xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnActivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnDeactivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAborting xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnError xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnReset xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnExecute xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStateUpdate xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnRateChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAction xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+    </rtc:Actions>
+    <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="" rtc:name="Event01-02">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="" rtc:name="Event02-Final">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State01" rtc:source="InitialState" rtc:condition="" rtc:name="">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+    </rtc:DataPorts>
+    <rtc:Language xsi:type="rtcExt:language_ext" rtc:kind="Python"/>
+</rtc:RtcProfile>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/test/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_test(NAME ${PROJECT_NAME}_test COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}Test.py -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event01-02&fsm_event_name=Event01-02,${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event02-Final&fsm_event_name=Event02-Final" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+string(REPLACE ";" "\\;" PYTHONPATH "$ENV{PYTHONPATH}")
+if(UNIX)
+  set_tests_properties(${PROJECT_NAME}_test PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}:${PYTHONPATH}")
+else()
+  set_tests_properties(${PROJECT_NAME}_test PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}\;${PYTHONPATH}")
+endif()

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/test/ModuleNameTest.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/test/ModuleNameTest.py
@@ -1,0 +1,291 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -*- Python -*-
+
+"""
+ @file ModuleNameTest.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+from __future__ import print_function
+import sys
+import time
+sys.path.append(".")
+
+# Import RTM module
+import RTC
+import OpenRTM_aist
+
+
+# Import Service implementation class
+# <rtc-template block="service_impl">
+
+import ModuleName
+
+# </rtc-template>
+
+# Import Service stub modules
+# <rtc-template block="consumer_import">
+# </rtc-template>
+
+
+# This module's spesification
+# <rtc-template block="module_spec">
+modulenametest_spec = ["implementation_id", "ModuleNameTest", 
+         "type_name",         "ModuleNameTest", 
+         "description",       "ModuleDescription", 
+         "version",           "1.0.0", 
+         "vendor",            "VenderName", 
+         "category",          "Category", 
+         "activity_type",     "STATIC", 
+         "max_instance",      "1", 
+         "language",          "Python", 
+         "lang_type",         "SCRIPT",
+         ""]
+# </rtc-template>
+
+##
+# @class ModuleNameTest
+# @brief ModuleDescription
+# 
+# 
+class ModuleNameTest(OpenRTM_aist.DataFlowComponentBase):
+    
+    ##
+    # @brief constructor
+    # @param manager Maneger Object
+    # 
+    def __init__(self, manager):
+        OpenRTM_aist.DataFlowComponentBase.__init__(self, manager)
+
+
+
+        
+
+        self._d_Event01-02 = OpenRTM_aist.instantiateDataType(RTC.TimedLong)
+        """
+        """
+        self._Event01-02Out = OpenRTM_aist.OutPort("Event01-02", self._d_Event01-02)
+
+        self._d_Event02-Final = OpenRTM_aist.instantiateDataType(RTC.TimedLong)
+        """
+        """
+        self._Event02-FinalOut = OpenRTM_aist.OutPort("Event02-Final", self._d_Event02-Final)
+
+
+        # initialize of configuration-data.
+        # <rtc-template block="init_conf_param">
+        
+        # </rtc-template>
+
+
+         
+    ##
+    #
+    # The initialize action (on CREATED->ALIVE transition)
+    # 
+    # @return RTC::ReturnCode_t
+    # 
+    #
+    def onInitialize(self):
+        # Bind variables and configuration variable
+        
+        # Set InPort buffers
+        
+        # Set OutPort buffers
+        self.addOutPort("Event01-02", self._Event01-02Out)
+        self.addOutPort("Event02-Final", self._Event02-FinalOut)
+        
+        # Set service provider to Ports
+        
+        # Set service consumers to Ports
+        
+        # Set CORBA Service Ports
+        
+        return RTC.RTC_OK
+    
+    ###
+    ## 
+    ## The finalize action (on ALIVE->END transition)
+    ## 
+    ## @return RTC::ReturnCode_t
+    #
+    ## 
+    #def onFinalize(self):
+    #
+    #    return RTC.RTC_OK
+    
+    #    ##
+    ##
+    ## The startup action when ExecutionContext startup
+    ## 
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onStartup(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The shutdown action when ExecutionContext stop
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onShutdown(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The activated action (Active state entry action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ## 
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onActivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    #    ##
+    ##
+    ## The deactivated action (Active state exit action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onDeactivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The execution action that is invoked periodically
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onExecute(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The aborting action when main logic error occurred.
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    #    #
+    ##
+    #def onAborting(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The error action in ERROR state
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onError(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The reset action that is invoked resetting
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onReset(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The state update action that is invoked after onExecute() action
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+
+    ##
+    #def onStateUpdate(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The action that is invoked when execution context's rate is changed
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onRateChanged(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    def runTest(self):
+        return True
+
+def RunTest():
+    manager = OpenRTM_aist.Manager.instance()
+    comp = manager.getComponent("ModuleNameTest0")
+    if comp is None:
+        print('Component get failed.', file=sys.stderr)
+        return False
+    return comp.runTest()
+
+def ModuleNameTestInit(manager):
+    profile = OpenRTM_aist.Properties(defaults_str=modulenametest_spec)
+    manager.registerFactory(profile,
+                            ModuleNameTest,
+                            OpenRTM_aist.Delete)
+
+def MyModuleInit(manager):
+    ModuleNameTestInit(manager)
+    ModuleName.ModuleNameInit(manager)
+
+    # Create a component
+    comp = manager.createComponent("ModuleNameTest")
+
+def main():
+    mgr = OpenRTM_aist.Manager.init(sys.argv)
+    mgr.setModuleInitProc(MyModuleInit)
+    mgr.activateManager()
+    mgr.runManager(True)
+
+    ret = RunTest()
+    mgr.shutdown()
+
+    if ret:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/ModuleName.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/ModuleName.py
@@ -1,0 +1,279 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -*- Python -*-
+
+"""
+ @file ModuleName.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+import sys
+import time
+sys.path.append(".")
+
+# Import RTM module
+import RTC
+import OpenRTM_aist
+import OpenRTM_aist.StaticFSM as StaticFSM
+import OpenRTM_aist.EventPort as EventPort
+import ModuleNameFSM
+
+
+# Import Service implementation class
+# <rtc-template block="service_impl">
+
+# </rtc-template>
+
+# Import Service stub modules
+# <rtc-template block="consumer_import">
+# </rtc-template>
+
+
+# This module's spesification
+# <rtc-template block="module_spec">
+modulename_spec = ["implementation_id", "ModuleName", 
+         "type_name",         "ModuleName", 
+         "description",       "ModuleDescription", 
+         "version",           "1.0.0", 
+         "vendor",            "VenderName", 
+         "category",          "Category", 
+         "activity_type",     "STATIC", 
+         "max_instance",      "1", 
+         "language",          "Python", 
+         "lang_type",         "SCRIPT",
+         ""]
+# </rtc-template>
+
+##
+# @class ModuleName
+# @brief ModuleDescription
+# 
+# 
+class ModuleName(OpenRTM_aist.DataFlowComponentBase):
+	
+    ##
+    # @brief constructor
+    # @param manager Maneger Object
+    # 
+    def __init__(self, manager):
+        OpenRTM_aist.DataFlowComponentBase.__init__(self, manager)
+
+
+
+		
+
+
+        # initialize of configuration-data.
+        # <rtc-template block="init_conf_param">
+		
+        # </rtc-template>
+
+
+		 
+    ##
+    #
+    # The initialize action (on CREATED->ALIVE transition)
+    # 
+    # @return RTC::ReturnCode_t
+    # 
+    #
+    def onInitialize(self):
+        # Bind variables and configuration variable
+		
+        # Set InPort buffers
+		
+        # Set OutPort buffers
+		
+        # Set service provider to Ports
+		
+        # Set service consumers to Ports
+		
+        # Set CORBA Service Ports
+        self._fsm = StaticFSM.Machine(ModuleNameFSM.Top, self)
+        self._eventIn = EventPort.EventInPort("event", self._fsm)
+        self.addInPort("event", self._eventIn)
+        self._eventIn.bindEvent1("Event01-02", ModuleNameFSM.Top.Event01-02, OpenRTM_aist.instantiateDataType(RTC.TimedLong))
+        self._eventIn.bindEvent1("Event02-Final", ModuleNameFSM.Top.Event02-Final, OpenRTM_aist.instantiateDataType(RTC.TimedString))
+		
+        return RTC.RTC_OK
+	
+    ###
+    ## 
+    ## The finalize action (on ALIVE->END transition)
+    ## 
+    ## @return RTC::ReturnCode_t
+    #
+    ## 
+    #def onFinalize(self):
+    #
+    #    self._fsm.shutdown()
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The startup action when ExecutionContext startup
+    ## 
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onStartup(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The shutdown action when ExecutionContext stop
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onShutdown(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The activated action (Active state entry action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ## 
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onActivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The deactivated action (Active state exit action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onDeactivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The execution action that is invoked periodically
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onExecute(self, ec_id):
+    #
+        self._fsm.run_event()
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The aborting action when main logic error occurred.
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onAborting(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The error action in ERROR state
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onError(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The reset action that is invoked resetting
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onReset(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The state update action that is invoked after onExecute() action
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+
+    ##
+    #def onStateUpdate(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The action that is invoked when execution context's rate is changed
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onRateChanged(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+
+
+
+def ModuleNameInit(manager):
+    profile = OpenRTM_aist.Properties(defaults_str=modulename_spec)
+    manager.registerFactory(profile,
+                            ModuleName,
+                            OpenRTM_aist.Delete)
+
+def MyModuleInit(manager):
+    ModuleNameInit(manager)
+
+    # create instance_name option for createComponent()
+    instance_name = [i for i in sys.argv if "--instance_name=" in i]
+    if instance_name:
+        args = instance_name[0].replace("--", "?")
+    else:
+        args = ""
+  
+    # Create a component
+    comp = manager.createComponent("ModuleName" + args)
+
+def main():
+    # remove --instance_name= option
+    argv = [i for i in sys.argv if not "--instance_name=" in i]
+    # Initialize manager
+    mgr = OpenRTM_aist.Manager.init(sys.argv)
+    mgr.setModuleInitProc(MyModuleInit)
+    mgr.activateManager()
+    mgr.runManager()
+
+if __name__ == "__main__":
+    main()
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/ModuleNameFSM.py
@@ -1,0 +1,43 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+ @file ModuleNameFSM.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+import sys
+
+import RTC
+import OpenRTM_aist.StaticFSM as StaticFSM
+
+@StaticFSM.FSM_TOPSTATE
+class Top(StaticFSM.Link):
+    def onInit(self):
+        self.set_state(StaticFSM.State(State01))
+        return RTC.RTC_OK
+        
+    """
+    """
+    def Event01-02(self, data):
+        pass
+
+    """
+    """
+    def Event02-Final(self, data):
+        pass
+
+
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class State01(StaticFSM.Link):
+    def Event01-02(self, data):
+        self.set_state(StaticFSM.State(State02))
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class State02(StaticFSM.Link):
+    def Event02-Final(self, data):
+        self.set_state(StaticFSM.State(FinalState))
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/ModuleNameFSM.scxml
@@ -1,0 +1,12 @@
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=212 h=513  -->
+ <state id="InitialState"><!--   node-size-and-position x=55.86 y=43 w=100 h=75  -->
+  <transition id="13" target="State01"></transition>
+ </state>
+ <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->
+  <transition cond="Cond01" event="Event01-02" id="15" target="State02"></transition>
+ </state>
+ <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->
+  <transition cond="Cond02" event="Event02-Final" id="17" target="FinalState"></transition>
+ </state>
+ <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final>
+</scxml>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/README.md
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/README.md
@@ -1,0 +1,278 @@
+﻿# ModuleName
+
+## Overview
+
+ModuleDescription
+
+## Description
+
+
+
+### Input and Output
+
+
+
+### Algorithm etc
+
+
+
+### Basic Information
+
+|  |  |
+----|---- 
+| Module Name | ModuleName |
+| Description | ModuleDescription |
+| Version | 1.0.0 |
+| Vendor | VenderName |
+| Category | Category |
+| Comp. Type | STATIC |
+| Act. Type | PERIODIC |
+| Kind | DataFlowComponent |
+| MAX Inst. | 1 |
+
+### Activity definition
+
+<table>
+  <tr>
+    <td rowspan="4">on_initialize</td>
+    <td colspan="2">implemented</td>
+    <tr>
+      <td>Description</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PreCondition</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PostCondition</td>
+      <td></td>
+    </tr>
+  </tr>
+  <tr>
+    <td>on_finalize</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_startup</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_shutdown</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_activated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_deactivated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_execute</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_aborting</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_error</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_reset</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_state_update</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_rate_changed</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+### EventPorts definition
+
+|  |  |
+----|---- 
+| Port Name | FSMEventPort |
+| FSM Type | StaticFSM |
+
+#### Node list
+
+<table>
+  <tr>
+    <td>State Name</td>
+    <td>Event Name</td>
+    <td>Target State</td>
+  </tr>
+  <tr>
+    <td>InitialState</td>
+    <td colspan="2">Initial State</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State01</td>
+    <td>Event01-02</td>
+    <td>State02</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State02</td>
+    <td>Event02-Final</td>
+    <td>FinalState</td>
+  </tr>
+  <tr>
+    <td>FinalState</td>
+    <td colspan="2">Final State</td>
+  </tr>
+
+</table>
+
+#### Event list
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">InitialState</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### Event01-02
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td>RTC::TimedLong</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### Event02-Final
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">FinalState</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td>RTC::TimedString</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+
+
+### InPorts definition
+
+
+### OutPorts definition
+
+
+### Service Port definition
+
+
+### Configuration definition
+
+
+## Demo
+
+## Requirement
+
+## Setup
+
+### Windows
+
+### Ubuntu
+
+## Usage
+
+## Running the tests
+
+## LICENCE
+
+
+
+
+## References
+
+
+
+
+## Author
+
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/RTC.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<rtc:RtcProfile rtc:version="0.3" rtc:id="RTC:VenderName:Category:ModuleName:1.0.0" xmlns:rtc="http://www.openrtp.org/namespaces/rtc" xmlns:rtcExt="http://www.openrtp.org/namespaces/rtc_ext" xmlns:rtcDoc="http://www.openrtp.org/namespaces/rtc_doc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <rtc:BasicInfo xsi:type="rtcExt:basic_info_ext" rtcExt:saveProject="FSMTest" rtc:updateDate="2019-12-20T00:07:52.000+09:00" rtc:creationDate="2019-12-19T22:49:56.000+09:00" rtc:version="1.0.0" rtc:vendor="VenderName" rtc:maxInstances="1" rtc:executionType="PeriodicExecutionContext" rtc:executionRate="1000.0" rtc:description="ModuleDescription" rtc:category="Category" rtc:componentKind="DataFlowComponent" rtc:activityType="PERIODIC" rtc:componentType="STATIC" rtc:name="ModuleName">
+        <rtcExt:Properties rtcExt:value="true" rtcExt:name="FSM"/>
+        <rtcExt:Properties rtcExt:value="StaticFSM" rtcExt:name="FSMType"/>
+    </rtc:BasicInfo>
+    <rtc:Actions>
+        <rtc:OnInitialize xsi:type="rtcDoc:action_status_doc" rtc:implemented="true"/>
+        <rtc:OnFinalize xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStartup xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnShutdown xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnActivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnDeactivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAborting xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnError xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnReset xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnExecute xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStateUpdate xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnRateChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAction xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+    </rtc:Actions>
+    <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedLong" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01-02">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedString" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02-Final">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State01" rtc:source="InitialState" rtc:condition="" rtc:name="">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+    </rtc:DataPorts>
+    <rtc:Language xsi:type="rtcExt:language_ext" rtc:kind="Python"/>
+</rtc:RtcProfile>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/test/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_test(NAME ${PROJECT_NAME}_test COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}Test.py -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event01-02&fsm_event_name=Event01-02,${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event02-Final&fsm_event_name=Event02-Final" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+string(REPLACE ";" "\\;" PYTHONPATH "$ENV{PYTHONPATH}")
+if(UNIX)
+  set_tests_properties(${PROJECT_NAME}_test PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}:${PYTHONPATH}")
+else()
+  set_tests_properties(${PROJECT_NAME}_test PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}\;${PYTHONPATH}")
+endif()

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/test/ModuleNameTest.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/test/ModuleNameTest.py
@@ -1,0 +1,291 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -*- Python -*-
+
+"""
+ @file ModuleNameTest.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+from __future__ import print_function
+import sys
+import time
+sys.path.append(".")
+
+# Import RTM module
+import RTC
+import OpenRTM_aist
+
+
+# Import Service implementation class
+# <rtc-template block="service_impl">
+
+import ModuleName
+
+# </rtc-template>
+
+# Import Service stub modules
+# <rtc-template block="consumer_import">
+# </rtc-template>
+
+
+# This module's spesification
+# <rtc-template block="module_spec">
+modulenametest_spec = ["implementation_id", "ModuleNameTest", 
+         "type_name",         "ModuleNameTest", 
+         "description",       "ModuleDescription", 
+         "version",           "1.0.0", 
+         "vendor",            "VenderName", 
+         "category",          "Category", 
+         "activity_type",     "STATIC", 
+         "max_instance",      "1", 
+         "language",          "Python", 
+         "lang_type",         "SCRIPT",
+         ""]
+# </rtc-template>
+
+##
+# @class ModuleNameTest
+# @brief ModuleDescription
+# 
+# 
+class ModuleNameTest(OpenRTM_aist.DataFlowComponentBase):
+    
+    ##
+    # @brief constructor
+    # @param manager Maneger Object
+    # 
+    def __init__(self, manager):
+        OpenRTM_aist.DataFlowComponentBase.__init__(self, manager)
+
+
+
+        
+
+        self._d_Event01-02 = OpenRTM_aist.instantiateDataType(RTC.TimedLong)
+        """
+        """
+        self._Event01-02Out = OpenRTM_aist.OutPort("Event01-02", self._d_Event01-02)
+
+        self._d_Event02-Final = OpenRTM_aist.instantiateDataType(RTC.TimedString)
+        """
+        """
+        self._Event02-FinalOut = OpenRTM_aist.OutPort("Event02-Final", self._d_Event02-Final)
+
+
+        # initialize of configuration-data.
+        # <rtc-template block="init_conf_param">
+        
+        # </rtc-template>
+
+
+         
+    ##
+    #
+    # The initialize action (on CREATED->ALIVE transition)
+    # 
+    # @return RTC::ReturnCode_t
+    # 
+    #
+    def onInitialize(self):
+        # Bind variables and configuration variable
+        
+        # Set InPort buffers
+        
+        # Set OutPort buffers
+        self.addOutPort("Event01-02", self._Event01-02Out)
+        self.addOutPort("Event02-Final", self._Event02-FinalOut)
+        
+        # Set service provider to Ports
+        
+        # Set service consumers to Ports
+        
+        # Set CORBA Service Ports
+        
+        return RTC.RTC_OK
+    
+    ###
+    ## 
+    ## The finalize action (on ALIVE->END transition)
+    ## 
+    ## @return RTC::ReturnCode_t
+    #
+    ## 
+    #def onFinalize(self):
+    #
+    #    return RTC.RTC_OK
+    
+    #    ##
+    ##
+    ## The startup action when ExecutionContext startup
+    ## 
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onStartup(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The shutdown action when ExecutionContext stop
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onShutdown(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The activated action (Active state entry action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ## 
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onActivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    #    ##
+    ##
+    ## The deactivated action (Active state exit action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onDeactivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The execution action that is invoked periodically
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onExecute(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The aborting action when main logic error occurred.
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    #    #
+    ##
+    #def onAborting(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The error action in ERROR state
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onError(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The reset action that is invoked resetting
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onReset(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The state update action that is invoked after onExecute() action
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+
+    ##
+    #def onStateUpdate(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The action that is invoked when execution context's rate is changed
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onRateChanged(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    def runTest(self):
+        return True
+
+def RunTest():
+    manager = OpenRTM_aist.Manager.instance()
+    comp = manager.getComponent("ModuleNameTest0")
+    if comp is None:
+        print('Component get failed.', file=sys.stderr)
+        return False
+    return comp.runTest()
+
+def ModuleNameTestInit(manager):
+    profile = OpenRTM_aist.Properties(defaults_str=modulenametest_spec)
+    manager.registerFactory(profile,
+                            ModuleNameTest,
+                            OpenRTM_aist.Delete)
+
+def MyModuleInit(manager):
+    ModuleNameTestInit(manager)
+    ModuleName.ModuleNameInit(manager)
+
+    # Create a component
+    comp = manager.createComponent("ModuleNameTest")
+
+def main():
+    mgr = OpenRTM_aist.Manager.init(sys.argv)
+    mgr.setModuleInitProc(MyModuleInit)
+    mgr.activateManager()
+    mgr.runManager(True)
+
+    ret = RunTest()
+    mgr.shutdown()
+
+    if ret:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/ModuleName.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/ModuleName.py
@@ -1,0 +1,277 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -*- Python -*-
+
+"""
+ @file ModuleName.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+import sys
+import time
+sys.path.append(".")
+
+# Import RTM module
+import RTC
+import OpenRTM_aist
+import OpenRTM_aist.StaticFSM as StaticFSM
+import OpenRTM_aist.EventPort as EventPort
+import ModuleNameFSM
+
+
+# Import Service implementation class
+# <rtc-template block="service_impl">
+
+# </rtc-template>
+
+# Import Service stub modules
+# <rtc-template block="consumer_import">
+# </rtc-template>
+
+
+# This module's spesification
+# <rtc-template block="module_spec">
+modulename_spec = ["implementation_id", "ModuleName", 
+         "type_name",         "ModuleName", 
+         "description",       "ModuleDescription", 
+         "version",           "1.0.0", 
+         "vendor",            "VenderName", 
+         "category",          "Category", 
+         "activity_type",     "STATIC", 
+         "max_instance",      "1", 
+         "language",          "Python", 
+         "lang_type",         "SCRIPT",
+         ""]
+# </rtc-template>
+
+##
+# @class ModuleName
+# @brief ModuleDescription
+# 
+# 
+class ModuleName(OpenRTM_aist.DataFlowComponentBase):
+	
+    ##
+    # @brief constructor
+    # @param manager Maneger Object
+    # 
+    def __init__(self, manager):
+        OpenRTM_aist.DataFlowComponentBase.__init__(self, manager)
+
+
+
+		
+
+
+        # initialize of configuration-data.
+        # <rtc-template block="init_conf_param">
+		
+        # </rtc-template>
+
+
+		 
+    ##
+    #
+    # The initialize action (on CREATED->ALIVE transition)
+    # 
+    # @return RTC::ReturnCode_t
+    # 
+    #
+    def onInitialize(self):
+        # Bind variables and configuration variable
+		
+        # Set InPort buffers
+		
+        # Set OutPort buffers
+		
+        # Set service provider to Ports
+		
+        # Set service consumers to Ports
+		
+        # Set CORBA Service Ports
+        self._fsm = StaticFSM.Machine(ModuleNameFSM.Top, self)
+        self._eventIn = EventPort.EventInPort("event", self._fsm)
+        self.addInPort("event", self._eventIn)
+		
+        return RTC.RTC_OK
+	
+    ###
+    ## 
+    ## The finalize action (on ALIVE->END transition)
+    ## 
+    ## @return RTC::ReturnCode_t
+    #
+    ## 
+    #def onFinalize(self):
+    #
+    #    self._fsm.shutdown()
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The startup action when ExecutionContext startup
+    ## 
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onStartup(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The shutdown action when ExecutionContext stop
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onShutdown(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The activated action (Active state entry action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ## 
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onActivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The deactivated action (Active state exit action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onDeactivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The execution action that is invoked periodically
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onExecute(self, ec_id):
+    #
+        self._fsm.run_event()
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The aborting action when main logic error occurred.
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onAborting(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The error action in ERROR state
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onError(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The reset action that is invoked resetting
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onReset(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The state update action that is invoked after onExecute() action
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+
+    ##
+    #def onStateUpdate(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The action that is invoked when execution context's rate is changed
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onRateChanged(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+
+
+
+def ModuleNameInit(manager):
+    profile = OpenRTM_aist.Properties(defaults_str=modulename_spec)
+    manager.registerFactory(profile,
+                            ModuleName,
+                            OpenRTM_aist.Delete)
+
+def MyModuleInit(manager):
+    ModuleNameInit(manager)
+
+    # create instance_name option for createComponent()
+    instance_name = [i for i in sys.argv if "--instance_name=" in i]
+    if instance_name:
+        args = instance_name[0].replace("--", "?")
+    else:
+        args = ""
+  
+    # Create a component
+    comp = manager.createComponent("ModuleName" + args)
+
+def main():
+    # remove --instance_name= option
+    argv = [i for i in sys.argv if not "--instance_name=" in i]
+    # Initialize manager
+    mgr = OpenRTM_aist.Manager.init(sys.argv)
+    mgr.setModuleInitProc(MyModuleInit)
+    mgr.activateManager()
+    mgr.runManager()
+
+if __name__ == "__main__":
+    main()
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/ModuleNameFSM.py
@@ -1,0 +1,29 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+ @file ModuleNameFSM.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+import sys
+
+import RTC
+import OpenRTM_aist.StaticFSM as StaticFSM
+
+@StaticFSM.FSM_TOPSTATE
+class Top(StaticFSM.Link):
+    def onInit(self):
+        self.set_state(StaticFSM.State(State01))
+        return RTC.RTC_OK
+        
+
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class State01(StaticFSM.Link):
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class State02(StaticFSM.Link):
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/ModuleNameFSM.scxml
@@ -1,0 +1,48 @@
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=854 h=400  -->
+
+
+
+ <state id="InitialState"><!--   node-size-and-position x=90 y=150 w=75 h=75  -->
+
+
+
+  <transition id="21" target="State01"></transition>
+
+
+
+ </state>
+
+
+
+ <state id="State01"><!--   node-size-and-position x=280 y=150 w=75 h=75  -->
+
+
+
+  <transition id="22" target="State02"></transition>
+
+
+
+ </state>
+
+
+
+ <state id="State02"><!--   node-size-and-position x=470 y=150 w=75 h=75  -->
+
+
+
+  <transition id="23" target="FinalState"></transition>
+
+
+
+ </state>
+
+
+
+ <final id="FinalState"><!--   node-size-and-position x=650 y=160 w=75 h=75  --></final>
+
+
+
+</scxml>
+
+
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/README.md
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/README.md
@@ -1,0 +1,278 @@
+﻿# ModuleName
+
+## Overview
+
+ModuleDescription
+
+## Description
+
+
+
+### Input and Output
+
+
+
+### Algorithm etc
+
+
+
+### Basic Information
+
+|  |  |
+----|---- 
+| Module Name | ModuleName |
+| Description | ModuleDescription |
+| Version | 1.0.0 |
+| Vendor | VenderName |
+| Category | Category |
+| Comp. Type | STATIC |
+| Act. Type | PERIODIC |
+| Kind | DataFlowComponent |
+| MAX Inst. | 1 |
+
+### Activity definition
+
+<table>
+  <tr>
+    <td rowspan="4">on_initialize</td>
+    <td colspan="2">implemented</td>
+    <tr>
+      <td>Description</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PreCondition</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PostCondition</td>
+      <td></td>
+    </tr>
+  </tr>
+  <tr>
+    <td>on_finalize</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_startup</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_shutdown</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_activated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_deactivated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_execute</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_aborting</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_error</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_reset</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_state_update</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_rate_changed</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+### EventPorts definition
+
+|  |  |
+----|---- 
+| Port Name | FSMEventPort |
+| FSM Type | StaticFSM |
+
+#### Node list
+
+<table>
+  <tr>
+    <td>State Name</td>
+    <td>Event Name</td>
+    <td>Target State</td>
+  </tr>
+  <tr>
+    <td>InitialState</td>
+    <td colspan="2">Initial State</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State01</td>
+    <td></td>
+    <td>State02</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State02</td>
+    <td></td>
+    <td>FinalState</td>
+  </tr>
+  <tr>
+    <td>FinalState</td>
+    <td colspan="2">Final State</td>
+  </tr>
+
+</table>
+
+#### Event list
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">InitialState</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">FinalState</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+
+
+### InPorts definition
+
+
+### OutPorts definition
+
+
+### Service Port definition
+
+
+### Configuration definition
+
+
+## Demo
+
+## Requirement
+
+## Setup
+
+### Windows
+
+### Ubuntu
+
+## Usage
+
+## Running the tests
+
+## LICENCE
+
+
+
+
+## References
+
+
+
+
+## Author
+
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/RTC.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<rtc:RtcProfile rtc:version="0.3" rtc:id="RTC:VenderName:Category:ModuleName:1.0.0" xmlns:rtc="http://www.openrtp.org/namespaces/rtc" xmlns:rtcExt="http://www.openrtp.org/namespaces/rtc_ext" xmlns:rtcDoc="http://www.openrtp.org/namespaces/rtc_doc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <rtc:BasicInfo xsi:type="rtcExt:basic_info_ext" rtcExt:saveProject="FSMTest" rtc:updateDate="2019-12-19T22:51:23.000+09:00" rtc:creationDate="2019-12-19T22:49:56.000+09:00" rtc:version="1.0.0" rtc:vendor="VenderName" rtc:maxInstances="1" rtc:executionType="PeriodicExecutionContext" rtc:executionRate="1000.0" rtc:description="ModuleDescription" rtc:category="Category" rtc:componentKind="DataFlowComponent" rtc:activityType="PERIODIC" rtc:componentType="STATIC" rtc:name="ModuleName">
+        <rtcExt:Properties rtcExt:value="true" rtcExt:name="FSM"/>
+        <rtcExt:Properties rtcExt:value="StaticFSM" rtcExt:name="FSMType"/>
+    </rtc:BasicInfo>
+    <rtc:Actions>
+        <rtc:OnInitialize xsi:type="rtcDoc:action_status_doc" rtc:implemented="true"/>
+        <rtc:OnFinalize xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStartup xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnShutdown xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnActivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnDeactivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAborting xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnError xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnReset xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnExecute xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStateUpdate xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnRateChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAction xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+    </rtc:Actions>
+    <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="" rtc:name="">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="" rtc:name="">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State01" rtc:source="InitialState" rtc:condition="" rtc:name="">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+    </rtc:DataPorts>
+    <rtc:Language xsi:type="rtcExt:language_ext" rtc:kind="Python"/>
+</rtc:RtcProfile>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/test/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_test(NAME ${PROJECT_NAME}_test COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}Test.py -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+string(REPLACE ";" "\\;" PYTHONPATH "$ENV{PYTHONPATH}")
+if(UNIX)
+  set_tests_properties(${PROJECT_NAME}_test PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}:${PYTHONPATH}")
+else()
+  set_tests_properties(${PROJECT_NAME}_test PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}\;${PYTHONPATH}")
+endif()

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/test/ModuleNameTest.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/test/ModuleNameTest.py
@@ -1,0 +1,279 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -*- Python -*-
+
+"""
+ @file ModuleNameTest.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+from __future__ import print_function
+import sys
+import time
+sys.path.append(".")
+
+# Import RTM module
+import RTC
+import OpenRTM_aist
+
+
+# Import Service implementation class
+# <rtc-template block="service_impl">
+
+import ModuleName
+
+# </rtc-template>
+
+# Import Service stub modules
+# <rtc-template block="consumer_import">
+# </rtc-template>
+
+
+# This module's spesification
+# <rtc-template block="module_spec">
+modulenametest_spec = ["implementation_id", "ModuleNameTest", 
+         "type_name",         "ModuleNameTest", 
+         "description",       "ModuleDescription", 
+         "version",           "1.0.0", 
+         "vendor",            "VenderName", 
+         "category",          "Category", 
+         "activity_type",     "STATIC", 
+         "max_instance",      "1", 
+         "language",          "Python", 
+         "lang_type",         "SCRIPT",
+         ""]
+# </rtc-template>
+
+##
+# @class ModuleNameTest
+# @brief ModuleDescription
+# 
+# 
+class ModuleNameTest(OpenRTM_aist.DataFlowComponentBase):
+    
+    ##
+    # @brief constructor
+    # @param manager Maneger Object
+    # 
+    def __init__(self, manager):
+        OpenRTM_aist.DataFlowComponentBase.__init__(self, manager)
+
+
+
+        
+
+
+        # initialize of configuration-data.
+        # <rtc-template block="init_conf_param">
+        
+        # </rtc-template>
+
+
+         
+    ##
+    #
+    # The initialize action (on CREATED->ALIVE transition)
+    # 
+    # @return RTC::ReturnCode_t
+    # 
+    #
+    def onInitialize(self):
+        # Bind variables and configuration variable
+        
+        # Set InPort buffers
+        
+        # Set OutPort buffers
+        
+        # Set service provider to Ports
+        
+        # Set service consumers to Ports
+        
+        # Set CORBA Service Ports
+        
+        return RTC.RTC_OK
+    
+    ###
+    ## 
+    ## The finalize action (on ALIVE->END transition)
+    ## 
+    ## @return RTC::ReturnCode_t
+    #
+    ## 
+    #def onFinalize(self):
+    #
+    #    return RTC.RTC_OK
+    
+    #    ##
+    ##
+    ## The startup action when ExecutionContext startup
+    ## 
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onStartup(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The shutdown action when ExecutionContext stop
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onShutdown(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The activated action (Active state entry action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ## 
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onActivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    #    ##
+    ##
+    ## The deactivated action (Active state exit action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onDeactivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The execution action that is invoked periodically
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onExecute(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The aborting action when main logic error occurred.
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    #    #
+    ##
+    #def onAborting(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The error action in ERROR state
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onError(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The reset action that is invoked resetting
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onReset(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The state update action that is invoked after onExecute() action
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+
+    ##
+    #def onStateUpdate(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The action that is invoked when execution context's rate is changed
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onRateChanged(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    def runTest(self):
+        return True
+
+def RunTest():
+    manager = OpenRTM_aist.Manager.instance()
+    comp = manager.getComponent("ModuleNameTest0")
+    if comp is None:
+        print('Component get failed.', file=sys.stderr)
+        return False
+    return comp.runTest()
+
+def ModuleNameTestInit(manager):
+    profile = OpenRTM_aist.Properties(defaults_str=modulenametest_spec)
+    manager.registerFactory(profile,
+                            ModuleNameTest,
+                            OpenRTM_aist.Delete)
+
+def MyModuleInit(manager):
+    ModuleNameTestInit(manager)
+    ModuleName.ModuleNameInit(manager)
+
+    # Create a component
+    comp = manager.createComponent("ModuleNameTest")
+
+def main():
+    mgr = OpenRTM_aist.Manager.init(sys.argv)
+    mgr.setModuleInitProc(MyModuleInit)
+    mgr.activateManager()
+    mgr.runManager(True)
+
+    ret = RunTest()
+    mgr.shutdown()
+
+    if ret:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/ModuleName.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/ModuleName.py
@@ -1,0 +1,279 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -*- Python -*-
+
+"""
+ @file ModuleName.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+import sys
+import time
+sys.path.append(".")
+
+# Import RTM module
+import RTC
+import OpenRTM_aist
+import OpenRTM_aist.StaticFSM as StaticFSM
+import OpenRTM_aist.EventPort as EventPort
+import ModuleNameFSM
+
+
+# Import Service implementation class
+# <rtc-template block="service_impl">
+
+# </rtc-template>
+
+# Import Service stub modules
+# <rtc-template block="consumer_import">
+# </rtc-template>
+
+
+# This module's spesification
+# <rtc-template block="module_spec">
+modulename_spec = ["implementation_id", "ModuleName", 
+         "type_name",         "ModuleName", 
+         "description",       "ModuleDescription", 
+         "version",           "1.0.0", 
+         "vendor",            "VenderName", 
+         "category",          "Category", 
+         "activity_type",     "STATIC", 
+         "max_instance",      "1", 
+         "language",          "Python", 
+         "lang_type",         "SCRIPT",
+         ""]
+# </rtc-template>
+
+##
+# @class ModuleName
+# @brief ModuleDescription
+# 
+# 
+class ModuleName(OpenRTM_aist.DataFlowComponentBase):
+	
+    ##
+    # @brief constructor
+    # @param manager Maneger Object
+    # 
+    def __init__(self, manager):
+        OpenRTM_aist.DataFlowComponentBase.__init__(self, manager)
+
+
+
+		
+
+
+        # initialize of configuration-data.
+        # <rtc-template block="init_conf_param">
+		
+        # </rtc-template>
+
+
+		 
+    ##
+    #
+    # The initialize action (on CREATED->ALIVE transition)
+    # 
+    # @return RTC::ReturnCode_t
+    # 
+    #
+    def onInitialize(self):
+        # Bind variables and configuration variable
+		
+        # Set InPort buffers
+		
+        # Set OutPort buffers
+		
+        # Set service provider to Ports
+		
+        # Set service consumers to Ports
+		
+        # Set CORBA Service Ports
+        self._fsm = StaticFSM.Machine(ModuleNameFSM.Top, self)
+        self._eventIn = EventPort.EventInPort("event", self._fsm)
+        self.addInPort("event", self._eventIn)
+        self._eventIn.bindEvent1("Event01-02", ModuleNameFSM.Top.Event01-02, OpenRTM_aist.instantiateDataType(RTC.TimedLong))
+        self._eventIn.bindEvent1("Event02-Final", ModuleNameFSM.Top.Event02-Final, OpenRTM_aist.instantiateDataType(RTC.TimedString))
+		
+        return RTC.RTC_OK
+	
+    ###
+    ## 
+    ## The finalize action (on ALIVE->END transition)
+    ## 
+    ## @return RTC::ReturnCode_t
+    #
+    ## 
+    #def onFinalize(self):
+    #
+    #    self._fsm.shutdown()
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The startup action when ExecutionContext startup
+    ## 
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onStartup(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The shutdown action when ExecutionContext stop
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onShutdown(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The activated action (Active state entry action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ## 
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onActivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The deactivated action (Active state exit action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onDeactivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The execution action that is invoked periodically
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onExecute(self, ec_id):
+    #
+        self._fsm.run_event()
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The aborting action when main logic error occurred.
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onAborting(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The error action in ERROR state
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onError(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The reset action that is invoked resetting
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onReset(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The state update action that is invoked after onExecute() action
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+
+    ##
+    #def onStateUpdate(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+    ###
+    ##
+    ## The action that is invoked when execution context's rate is changed
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onRateChanged(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+	
+
+
+
+def ModuleNameInit(manager):
+    profile = OpenRTM_aist.Properties(defaults_str=modulename_spec)
+    manager.registerFactory(profile,
+                            ModuleName,
+                            OpenRTM_aist.Delete)
+
+def MyModuleInit(manager):
+    ModuleNameInit(manager)
+
+    # create instance_name option for createComponent()
+    instance_name = [i for i in sys.argv if "--instance_name=" in i]
+    if instance_name:
+        args = instance_name[0].replace("--", "?")
+    else:
+        args = ""
+  
+    # Create a component
+    comp = manager.createComponent("ModuleName" + args)
+
+def main():
+    # remove --instance_name= option
+    argv = [i for i in sys.argv if not "--instance_name=" in i]
+    # Initialize manager
+    mgr = OpenRTM_aist.Manager.init(sys.argv)
+    mgr.setModuleInitProc(MyModuleInit)
+    mgr.activateManager()
+    mgr.runManager()
+
+if __name__ == "__main__":
+    main()
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/ModuleNameFSM.py
@@ -1,0 +1,67 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+ @file ModuleNameFSM.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+import sys
+
+import RTC
+import OpenRTM_aist.StaticFSM as StaticFSM
+
+@StaticFSM.FSM_TOPSTATE
+class Top(StaticFSM.Link):
+    def onInit(self):
+        self.set_state(StaticFSM.State(State01))
+        return RTC.RTC_OK
+        
+    """
+    Abst01-02
+    - Type: Type01-02
+     - Number: Num01-02
+     - Semantics: Detail01-02
+    - Unit: Unit01-02
+     - Operation Cycle: Period01-02
+    """
+    def Event01-02(self, data):
+        pass
+
+    """
+    Abst02-Final
+    - Type: Type02-Final
+     - Number: Num02-Final
+     - Semantics: Detail02-Final
+    - Unit: Unit02-Final
+     - Operation Cycle: Period02-Final
+    """
+    def Event02-Final(self, data):
+        pass
+
+
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class State01(StaticFSM.Link):
+    def onEntry(self):
+        return RTC.RTC_OK
+
+    def onExit(self):
+        return RTC.RTC_OK
+
+    def Event01-02(self, data):
+        self.set_state(StaticFSM.State(State02))
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class State02(StaticFSM.Link):
+    def onEntry(self):
+        return RTC.RTC_OK
+
+    def onExit(self):
+        return RTC.RTC_OK
+
+    def Event02-Final(self, data):
+        self.set_state(StaticFSM.State(FinalState))
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/ModuleNameFSM.scxml
@@ -1,0 +1,48 @@
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=212 h=513  -->
+
+ <state id="InitialState"><!--   node-size-and-position x=55.86 y=43 w=100 h=75  -->
+
+  <transition id="13" target="State01"></transition>
+
+ </state>
+
+ <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->
+
+  <onentry>
+
+   <log label="ON"></log>
+
+  </onentry>
+
+  <onexit>
+
+   <log label="ON"></log>
+
+  </onexit>
+
+  <transition cond="Cond01" event="Event01-02" id="15" target="State02"></transition>
+
+ </state>
+
+ <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->
+
+  <onentry>
+
+   <log label="ON"></log>
+
+  </onentry>
+
+  <onexit>
+
+   <log label="ON"></log>
+
+  </onexit>
+
+  <transition cond="Cond02" event="Event02-Final" id="17" target="FinalState"></transition>
+
+ </state>
+
+ <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final>
+
+</scxml>
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/README.md
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/README.md
@@ -1,0 +1,278 @@
+﻿# ModuleName
+
+## Overview
+
+ModuleDescription
+
+## Description
+
+
+
+### Input and Output
+
+
+
+### Algorithm etc
+
+
+
+### Basic Information
+
+|  |  |
+----|---- 
+| Module Name | ModuleName |
+| Description | ModuleDescription |
+| Version | 1.0.0 |
+| Vendor | VenderName |
+| Category | Category |
+| Comp. Type | STATIC |
+| Act. Type | PERIODIC |
+| Kind | DataFlowComponent |
+| MAX Inst. | 1 |
+
+### Activity definition
+
+<table>
+  <tr>
+    <td rowspan="4">on_initialize</td>
+    <td colspan="2">implemented</td>
+    <tr>
+      <td>Description</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PreCondition</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PostCondition</td>
+      <td></td>
+    </tr>
+  </tr>
+  <tr>
+    <td>on_finalize</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_startup</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_shutdown</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_activated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_deactivated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_execute</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_aborting</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_error</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_reset</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_state_update</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_rate_changed</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+### EventPorts definition
+
+|  |  |
+----|---- 
+| Port Name | FSMEventPort |
+| FSM Type | StaticFSM |
+
+#### Node list
+
+<table>
+  <tr>
+    <td>State Name</td>
+    <td>Event Name</td>
+    <td>Target State</td>
+  </tr>
+  <tr>
+    <td>InitialState</td>
+    <td colspan="2">Initial State</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State01</td>
+    <td>Event01-02</td>
+    <td>State02</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State02</td>
+    <td>Event02-Final</td>
+    <td>FinalState</td>
+  </tr>
+  <tr>
+    <td>FinalState</td>
+    <td colspan="2">Final State</td>
+  </tr>
+
+</table>
+
+#### Event list
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">InitialState</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### Event01-02
+
+Abst01-02
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td>RTC::TimedLong</td>
+    <td>Type01-02</td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2">Num01-02</td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2">Unit01-02</td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2">Period01-02</td>
+  </tr>
+</table>
+
+Detail01-02
+
+##### Event02-Final
+
+Abst02-Final
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">FinalState</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td>RTC::TimedString</td>
+    <td>Type02-Final</td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2">Num02-Final</td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2">Unit02-Final</td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2">Period02-Final</td>
+  </tr>
+</table>
+
+Detail02-Final
+
+
+
+### InPorts definition
+
+
+### OutPorts definition
+
+
+### Service Port definition
+
+
+### Configuration definition
+
+
+## Demo
+
+## Requirement
+
+## Setup
+
+### Windows
+
+### Ubuntu
+
+## Usage
+
+## Running the tests
+
+## LICENCE
+
+
+
+
+## References
+
+
+
+
+## Author
+
+

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/RTC.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<rtc:RtcProfile rtc:version="0.3" rtc:id="RTC:VenderName:Category:ModuleName:1.0.0" xmlns:rtc="http://www.openrtp.org/namespaces/rtc" xmlns:rtcExt="http://www.openrtp.org/namespaces/rtc_ext" xmlns:rtcDoc="http://www.openrtp.org/namespaces/rtc_doc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <rtc:BasicInfo xsi:type="rtcExt:basic_info_ext" rtcExt:saveProject="FSMTest" rtc:updateDate="2019-12-20T00:07:52.000+09:00" rtc:creationDate="2019-12-19T22:49:56.000+09:00" rtc:version="1.0.0" rtc:vendor="VenderName" rtc:maxInstances="1" rtc:executionType="PeriodicExecutionContext" rtc:executionRate="1000.0" rtc:description="ModuleDescription" rtc:category="Category" rtc:componentKind="DataFlowComponent" rtc:activityType="PERIODIC" rtc:componentType="STATIC" rtc:name="ModuleName">
+        <rtcExt:Properties rtcExt:value="true" rtcExt:name="FSM"/>
+        <rtcExt:Properties rtcExt:value="StaticFSM" rtcExt:name="FSMType"/>
+    </rtc:BasicInfo>
+    <rtc:Actions>
+        <rtc:OnInitialize xsi:type="rtcDoc:action_status_doc" rtc:implemented="true"/>
+        <rtc:OnFinalize xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStartup xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnShutdown xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnActivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnDeactivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAborting xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnError xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnReset xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnExecute xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStateUpdate xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnRateChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAction xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+    </rtc:Actions>
+    <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedLong" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01-02">
+            <rtcDoc:Doc rtcDoc:operation="Period01-02" rtcDoc:unit="Unit01-02" rtcDoc:semantics="Detail01-02" rtcDoc:number="Num01-02" rtcDoc:type="Type01-02" rtcDoc:description="Abst01-02"/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedString" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02-Final">
+            <rtcDoc:Doc rtcDoc:operation="Period02-Final" rtcDoc:unit="Unit02-Final" rtcDoc:semantics="Detail02-Final" rtcDoc:number="Num02-Final" rtcDoc:type="Type02-Final" rtcDoc:description="Abst02-Final"/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State01" rtc:source="InitialState" rtc:condition="" rtc:name="">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+    </rtc:DataPorts>
+    <rtc:Language xsi:type="rtcExt:language_ext" rtc:kind="Python"/>
+</rtc:RtcProfile>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/test/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_test(NAME ${PROJECT_NAME}_test COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}Test.py -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event01-02&fsm_event_name=Event01-02,${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event02-Final&fsm_event_name=Event02-Final" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+string(REPLACE ";" "\\;" PYTHONPATH "$ENV{PYTHONPATH}")
+if(UNIX)
+  set_tests_properties(${PROJECT_NAME}_test PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}:${PYTHONPATH}")
+else()
+  set_tests_properties(${PROJECT_NAME}_test PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}\;${PYTHONPATH}")
+endif()

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/test/ModuleNameTest.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/test/ModuleNameTest.py
@@ -1,0 +1,291 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -*- Python -*-
+
+"""
+ @file ModuleNameTest.py
+ @brief ModuleDescription
+ @date $Date$
+
+
+"""
+from __future__ import print_function
+import sys
+import time
+sys.path.append(".")
+
+# Import RTM module
+import RTC
+import OpenRTM_aist
+
+
+# Import Service implementation class
+# <rtc-template block="service_impl">
+
+import ModuleName
+
+# </rtc-template>
+
+# Import Service stub modules
+# <rtc-template block="consumer_import">
+# </rtc-template>
+
+
+# This module's spesification
+# <rtc-template block="module_spec">
+modulenametest_spec = ["implementation_id", "ModuleNameTest", 
+         "type_name",         "ModuleNameTest", 
+         "description",       "ModuleDescription", 
+         "version",           "1.0.0", 
+         "vendor",            "VenderName", 
+         "category",          "Category", 
+         "activity_type",     "STATIC", 
+         "max_instance",      "1", 
+         "language",          "Python", 
+         "lang_type",         "SCRIPT",
+         ""]
+# </rtc-template>
+
+##
+# @class ModuleNameTest
+# @brief ModuleDescription
+# 
+# 
+class ModuleNameTest(OpenRTM_aist.DataFlowComponentBase):
+    
+    ##
+    # @brief constructor
+    # @param manager Maneger Object
+    # 
+    def __init__(self, manager):
+        OpenRTM_aist.DataFlowComponentBase.__init__(self, manager)
+
+
+
+        
+
+        self._d_Event01-02 = OpenRTM_aist.instantiateDataType(RTC.TimedLong)
+        """
+        """
+        self._Event01-02Out = OpenRTM_aist.OutPort("Event01-02", self._d_Event01-02)
+
+        self._d_Event02-Final = OpenRTM_aist.instantiateDataType(RTC.TimedString)
+        """
+        """
+        self._Event02-FinalOut = OpenRTM_aist.OutPort("Event02-Final", self._d_Event02-Final)
+
+
+        # initialize of configuration-data.
+        # <rtc-template block="init_conf_param">
+        
+        # </rtc-template>
+
+
+         
+    ##
+    #
+    # The initialize action (on CREATED->ALIVE transition)
+    # 
+    # @return RTC::ReturnCode_t
+    # 
+    #
+    def onInitialize(self):
+        # Bind variables and configuration variable
+        
+        # Set InPort buffers
+        
+        # Set OutPort buffers
+        self.addOutPort("Event01-02", self._Event01-02Out)
+        self.addOutPort("Event02-Final", self._Event02-FinalOut)
+        
+        # Set service provider to Ports
+        
+        # Set service consumers to Ports
+        
+        # Set CORBA Service Ports
+        
+        return RTC.RTC_OK
+    
+    ###
+    ## 
+    ## The finalize action (on ALIVE->END transition)
+    ## 
+    ## @return RTC::ReturnCode_t
+    #
+    ## 
+    #def onFinalize(self):
+    #
+    #    return RTC.RTC_OK
+    
+    #    ##
+    ##
+    ## The startup action when ExecutionContext startup
+    ## 
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onStartup(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The shutdown action when ExecutionContext stop
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onShutdown(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The activated action (Active state entry action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ## 
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onActivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    #    ##
+    ##
+    ## The deactivated action (Active state exit action)
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onDeactivated(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The execution action that is invoked periodically
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onExecute(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The aborting action when main logic error occurred.
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    #    #
+    ##
+    #def onAborting(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The error action in ERROR state
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onError(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The reset action that is invoked resetting
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onReset(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The state update action that is invoked after onExecute() action
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+
+    ##
+    #def onStateUpdate(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    ###
+    ##
+    ## The action that is invoked when execution context's rate is changed
+    ##
+    ## @param ec_id target ExecutionContext Id
+    ##
+    ## @return RTC::ReturnCode_t
+    ##
+    ##
+    #def onRateChanged(self, ec_id):
+    #
+    #    return RTC.RTC_OK
+    
+    def runTest(self):
+        return True
+
+def RunTest():
+    manager = OpenRTM_aist.Manager.instance()
+    comp = manager.getComponent("ModuleNameTest0")
+    if comp is None:
+        print('Component get failed.', file=sys.stderr)
+        return False
+    return comp.runTest()
+
+def ModuleNameTestInit(manager):
+    profile = OpenRTM_aist.Properties(defaults_str=modulenametest_spec)
+    manager.registerFactory(profile,
+                            ModuleNameTest,
+                            OpenRTM_aist.Delete)
+
+def MyModuleInit(manager):
+    ModuleNameTestInit(manager)
+    ModuleName.ModuleNameInit(manager)
+
+    # Create a component
+    comp = manager.createComponent("ModuleNameTest")
+
+def main():
+    mgr = OpenRTM_aist.Manager.init(sys.argv)
+    mgr.setModuleInitProc(MyModuleInit)
+    mgr.activateManager()
+    mgr.runManager(True)
+
+    ret = RunTest()
+    mgr.shutdown()
+
+    if ret:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+

--- a/jp.go.aist.rtm.rtcbuilder.python/test/jp/go/aist/rtm/rtcbuilder/python/_test/AllTestsPy.java
+++ b/jp.go.aist.rtm.rtcbuilder.python/test/jp/go/aist/rtm/rtcbuilder/python/_test/AllTestsPy.java
@@ -4,6 +4,7 @@ import jp.go.aist.rtm.rtcbuilder.python._test._100.AISTTest;
 import jp.go.aist.rtm.rtcbuilder.python._test._100.BaseTest;
 import jp.go.aist.rtm.rtcbuilder.python._test._100.BuildTest;
 import jp.go.aist.rtm.rtcbuilder.python._test._100.ConfigSetTest;
+import jp.go.aist.rtm.rtcbuilder.python._test._100.FSMTest;
 import jp.go.aist.rtm.rtcbuilder.python._test._100.IDLPathTest;
 import jp.go.aist.rtm.rtcbuilder.python._test._100.PyDocTest;
 import jp.go.aist.rtm.rtcbuilder.python._test._100.PyIDLInheritTest;
@@ -29,6 +30,8 @@ public class AllTestsPy {
 		suite.addTestSuite(PyIDLType.class);
 		suite.addTestSuite(BuildTest.class);
 		suite.addTestSuite(IDLPathTest.class);
+		
+		suite.addTestSuite(FSMTest.class);
 		//$JUnit-END$
 		return suite;
 	}

--- a/jp.go.aist.rtm.rtcbuilder.python/test/jp/go/aist/rtm/rtcbuilder/python/_test/TestBase.java
+++ b/jp.go.aist.rtm.rtcbuilder.python/test/jp/go/aist/rtm/rtcbuilder/python/_test/TestBase.java
@@ -98,6 +98,7 @@ public class TestBase extends TestCase {
 		expPath = resourceDir + fileName;
 		expContent = readFile(expPath);
 		expContent = replaceRootPath(expContent);
+		expContent = expContent.replace("\uFEFF", "");
 		assertEquals(expContent,
 				getGeneratedString(result.get(index).getCode()));
 	}

--- a/jp.go.aist.rtm.rtcbuilder.python/test/jp/go/aist/rtm/rtcbuilder/python/_test/_100/FSMTest.java
+++ b/jp.go.aist.rtm.rtcbuilder.python/test/jp/go/aist/rtm/rtcbuilder/python/_test/_100/FSMTest.java
@@ -1,0 +1,113 @@
+package jp.go.aist.rtm.rtcbuilder.python._test._100;
+
+import java.util.List;
+
+import jp.go.aist.rtm.rtcbuilder.Generator;
+import jp.go.aist.rtm.rtcbuilder.fsm.ScXMLHandler;
+import jp.go.aist.rtm.rtcbuilder.fsm.StateParam;
+import jp.go.aist.rtm.rtcbuilder.generator.GeneratedResult;
+import jp.go.aist.rtm.rtcbuilder.generator.ProfileHandler;
+import jp.go.aist.rtm.rtcbuilder.generator.param.GeneratorParam;
+import jp.go.aist.rtm.rtcbuilder.python._test.TestBase;
+import jp.go.aist.rtm.rtcbuilder.python.manager.PythonCMakeGenerateManager;
+import jp.go.aist.rtm.rtcbuilder.python.manager.PythonGenerateManager;
+
+public class FSMTest extends TestBase {
+
+	protected void setUp() throws Exception {
+	}
+
+	private List<GeneratedResult> generateCode(String rtcProfile, String fsmProfile) throws Exception {
+		ProfileHandler handler = new ProfileHandler(true);
+		handler.addManager(new PythonGenerateManager());
+		GeneratorParam genParam = handler.restorefromXMLFile(rtcProfile, true);
+		
+		ScXMLHandler scHandler = new ScXMLHandler();
+		StringBuffer buffer = new StringBuffer();
+		StateParam rootState = scHandler.parseSCXML(fsmProfile, buffer);
+		if(rootState!=null) {
+			genParam.getRtcParam().setFsmParam(rootState);
+			genParam.getRtcParam().setFsmContents(buffer.toString());
+			genParam.getRtcParam().parseEvent();
+			
+		}
+		
+		Generator generator = new Generator();
+		generator.addGenerateManager(new PythonGenerateManager());
+		generator.addGenerateManager(new PythonCMakeGenerateManager());
+		List<GeneratedResult> result = generator.generateTemplateCode(genParam);
+		return result;
+	}
+
+	private void checkGeneratedCode(List<GeneratedResult> result, String resourceDir) {
+		checkCode(result, resourceDir, "README.md");
+		checkCode(result, resourceDir, "ModuleName.py");
+		checkCode(result, resourceDir, "ModuleNameFSM.py");
+		
+		checkCode(result, resourceDir, "test/CMakeLists.txt");
+		checkCode(result, resourceDir, "test/ModuleNameTest.py");
+	}
+
+	public void testBasic() throws Exception {
+		String rtcProfile = rootPath + "resource/FSM/basic/RTC.xml";
+		String fsmProfile = rootPath + "resource/FSM/basic/ModuleNameFSM.scxml";
+		String resourceDir = rootPath + "/resource/FSM/basic/";
+		
+		List<GeneratedResult> result = generateCode(rtcProfile, fsmProfile);
+		checkGeneratedCode(result, resourceDir);
+	}
+	
+	public void testPortName() throws Exception {
+		String rtcProfile = rootPath + "resource/FSM/portName/RTC.xml";
+		String fsmProfile = rootPath + "resource/FSM/portName/ModuleNameFSM.scxml";
+		String resourceDir = rootPath + "/resource/FSM/portName/";
+		
+		List<GeneratedResult> result = generateCode(rtcProfile, fsmProfile);
+		checkGeneratedCode(result, resourceDir);
+	}
+	
+	public void testEventName() throws Exception {
+		String rtcProfile = rootPath + "resource/FSM/eventName/RTC.xml";
+		String fsmProfile = rootPath + "resource/FSM/eventName/ModuleNameFSM.scxml";
+		String resourceDir = rootPath + "/resource/FSM/eventName/";
+		
+		List<GeneratedResult> result = generateCode(rtcProfile, fsmProfile);
+		checkGeneratedCode(result, resourceDir);
+	}
+	
+	public void testEventCond() throws Exception {
+		String rtcProfile = rootPath + "resource/FSM/eventCond/RTC.xml";
+		String fsmProfile = rootPath + "resource/FSM/eventCond/ModuleNameFSM.scxml";
+		String resourceDir = rootPath + "/resource/FSM/eventCond/";
+		
+		List<GeneratedResult> result = generateCode(rtcProfile, fsmProfile);
+		checkGeneratedCode(result, resourceDir);
+	}
+	
+	public void testEventType() throws Exception {
+		String rtcProfile = rootPath + "resource/FSM/eventType/RTC.xml";
+		String fsmProfile = rootPath + "resource/FSM/eventType/ModuleNameFSM.scxml";
+		String resourceDir = rootPath + "/resource/FSM/eventType/";
+		
+		List<GeneratedResult> result = generateCode(rtcProfile, fsmProfile);
+		checkGeneratedCode(result, resourceDir);
+	}
+	
+	public void testEventDoc() throws Exception {
+		String rtcProfile = rootPath + "resource/FSM/eventDoc/RTC.xml";
+		String fsmProfile = rootPath + "resource/FSM/eventDoc/ModuleNameFSM.scxml";
+		String resourceDir = rootPath + "/resource/FSM/eventDoc/";
+		
+		List<GeneratedResult> result = generateCode(rtcProfile, fsmProfile);
+		checkGeneratedCode(result, resourceDir);
+	}
+	
+	public void testStateEntry() throws Exception {
+		String rtcProfile = rootPath + "resource/FSM/stateEntry/RTC.xml";
+		String fsmProfile = rootPath + "resource/FSM/stateEntry/ModuleNameFSM.scxml";
+		String resourceDir = rootPath + "/resource/FSM/stateEntry/";
+		
+		List<GeneratedResult> result = generateCode(rtcProfile, fsmProfile);
+		checkGeneratedCode(result, resourceDir);
+	}
+}

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/ModuleNameFSM.scxml
@@ -1,0 +1,12 @@
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=854 h=400  -->
+ <state id="InitialState"><!--   node-size-and-position x=90 y=150 w=75 h=75  -->
+  <transition id="21" target="State01"></transition>
+ </state>
+ <state id="State01"><!--   node-size-and-position x=280 y=150 w=75 h=75  -->
+  <transition id="22" target="State02"></transition>
+ </state>
+ <state id="State02"><!--   node-size-and-position x=470 y=150 w=75 h=75  -->
+  <transition id="23" target="FinalState"></transition>
+ </state>
+ <final id="FinalState"><!--   node-size-and-position x=650 y=160 w=75 h=75  --></final>
+</scxml>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/README.md
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/README.md
@@ -1,0 +1,278 @@
+﻿# ModuleName
+
+## Overview
+
+ModuleDescription
+
+## Description
+
+
+
+### Input and Output
+
+
+
+### Algorithm etc
+
+
+
+### Basic Information
+
+|  |  |
+----|---- 
+| Module Name | ModuleName |
+| Description | ModuleDescription |
+| Version | 1.0.0 |
+| Vendor | VenderName |
+| Category | Category |
+| Comp. Type | STATIC |
+| Act. Type | PERIODIC |
+| Kind | DataFlowComponent |
+| MAX Inst. | 1 |
+
+### Activity definition
+
+<table>
+  <tr>
+    <td rowspan="4">on_initialize</td>
+    <td colspan="2">implemented</td>
+    <tr>
+      <td>Description</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PreCondition</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PostCondition</td>
+      <td></td>
+    </tr>
+  </tr>
+  <tr>
+    <td>on_finalize</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_startup</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_shutdown</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_activated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_deactivated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_execute</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_aborting</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_error</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_reset</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_state_update</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_rate_changed</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+### EventPorts definition
+
+|  |  |
+----|---- 
+| Port Name | FSMEvent |
+| FSM Type | StaticFSM |
+
+#### Node list
+
+<table>
+  <tr>
+    <td>State Name</td>
+    <td>Event Name</td>
+    <td>Target State</td>
+  </tr>
+  <tr>
+    <td>InitialState</td>
+    <td colspan="2">Initial State</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State01</td>
+    <td></td>
+    <td>State02</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State02</td>
+    <td></td>
+    <td>FinalState</td>
+  </tr>
+  <tr>
+    <td>FinalState</td>
+    <td colspan="2">Final State</td>
+  </tr>
+
+</table>
+
+#### Event list
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">InitialState</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">FinalState</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+
+
+### InPorts definition
+
+
+### OutPorts definition
+
+
+### Service Port definition
+
+
+### Configuration definition
+
+
+## Demo
+
+## Requirement
+
+## Setup
+
+### Windows
+
+### Ubuntu
+
+## Usage
+
+## Running the tests
+
+## LICENCE
+
+
+
+
+## References
+
+
+
+
+## Author
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/RTC.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<rtc:RtcProfile rtc:version="0.3" rtc:id="RTC:VenderName:Category:ModuleName:1.0.0" xmlns:rtc="http://www.openrtp.org/namespaces/rtc" xmlns:rtcExt="http://www.openrtp.org/namespaces/rtc_ext" xmlns:rtcDoc="http://www.openrtp.org/namespaces/rtc_doc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <rtc:BasicInfo xsi:type="rtcExt:basic_info_ext" rtcExt:saveProject="FSMTest" rtc:updateDate="2019-12-19T22:51:23.000+09:00" rtc:creationDate="2019-12-19T22:49:56.000+09:00" rtc:version="1.0.0" rtc:vendor="VenderName" rtc:maxInstances="1" rtc:executionType="PeriodicExecutionContext" rtc:executionRate="1000.0" rtc:description="ModuleDescription" rtc:category="Category" rtc:componentKind="DataFlowComponent" rtc:activityType="PERIODIC" rtc:componentType="STATIC" rtc:name="ModuleName">
+        <rtcExt:Properties rtcExt:value="true" rtcExt:name="FSM"/>
+        <rtcExt:Properties rtcExt:value="StaticFSM" rtcExt:name="FSMType"/>
+    </rtc:BasicInfo>
+    <rtc:Actions>
+        <rtc:OnInitialize xsi:type="rtcDoc:action_status_doc" rtc:implemented="true"/>
+        <rtc:OnFinalize xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStartup xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnShutdown xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnActivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnDeactivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAborting xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnError xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnReset xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnExecute xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStateUpdate xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnRateChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAction xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+    </rtc:Actions>
+    <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEvent" rtc:type="Any" rtc:name="FSMEvent" rtc:portType="EventPort">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="" rtc:name="">
+            <rtcDoc:Doc/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="" rtc:name="">
+            <rtcDoc:Doc/>
+        </rtc:Event>
+    </rtc:DataPorts>
+    <rtc:Language xsi:type="rtcExt:language_ext" rtc:kind="C++"/>
+</rtc:RtcProfile>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/include/ModuleName/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/include/ModuleName/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(hdrs ModuleName.h
+    ModuleNameFSM.h
+    PARENT_SCOPE
+    )

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/include/ModuleName/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/include/ModuleName/ModuleName.h
@@ -1,0 +1,280 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleName.h
+ * @brief ModuleDescription
+ * @date  $Date$
+ *
+ * $Id$
+ */
+
+#ifndef MODULENAME_H
+#define MODULENAME_H
+
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/idl/ExtendedDataTypesSkel.h>
+#include <rtm/idl/InterfaceDataTypesSkel.h>
+
+// Service implementation headers
+// <rtc-template block="service_impl_h">
+
+// </rtc-template>
+
+// Service Consumer stub headers
+// <rtc-template block="consumer_stub_h">
+
+// </rtc-template>
+
+#include <rtm/Manager.h>
+#include <rtm/DataFlowComponentBase.h>
+#include <rtm/CorbaPort.h>
+#include <rtm/DataInPort.h>
+#include <rtm/DataOutPort.h>
+
+// FSM headers
+
+#include <rtm/EventPort.h>
+// <rtc-template block="fsm_h">
+#include "ModuleNameFSM.h"
+// </rtc-template>
+
+
+/*!
+ * @class ModuleName
+ * @brief ModuleDescription
+ *
+ */
+class ModuleName
+  : public RTC::DataFlowComponentBase
+{
+ public:
+  /*!
+   * @brief constructor
+   * @param manager Maneger Object
+   */
+  ModuleName(RTC::Manager* manager);
+
+  /*!
+   * @brief destructor
+   */
+  ~ModuleName() override;
+
+  // <rtc-template block="public_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="public_operation">
+  
+  // </rtc-template>
+
+  // <rtc-template block="activity">
+  /***
+   *
+   * The initialize action (on CREATED->ALIVE transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+   RTC::ReturnCode_t onInitialize() override;
+
+  /***
+   *
+   * The finalize action (on ALIVE->END transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onFinalize() override;
+
+  /***
+   *
+   * The startup action when ExecutionContext startup
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStartup(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The shutdown action when ExecutionContext stop
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onShutdown(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The activated action (Active state entry action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The deactivated action (Active state exit action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The execution action that is invoked periodically
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The aborting action when main logic error occurred.
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onAborting(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The error action in ERROR state
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onError(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The reset action that is invoked resetting
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onReset(RTC::UniqueId ec_id) override;
+  
+  /***
+   *
+   * The state update action that is invoked after onExecute() action
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStateUpdate(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The action that is invoked when execution context's rate is changed
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id) override;
+  // </rtc-template>
+
+
+ protected:
+  // <rtc-template block="protected_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="protected_operation">
+  
+  // </rtc-template>
+
+  // Configuration variable declaration
+  // <rtc-template block="config_declare">
+
+  // </rtc-template>
+
+  // DataInPort declaration
+  // <rtc-template block="inport_declare">
+  
+  // </rtc-template>
+
+
+  // DataOutPort declaration
+  // <rtc-template block="outport_declare">
+  
+  // </rtc-template>
+
+  // CORBA Port declaration
+  // <rtc-template block="corbaport_declare">
+  
+  // </rtc-template>
+
+  // Service declaration
+  // <rtc-template block="service_declare">
+  
+  // </rtc-template>
+
+  // Consumer declaration
+  // <rtc-template block="consumer_declare">
+  
+  // </rtc-template>
+
+  // State machine declaration
+  // <rtc-template block="fsm_declare">
+  RTC::Machine<ModuleNameFsm::Top> m_fsm;
+  // </rtc-template>
+  
+  // EventPort declaration
+  // <rtc-template block="event_declare">
+  
+  RTC::EventInPort< RTC::Machine<ModuleNameFsm::Top> > m_FSMEventIn;
+  // </rtc-template>
+
+ private:
+  // <rtc-template block="private_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="private_operation">
+  
+  // </rtc-template>
+
+};
+
+
+extern "C"
+{
+  DLL_EXPORT void ModuleNameInit(RTC::Manager* manager);
+};
+
+#endif // MODULENAME_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/include/ModuleName/ModuleNameFSM.h
@@ -1,0 +1,65 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameFSM.h
+ * @date  $Date$
+ * $Id$
+ */
+
+#ifndef MODULENAMEFSM_H
+#define MODULENAMEFSM_H
+
+#include <rtm/StaticFSM.h>
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/RTC.h>
+
+class ModuleName;
+
+namespace ModuleNameFsm {
+
+  /*!
+   * @if jp
+   * @class TOP状態
+   *
+   *
+   * @else
+   * @brief TOP state
+   *
+   * @endif
+   */
+  FSM_TOPSTATE(Top) {
+    // Top state variables (visible to all substates)
+  
+    FSM_STATE(Top);
+
+    // Machine's event protocol
+  
+   private:
+     RTC::ReturnCode_t onInit() override;
+     RTC::ReturnCode_t onEntry() override;
+     RTC::ReturnCode_t onExit() override;
+  };
+
+  FSM_SUBSTATE(State01, Top) {
+    FSM_STATE(State01);
+  
+
+    // Event handler
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+  };
+
+  FSM_SUBSTATE(State02, Top) {
+    FSM_STATE(State02);
+  
+
+    // Event handler
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+  };
+
+
+} //end namespace 'ModuleNameFSM'
+
+#endif // MODULENAMEFSM_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/src/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/src/CMakeLists.txt
@@ -1,0 +1,64 @@
+set(comp_srcs ModuleName.cpp ModuleNameFSM.cpp)
+set(standalone_srcs ModuleNameComp.cpp)
+
+if(${OPENRTM_VERSION_MAJOR} LESS 2)
+  set(OPENRTM_CFLAGS ${OPENRTM_CFLAGS} ${OMNIORB_CFLAGS})
+  set(OPENRTM_INCLUDE_DIRS ${OPENRTM_INCLUDE_DIRS} ${OMNIORB_INCLUDE_DIRS})
+  set(OPENRTM_LIBRARY_DIRS ${OPENRTM_LIBRARY_DIRS} ${OMNIORB_LIBRARY_DIRS})
+endif()
+
+if (DEFINED OPENRTM_INCLUDE_DIRS)
+  string(REGEX REPLACE "-I" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+endif (DEFINED OPENRTM_INCLUDE_DIRS)
+
+if (DEFINED OPENRTM_LIBRARY_DIRS)
+  string(REGEX REPLACE "-L" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+endif (DEFINED OPENRTM_LIBRARY_DIRS)
+
+if (DEFINED OPENRTM_LIBRARIES)
+  string(REGEX REPLACE "-l" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+endif (DEFINED OPENRTM_LIBRARIES)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME})
+include_directories(${PROJECT_BINARY_DIR})
+include_directories(${PROJECT_BINARY_DIR}/idl)
+include_directories(${OPENRTM_INCLUDE_DIRS})
+add_definitions(${OPENRTM_CFLAGS})
+
+MAP_ADD_STR(comp_hdrs "../" comp_headers)
+
+link_directories(${OPENRTM_LIBRARY_DIRS})
+
+add_library(${PROJECT_NAME} ${LIB_TYPE} ${comp_srcs}
+  ${comp_headers} ${ALL_IDL_SRCS})
+set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
+set_source_files_properties(${ALL_IDL_SRCS} PROPERTIES GENERATED 1)
+if(NOT TARGET ALL_IDL_TGT)
+ add_custom_target(ALL_IDL_TGT)
+endif(NOT TARGET ALL_IDL_TGT)
+add_dependencies(${PROJECT_NAME} ALL_IDL_TGT)
+target_link_libraries(${PROJECT_NAME} ${OPENRTM_LIBRARIES})
+
+add_executable(${PROJECT_NAME}Comp ${standalone_srcs}
+  ${comp_srcs} ${comp_headers} ${ALL_IDL_SRCS})
+add_dependencies(${PROJECT_NAME}Comp ALL_IDL_TGT)
+target_link_libraries(${PROJECT_NAME}Comp ${OPENRTM_LIBRARIES})
+
+install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}Comp
+    EXPORT ${PROJECT_NAME}
+    RUNTIME DESTINATION ${INSTALL_PREFIX} COMPONENT component
+    LIBRARY DESTINATION ${INSTALL_PREFIX} COMPONENT component
+    ARCHIVE DESTINATION ${INSTALL_PREFIX} COMPONENT component)
+
+install(FILES ${PROJECT_SOURCE_DIR}/RTC.xml DESTINATION ${INSTALL_PREFIX}
+        COMPONENT component)

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/src/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/src/ModuleName.cpp
@@ -1,0 +1,178 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleName.cpp
+ * @brief ModuleDescription
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include "ModuleName.h"
+
+// Module specification
+// <rtc-template block="module_spec">
+static const char* modulename_spec[] =
+  {
+    "implementation_id", "ModuleName",
+    "type_name",         "ModuleName",
+    "description",       "ModuleDescription",
+    "version",           "1.0.0",
+    "vendor",            "VenderName",
+    "category",          "Category",
+    "activity_type",     "PERIODIC",
+    "kind",              "DataFlowComponent",
+    "max_instance",      "1",
+    "language",          "C++",
+    "lang_type",         "compile",
+    ""
+  };
+// </rtc-template>
+
+/*!
+ * @brief constructor
+ * @param manager Maneger Object
+ */
+ModuleName::ModuleName(RTC::Manager* manager)
+    // <rtc-template block="initializer">
+  : RTC::DataFlowComponentBase(manager),
+    m_fsm(this),
+    m_FSMEventIn("event", m_fsm)
+
+    // </rtc-template>
+{
+}
+
+/*!
+ * @brief destructor
+ */
+ModuleName::~ModuleName()
+{
+}
+
+
+
+RTC::ReturnCode_t ModuleName::onInitialize()
+{
+#ifdef ORB_IS_TAO
+  ::CORBA_Util::toRepositoryIdOfStruct<TimedLong>();
+#endif
+  // Registration: InPort/OutPort/Service
+  // <rtc-template block="registration">
+  // Set InPort buffers
+  
+  // Set OutPort buffer
+
+  // Set EventPort buffer
+  addInPort("event", m_FSMEventIn);
+  
+  // Set service provider to Ports
+  
+  // Set service consumers to Ports
+  
+  // Set CORBA Service Ports
+  
+  // </rtc-template>
+
+  // <rtc-template block="bind_config">
+  // </rtc-template>
+  // <rtc-template block="bind_event">
+  // </rtc-template>
+
+  
+  return RTC::RTC_OK;
+}
+
+/*
+RTC::ReturnCode_t ModuleName::onFinalize()
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onStartup(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onShutdown(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onActivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onDeactivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onExecute(RTC::UniqueId ec_id)
+{
+  m_fsm.run_event();
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onAborting(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onError(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onReset(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onStateUpdate(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onRateChanged(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+
+
+extern "C"
+{
+ 
+  void ModuleNameInit(RTC::Manager* manager)
+  {
+    coil::Properties profile(modulename_spec);
+    manager->registerFactory(profile,
+                             RTC::Create<ModuleName>,
+                             RTC::Delete<ModuleName>);
+  }
+  
+};
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/src/ModuleNameComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/src/ModuleNameComp.cpp
@@ -1,0 +1,129 @@
+﻿// -*- C++ -*-
+/*!
+ * @file ModuleNameComp.cpp
+ * @brief Standalone component
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include <rtm/Manager.h>
+#include <iostream>
+#include <string>
+#include <stdlib.h>
+#include "ModuleName.h"
+
+class OverwriteInstanceName
+  : public RTM::RtcLifecycleActionListener
+{
+public:
+  OverwriteInstanceName(int argc, char** argv)
+    : m_name(""), m_count(0)
+  {
+    for (size_t i = 0; i < argc; ++i)
+      {
+        std::string opt = argv[i];
+        if (opt.find("--instance_name=") == std::string::npos) { continue; }
+
+        coil::replaceString(opt, "--instance_name=", "");
+        if (opt.empty()) { continue; }
+
+        m_name = opt;
+      }
+  }
+  virtual ~OverwriteInstanceName() {}
+  virtual void preCreate(std::string& args)
+  {
+    if (m_count != 0 || m_name.empty()) { return; }
+    args = args + "?instance_name=" + m_name;
+    ++m_count;
+  };
+  virtual void postCreate(RTC::RTObject_impl*) {};
+  virtual void preConfigure(coil::Properties&) {};
+  virtual void postConfigure(coil::Properties&) {};
+  virtual void preInitialize() {};
+  virtual void postInitialize() {};
+private:
+  std::string m_name;
+  int32_t m_count;
+};
+
+void MyModuleInit(RTC::Manager* manager)
+{
+  ModuleNameInit(manager);
+  RTC::RtcBase* comp;
+
+  // Create a component
+  comp = manager->createComponent("ModuleName");
+
+  if (comp==NULL)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
+
+  // Example
+  // The following procedure is examples how handle RT-Components.
+  // These should not be in this function.
+
+  // Get the component's object reference
+//  RTC::RTObject_var rtobj;
+//  rtobj = RTC::RTObject::_narrow(manager->getPOA()->servant_to_reference(comp));
+
+  // Get the port list of the component
+//  PortServiceList* portlist;
+//  portlist = rtobj->get_ports();
+
+  // getting port profiles
+//  std::cout << "Number of Ports: ";
+//  std::cout << portlist->length() << std::endl << std::endl; 
+//  for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
+//  {
+//    PortService_ptr port;
+//    port = (*portlist)[i];
+//    std::cout << "Port" << i << " (name): ";
+//    std::cout << port->get_port_profile()->name << std::endl;
+//    
+//    RTC::PortInterfaceProfileList iflist;
+//    iflist = port->get_port_profile()->interfaces;
+//    std::cout << "---interfaces---" << std::endl;
+//    for (CORBA::ULong i(0), n(iflist.length()); i < n; ++i)
+//    {
+//      std::cout << "I/F name: ";
+//      std::cout << iflist[i].instance_name << std::endl;
+//      std::cout << "I/F type: ";
+//      std::cout << iflist[i].type_name << std::endl;
+//      const char* pol;
+//      pol = iflist[i].polarity == 0 ? "PROVIDED" : "REQUIRED";
+//      std::cout << "Polarity: " << pol << std::endl;
+//    }
+//    std::cout << "---properties---" << std::endl;
+//    NVUtil::dump(port->get_port_profile()->properties);
+//    std::cout << "----------------" << std::endl << std::endl;
+//  }
+
+  return;
+}
+
+int main (int argc, char** argv)
+{
+  RTC::Manager* manager;
+  manager = RTC::Manager::init(argc, argv);
+  manager->addRtcLifecycleActionListener(new OverwriteInstanceName(argc, argv), true);
+
+  // Set module initialization proceduer
+  // This procedure will be invoked in activateManager() function.
+  manager->setModuleInitProc(MyModuleInit);
+
+  // Activate manager and register to naming service
+  manager->activateManager();
+
+  // run the manager in blocking mode
+  // runManager(false) is the default.
+  manager->runManager();
+
+  // If you want to run the manager in non-blocking mode, do like this
+  // manager->runManager(true);
+
+  return 0;
+}

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/src/ModuleNameFSM.cpp
@@ -1,0 +1,42 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameFSM.cpp
+ * @date $Date$
+ * $Id$
+ */
+
+#include "ModuleNameFSM.h"
+
+namespace ModuleNameFsm {
+
+// Top state
+RTC::ReturnCode_t Top::onInit() {
+  setState<State01>();
+  return RTC::RTC_OK;
+}
+
+RTC::ReturnCode_t Top::onEntry() {
+  return RTC::RTC_OK;
+}
+
+RTC::ReturnCode_t Top::onExit() {
+  return RTC::RTC_OK;
+}
+
+//============================================================
+// State State01
+// RTC::ReturnCode_t State01::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+
+
+//============================================================
+// State State02
+// RTC::ReturnCode_t State02::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+
+
+} //end namespace 'ModuleNameFSM'

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/test/include/ModuleNameTest/ModuleNameTest.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/test/include/ModuleNameTest/ModuleNameTest.h
@@ -1,0 +1,262 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameTest.h
+ * @brief ModuleDescription
+ * @date  $Date$
+ *
+ * $Id$
+ */
+
+#ifndef MODULENAME_TEST__H
+#define MODULENAME_TEST_H
+
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/idl/ExtendedDataTypesSkel.h>
+#include <rtm/idl/InterfaceDataTypesSkel.h>
+
+// Service implementation headers
+// <rtc-template block="service_impl_h">
+
+// </rtc-template>
+
+// Service Consumer stub headers
+// <rtc-template block="consumer_stub_h">
+
+// </rtc-template>
+
+#include <rtm/Manager.h>
+#include <rtm/DataFlowComponentBase.h>
+#include <rtm/CorbaPort.h>
+#include <rtm/DataInPort.h>
+#include <rtm/DataOutPort.h>
+
+/*!
+ * @class ModuleNameTest
+ * @brief ModuleDescription
+ *
+ */
+class ModuleNameTest
+  : public RTC::DataFlowComponentBase
+{
+ public:
+  /*!
+   * @brief constructor
+   * @param manager Maneger Object
+   */
+  ModuleNameTest(RTC::Manager* manager);
+
+  /*!
+   * @brief destructor
+   */
+  ~ModuleNameTest() override;
+
+  // <rtc-template block="public_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="public_operation">
+  
+  // </rtc-template>
+
+  // <rtc-template block="activity">
+  /***
+   *
+   * The initialize action (on CREATED->ALIVE transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+   RTC::ReturnCode_t onInitialize() override;
+
+  /***
+   *
+   * The finalize action (on ALIVE->END transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onFinalize() override;
+
+  /***
+   *
+   * The startup action when ExecutionContext startup
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStartup(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The shutdown action when ExecutionContext stop
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onShutdown(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The activated action (Active state entry action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The deactivated action (Active state exit action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The execution action that is invoked periodically
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The aborting action when main logic error occurred.
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onAborting(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The error action in ERROR state
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onError(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The reset action that is invoked resetting
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onReset(RTC::UniqueId ec_id) override;
+  
+  /***
+   *
+   * The state update action that is invoked after onExecute() action
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStateUpdate(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The action that is invoked when execution context's rate is changed
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id) override;
+  // </rtc-template>
+
+  bool runTest();
+
+ protected:
+  // <rtc-template block="protected_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="protected_operation">
+  
+  // </rtc-template>
+
+  // Configuration variable declaration
+  // <rtc-template block="config_declare">
+
+  // </rtc-template>
+
+  // DataInPort declaration
+  // <rtc-template block="inport_declare">
+  
+  // </rtc-template>
+
+
+  // DataOutPort declaration
+  // <rtc-template block="outport_declare">
+  
+  // </rtc-template>
+
+  // CORBA Port declaration
+  // <rtc-template block="corbaport_declare">
+  
+  // </rtc-template>
+
+  // Service declaration
+  // <rtc-template block="service_declare">
+  
+  // </rtc-template>
+
+  // Consumer declaration
+  // <rtc-template block="consumer_declare">
+  
+  // </rtc-template>
+
+ private:
+  // <rtc-template block="private_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="private_operation">
+  
+  // </rtc-template>
+
+};
+
+
+extern "C"
+{
+  DLL_EXPORT void ModuleNameTestInit(RTC::Manager* manager);
+};
+
+#endif // MODULENAME_TEST_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/test/src/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/test/src/CMakeLists.txt
@@ -1,0 +1,57 @@
+set(comp_srcs
+   ModuleNameTest.cpp
+   )
+set(standalone_srcs ModuleNameTestComp.cpp)
+
+if(${OPENRTM_VERSION_MAJOR} LESS 2)
+  set(OPENRTM_CFLAGS ${OPENRTM_CFLAGS} ${OMNIORB_CFLAGS})
+  set(OPENRTM_INCLUDE_DIRS ${OPENRTM_INCLUDE_DIRS} ${OMNIORB_INCLUDE_DIRS})
+  set(OPENRTM_LIBRARY_DIRS ${OPENRTM_LIBRARY_DIRS} ${OMNIORB_LIBRARY_DIRS})
+endif()
+
+if (DEFINED OPENRTM_INCLUDE_DIRS)
+  string(REGEX REPLACE "-I" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+endif (DEFINED OPENRTM_INCLUDE_DIRS)
+
+if (DEFINED OPENRTM_LIBRARY_DIRS)
+  string(REGEX REPLACE "-L" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+endif (DEFINED OPENRTM_LIBRARY_DIRS)
+
+if (DEFINED OPENRTM_LIBRARIES)
+  string(REGEX REPLACE "-l" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+endif (DEFINED OPENRTM_LIBRARIES)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME})
+include_directories(${PROJECT_SOURCE_DIR}/test/include)
+include_directories(${PROJECT_SOURCE_DIR}/test/include/${PROJECT_NAME}Test)
+include_directories(${PROJECT_BINARY_DIR})
+include_directories(${PROJECT_BINARY_DIR}/idl)
+include_directories(${OPENRTM_INCLUDE_DIRS})
+add_definitions(${OPENRTM_CFLAGS})
+
+MAP_ADD_STR(comp_test_hdrs "../" comp_headers)
+
+link_directories(${OPENRTM_LIBRARY_DIRS})
+
+if(NOT TARGET ALL_IDL_TGT)
+ add_custom_target(ALL_IDL_TGT)
+endif(NOT TARGET ALL_IDL_TGT)
+
+add_executable(${PROJECT_NAME}Test ${standalone_srcs}
+  ${comp_srcs} ${comp_headers} ${ALL_IDL_SRCS})
+set_source_files_properties(${ALL_IDL_SRCS} PROPERTIES GENERATED 1)
+add_dependencies(${PROJECT_NAME}Test ${PROJECT_NAME})
+target_link_libraries(${PROJECT_NAME}Test ${OPENRTM_LIBRARIES} ${PROJECT_NAME})
+set_property(TARGET ${PROJECT_NAME}Test PROPERTY CXX_STANDARD 11)
+
+add_test(NAME ${PROJECT_NAME}_test COMMAND $<TARGET_FILE:${PROJECT_NAME}Test> -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/test/src/ModuleNameTest.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/test/src/ModuleNameTest.cpp
@@ -1,0 +1,171 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameTest.cpp
+ * @brief ModuleDescription
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include "ModuleNameTest.h"
+
+// Module specification
+// <rtc-template block="module_spec">
+static const char* modulename_spec[] =
+  {
+    "implementation_id", "ModuleNameTest",
+    "type_name",         "ModuleNameTest",
+    "description",       "ModuleDescription",
+    "version",           "1.0.0",
+    "vendor",            "VenderName",
+    "category",          "Category",
+    "activity_type",     "PERIODIC",
+    "kind",              "DataFlowComponent",
+    "max_instance",      "1",
+    "language",          "C++",
+    "lang_type",         "compile",
+    ""
+  };
+// </rtc-template>
+
+/*!
+ * @brief constructor
+ * @param manager Maneger Object
+ */
+ModuleNameTest::ModuleNameTest(RTC::Manager* manager)
+    // <rtc-template block="initializer">
+  : RTC::DataFlowComponentBase(manager)
+
+    // </rtc-template>
+{
+}
+
+/*!
+ * @brief destructor
+ */
+ModuleNameTest::~ModuleNameTest()
+{
+}
+
+
+
+RTC::ReturnCode_t ModuleNameTest::onInitialize()
+{
+  // Registration: InPort/OutPort/Service
+  // <rtc-template block="registration">
+  // Set InPort buffers
+  
+  // Set OutPort buffer
+  
+  // Set service provider to Ports
+  
+  // Set service consumers to Ports
+  
+  // Set CORBA Service Ports
+  
+  // </rtc-template>
+
+  // <rtc-template block="bind_config">
+  // </rtc-template>
+  
+  return RTC::RTC_OK;
+}
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onFinalize()
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onStartup(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onShutdown(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onActivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onDeactivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onExecute(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onAborting(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onError(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onReset(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onStateUpdate(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onRateChanged(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+
+bool ModuleNameTest::runTest()
+{
+    return true;
+}
+
+
+extern "C"
+{
+ 
+  void ModuleNameTestInit(RTC::Manager* manager)
+  {
+    coil::Properties profile(modulename_spec);
+    manager->registerFactory(profile,
+                             RTC::Create<ModuleNameTest>,
+                             RTC::Delete<ModuleNameTest>);
+  }
+  
+};
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/test/src/ModuleNameTestComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/test/src/ModuleNameTestComp.cpp
@@ -1,0 +1,135 @@
+﻿// -*- C++ -*-
+/*!
+ * @file ModuleNameTestComp.cpp
+ * @brief Standalone component
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include <rtm/Manager.h>
+#include <iostream>
+#include <string>
+#include <stdlib.h>
+#include <rtm/CORBA_RTCUtil.h>
+#include "ModuleNameTest.h"
+#include "ModuleName.h"
+
+
+void MyModuleInit(RTC::Manager* manager)
+{
+  ModuleNameTestInit(manager);
+  ModuleNameInit(manager);
+  RTC::RtcBase* comp;
+
+  // Create a component
+  comp = manager->createComponent("ModuleNameTest");
+
+  if (comp==nullptr)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
+
+  // Example
+  // The following procedure is examples how handle RT-Components.
+  // These should not be in this function.
+
+  // Get the component's object reference
+//  RTC::RTObject_var rtobj;
+//  rtobj = RTC::RTObject::_narrow(manager->getPOA()->servant_to_reference(comp));
+
+  // Get the port list of the component
+//  PortServiceList* portlist;
+//  portlist = rtobj->get_ports();
+
+  // getting port profiles
+//  std::cout << "Number of Ports: ";
+//  std::cout << portlist->length() << std::endl << std::endl; 
+//  for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
+//  {
+//    PortService_ptr port;
+//    port = (*portlist)[i];
+//    std::cout << "Port" << i << " (name): ";
+//    std::cout << port->get_port_profile()->name << std::endl;
+//    
+//    RTC::PortInterfaceProfileList iflist;
+//    iflist = port->get_port_profile()->interfaces;
+//    std::cout << "---interfaces---" << std::endl;
+//    for (CORBA::ULong i(0), n(iflist.length()); i < n; ++i)
+//    {
+//      std::cout << "I/F name: ";
+//      std::cout << iflist[i].instance_name << std::endl;
+//      std::cout << "I/F type: ";
+//      std::cout << iflist[i].type_name << std::endl;
+//      const char* pol;
+//      pol = iflist[i].polarity == 0 ? "PROVIDED" : "REQUIRED";
+//      std::cout << "Polarity: " << pol << std::endl;
+//    }
+//    std::cout << "---properties---" << std::endl;
+//    NVUtil::dump(port->get_port_profile()->properties);
+//    std::cout << "----------------" << std::endl << std::endl;
+//  }
+
+  return;
+}
+
+bool RunTest()
+{
+  RTC::RtcBase* comp;
+  RTC::Manager &mamager = RTC::Manager::instance();
+  comp = mamager.getComponent("ModuleNameTest0");
+  if (comp == nullptr)
+  {
+    std::cerr << "Component get failed." << std::endl;
+    return false;
+  }
+
+  ModuleNameTest* testcomp = dynamic_cast<ModuleNameTest*>(comp);
+  if (testcomp == nullptr)
+  {
+    std::cerr << "Component get failed." << std::endl;
+    return false;
+  }
+
+  return testcomp->runTest();
+}
+
+int main (int argc, char** argv)
+{
+  RTC::Manager* manager;
+  manager = RTC::Manager::init(argc, argv);
+
+  // Set module initialization proceduer
+  // This procedure will be invoked in activateManager() function.
+  manager->setModuleInitProc(MyModuleInit);
+
+  // Activate manager and register to naming service
+  manager->activateManager();
+
+  // run the manager in blocking mode
+  // runManager(false) is the default.
+  // manager->runManager();
+
+  // If you want to run the manager in non-blocking mode, do like this
+  manager->runManager(true);
+
+  bool ret = RunTest();
+
+#if RTM_MAJOR_VERSION >= 2
+  manager->terminate();
+  manager->join();
+#else
+  manager->shutdown();
+#endif
+
+  
+  if (ret)
+  {
+    return 0;
+  }
+  else
+  {
+    return 1;
+  }
+}

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/ModuleNameFSM.scxml
@@ -1,0 +1,12 @@
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=212 h=513  -->
+ <state id="InitialState"><!--   node-size-and-position x=55.86 y=43 w=100 h=75  -->
+  <transition id="13" target="State01"></transition>
+ </state>
+ <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->
+  <transition cond="Cond01" event="Event01-02" id="15" target="State02"></transition>
+ </state>
+ <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->
+  <transition cond="Cond02" event="Event02-Final" id="17" target="FinalState"></transition>
+ </state>
+ <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final>
+</scxml>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/README.md
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/README.md
@@ -1,0 +1,278 @@
+﻿# ModuleName
+
+## Overview
+
+ModuleDescription
+
+## Description
+
+
+
+### Input and Output
+
+
+
+### Algorithm etc
+
+
+
+### Basic Information
+
+|  |  |
+----|---- 
+| Module Name | ModuleName |
+| Description | ModuleDescription |
+| Version | 1.0.0 |
+| Vendor | VenderName |
+| Category | Category |
+| Comp. Type | STATIC |
+| Act. Type | PERIODIC |
+| Kind | DataFlowComponent |
+| MAX Inst. | 1 |
+
+### Activity definition
+
+<table>
+  <tr>
+    <td rowspan="4">on_initialize</td>
+    <td colspan="2">implemented</td>
+    <tr>
+      <td>Description</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PreCondition</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PostCondition</td>
+      <td></td>
+    </tr>
+  </tr>
+  <tr>
+    <td>on_finalize</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_startup</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_shutdown</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_activated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_deactivated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_execute</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_aborting</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_error</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_reset</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_state_update</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_rate_changed</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+### EventPorts definition
+
+|  |  |
+----|---- 
+| Port Name | FSMEventPort |
+| FSM Type | StaticFSM |
+
+#### Node list
+
+<table>
+  <tr>
+    <td>State Name</td>
+    <td>Event Name</td>
+    <td>Target State</td>
+  </tr>
+  <tr>
+    <td>InitialState</td>
+    <td colspan="2">Initial State</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State01</td>
+    <td>Event01-02</td>
+    <td>State02</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State02</td>
+    <td>Event02-Final</td>
+    <td>FinalState</td>
+  </tr>
+  <tr>
+    <td>FinalState</td>
+    <td colspan="2">Final State</td>
+  </tr>
+
+</table>
+
+#### Event list
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">InitialState</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### Event01-02
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### Event02-Final
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">FinalState</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+
+
+### InPorts definition
+
+
+### OutPorts definition
+
+
+### Service Port definition
+
+
+### Configuration definition
+
+
+## Demo
+
+## Requirement
+
+## Setup
+
+### Windows
+
+### Ubuntu
+
+## Usage
+
+## Running the tests
+
+## LICENCE
+
+
+
+
+## References
+
+
+
+
+## Author
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/RTC.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<rtc:RtcProfile rtc:version="0.3" rtc:id="RTC:VenderName:Category:ModuleName:1.0.0" xmlns:rtc="http://www.openrtp.org/namespaces/rtc" xmlns:rtcExt="http://www.openrtp.org/namespaces/rtc_ext" xmlns:rtcDoc="http://www.openrtp.org/namespaces/rtc_doc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <rtc:BasicInfo xsi:type="rtcExt:basic_info_ext" rtcExt:saveProject="FSMTest" rtc:updateDate="2019-12-19T22:51:23.000+09:00" rtc:creationDate="2019-12-19T22:49:56.000+09:00" rtc:version="1.0.0" rtc:vendor="VenderName" rtc:maxInstances="1" rtc:executionType="PeriodicExecutionContext" rtc:executionRate="1000.0" rtc:description="ModuleDescription" rtc:category="Category" rtc:componentKind="DataFlowComponent" rtc:activityType="PERIODIC" rtc:componentType="STATIC" rtc:name="ModuleName">
+        <rtcExt:Properties rtcExt:value="true" rtcExt:name="FSM"/>
+        <rtcExt:Properties rtcExt:value="StaticFSM" rtcExt:name="FSMType"/>
+    </rtc:BasicInfo>
+    <rtc:Actions>
+        <rtc:OnInitialize xsi:type="rtcDoc:action_status_doc" rtc:implemented="true"/>
+        <rtc:OnFinalize xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStartup xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnShutdown xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnActivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnDeactivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAborting xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnError xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnReset xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnExecute xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStateUpdate xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnRateChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAction xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+    </rtc:Actions>
+    <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="" rtc:name="Event01-02">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="" rtc:name="Event02-Final">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+    </rtc:DataPorts>
+    <rtc:Language xsi:type="rtcExt:language_ext" rtc:kind="C++"/>
+</rtc:RtcProfile>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/include/ModuleName/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/include/ModuleName/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(hdrs ModuleName.h
+    ModuleNameFSM.h
+    PARENT_SCOPE
+    )

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/include/ModuleName/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/include/ModuleName/ModuleName.h
@@ -1,0 +1,280 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleName.h
+ * @brief ModuleDescription
+ * @date  $Date$
+ *
+ * $Id$
+ */
+
+#ifndef MODULENAME_H
+#define MODULENAME_H
+
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/idl/ExtendedDataTypesSkel.h>
+#include <rtm/idl/InterfaceDataTypesSkel.h>
+
+// Service implementation headers
+// <rtc-template block="service_impl_h">
+
+// </rtc-template>
+
+// Service Consumer stub headers
+// <rtc-template block="consumer_stub_h">
+
+// </rtc-template>
+
+#include <rtm/Manager.h>
+#include <rtm/DataFlowComponentBase.h>
+#include <rtm/CorbaPort.h>
+#include <rtm/DataInPort.h>
+#include <rtm/DataOutPort.h>
+
+// FSM headers
+
+#include <rtm/EventPort.h>
+// <rtc-template block="fsm_h">
+#include "ModuleNameFSM.h"
+// </rtc-template>
+
+
+/*!
+ * @class ModuleName
+ * @brief ModuleDescription
+ *
+ */
+class ModuleName
+  : public RTC::DataFlowComponentBase
+{
+ public:
+  /*!
+   * @brief constructor
+   * @param manager Maneger Object
+   */
+  ModuleName(RTC::Manager* manager);
+
+  /*!
+   * @brief destructor
+   */
+  ~ModuleName() override;
+
+  // <rtc-template block="public_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="public_operation">
+  
+  // </rtc-template>
+
+  // <rtc-template block="activity">
+  /***
+   *
+   * The initialize action (on CREATED->ALIVE transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+   RTC::ReturnCode_t onInitialize() override;
+
+  /***
+   *
+   * The finalize action (on ALIVE->END transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onFinalize() override;
+
+  /***
+   *
+   * The startup action when ExecutionContext startup
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStartup(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The shutdown action when ExecutionContext stop
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onShutdown(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The activated action (Active state entry action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The deactivated action (Active state exit action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The execution action that is invoked periodically
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The aborting action when main logic error occurred.
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onAborting(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The error action in ERROR state
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onError(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The reset action that is invoked resetting
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onReset(RTC::UniqueId ec_id) override;
+  
+  /***
+   *
+   * The state update action that is invoked after onExecute() action
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStateUpdate(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The action that is invoked when execution context's rate is changed
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id) override;
+  // </rtc-template>
+
+
+ protected:
+  // <rtc-template block="protected_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="protected_operation">
+  
+  // </rtc-template>
+
+  // Configuration variable declaration
+  // <rtc-template block="config_declare">
+
+  // </rtc-template>
+
+  // DataInPort declaration
+  // <rtc-template block="inport_declare">
+  
+  // </rtc-template>
+
+
+  // DataOutPort declaration
+  // <rtc-template block="outport_declare">
+  
+  // </rtc-template>
+
+  // CORBA Port declaration
+  // <rtc-template block="corbaport_declare">
+  
+  // </rtc-template>
+
+  // Service declaration
+  // <rtc-template block="service_declare">
+  
+  // </rtc-template>
+
+  // Consumer declaration
+  // <rtc-template block="consumer_declare">
+  
+  // </rtc-template>
+
+  // State machine declaration
+  // <rtc-template block="fsm_declare">
+  RTC::Machine<ModuleNameFsm::Top> m_fsm;
+  // </rtc-template>
+  
+  // EventPort declaration
+  // <rtc-template block="event_declare">
+  
+  RTC::EventInPort< RTC::Machine<ModuleNameFsm::Top> > m_FSMEventVarIn;
+  // </rtc-template>
+
+ private:
+  // <rtc-template block="private_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="private_operation">
+  
+  // </rtc-template>
+
+};
+
+
+extern "C"
+{
+  DLL_EXPORT void ModuleNameInit(RTC::Manager* manager);
+};
+
+#endif // MODULENAME_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/include/ModuleName/ModuleNameFSM.h
@@ -1,0 +1,75 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameFSM.h
+ * @date  $Date$
+ * $Id$
+ */
+
+#ifndef MODULENAMEFSM_H
+#define MODULENAMEFSM_H
+
+#include <rtm/StaticFSM.h>
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/RTC.h>
+
+class ModuleName;
+
+namespace ModuleNameFsm {
+
+  /*!
+   * @if jp
+   * @class TOP状態
+   *
+   *
+   * @else
+   * @brief TOP state
+   *
+   * @endif
+   */
+  FSM_TOPSTATE(Top) {
+    // Top state variables (visible to all substates)
+  
+    FSM_STATE(Top);
+
+    // Machine's event protocol
+    /*!
+     */
+    virtual void Event01-02() {}
+    
+    /*!
+     */
+    virtual void Event02-Final() {}
+    
+  
+   private:
+     RTC::ReturnCode_t onInit() override;
+     RTC::ReturnCode_t onEntry() override;
+     RTC::ReturnCode_t onExit() override;
+  };
+
+  FSM_SUBSTATE(State01, Top) {
+    FSM_STATE(State01);
+  
+
+    // Event handler
+    void Event01-02() override;
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+  };
+
+  FSM_SUBSTATE(State02, Top) {
+    FSM_STATE(State02);
+  
+
+    // Event handler
+    void Event02-Final() override;
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+  };
+
+
+} //end namespace 'ModuleNameFSM'
+
+#endif // MODULENAMEFSM_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/src/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/src/CMakeLists.txt
@@ -1,0 +1,64 @@
+set(comp_srcs ModuleName.cpp ModuleNameFSM.cpp)
+set(standalone_srcs ModuleNameComp.cpp)
+
+if(${OPENRTM_VERSION_MAJOR} LESS 2)
+  set(OPENRTM_CFLAGS ${OPENRTM_CFLAGS} ${OMNIORB_CFLAGS})
+  set(OPENRTM_INCLUDE_DIRS ${OPENRTM_INCLUDE_DIRS} ${OMNIORB_INCLUDE_DIRS})
+  set(OPENRTM_LIBRARY_DIRS ${OPENRTM_LIBRARY_DIRS} ${OMNIORB_LIBRARY_DIRS})
+endif()
+
+if (DEFINED OPENRTM_INCLUDE_DIRS)
+  string(REGEX REPLACE "-I" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+endif (DEFINED OPENRTM_INCLUDE_DIRS)
+
+if (DEFINED OPENRTM_LIBRARY_DIRS)
+  string(REGEX REPLACE "-L" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+endif (DEFINED OPENRTM_LIBRARY_DIRS)
+
+if (DEFINED OPENRTM_LIBRARIES)
+  string(REGEX REPLACE "-l" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+endif (DEFINED OPENRTM_LIBRARIES)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME})
+include_directories(${PROJECT_BINARY_DIR})
+include_directories(${PROJECT_BINARY_DIR}/idl)
+include_directories(${OPENRTM_INCLUDE_DIRS})
+add_definitions(${OPENRTM_CFLAGS})
+
+MAP_ADD_STR(comp_hdrs "../" comp_headers)
+
+link_directories(${OPENRTM_LIBRARY_DIRS})
+
+add_library(${PROJECT_NAME} ${LIB_TYPE} ${comp_srcs}
+  ${comp_headers} ${ALL_IDL_SRCS})
+set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
+set_source_files_properties(${ALL_IDL_SRCS} PROPERTIES GENERATED 1)
+if(NOT TARGET ALL_IDL_TGT)
+ add_custom_target(ALL_IDL_TGT)
+endif(NOT TARGET ALL_IDL_TGT)
+add_dependencies(${PROJECT_NAME} ALL_IDL_TGT)
+target_link_libraries(${PROJECT_NAME} ${OPENRTM_LIBRARIES})
+
+add_executable(${PROJECT_NAME}Comp ${standalone_srcs}
+  ${comp_srcs} ${comp_headers} ${ALL_IDL_SRCS})
+add_dependencies(${PROJECT_NAME}Comp ALL_IDL_TGT)
+target_link_libraries(${PROJECT_NAME}Comp ${OPENRTM_LIBRARIES})
+
+install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}Comp
+    EXPORT ${PROJECT_NAME}
+    RUNTIME DESTINATION ${INSTALL_PREFIX} COMPONENT component
+    LIBRARY DESTINATION ${INSTALL_PREFIX} COMPONENT component
+    ARCHIVE DESTINATION ${INSTALL_PREFIX} COMPONENT component)
+
+install(FILES ${PROJECT_SOURCE_DIR}/RTC.xml DESTINATION ${INSTALL_PREFIX}
+        COMPONENT component)

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/src/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/src/ModuleName.cpp
@@ -1,0 +1,180 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleName.cpp
+ * @brief ModuleDescription
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include "ModuleName.h"
+
+// Module specification
+// <rtc-template block="module_spec">
+static const char* modulename_spec[] =
+  {
+    "implementation_id", "ModuleName",
+    "type_name",         "ModuleName",
+    "description",       "ModuleDescription",
+    "version",           "1.0.0",
+    "vendor",            "VenderName",
+    "category",          "Category",
+    "activity_type",     "PERIODIC",
+    "kind",              "DataFlowComponent",
+    "max_instance",      "1",
+    "language",          "C++",
+    "lang_type",         "compile",
+    ""
+  };
+// </rtc-template>
+
+/*!
+ * @brief constructor
+ * @param manager Maneger Object
+ */
+ModuleName::ModuleName(RTC::Manager* manager)
+    // <rtc-template block="initializer">
+  : RTC::DataFlowComponentBase(manager),
+    m_fsm(this),
+    m_FSMEventIn("event", m_fsm)
+
+    // </rtc-template>
+{
+}
+
+/*!
+ * @brief destructor
+ */
+ModuleName::~ModuleName()
+{
+}
+
+
+
+RTC::ReturnCode_t ModuleName::onInitialize()
+{
+#ifdef ORB_IS_TAO
+  ::CORBA_Util::toRepositoryIdOfStruct<TimedLong>();
+#endif
+  // Registration: InPort/OutPort/Service
+  // <rtc-template block="registration">
+  // Set InPort buffers
+  
+  // Set OutPort buffer
+
+  // Set EventPort buffer
+  addInPort("event", m_FSMEventVarIn);
+  
+  // Set service provider to Ports
+  
+  // Set service consumers to Ports
+  
+  // Set CORBA Service Ports
+  
+  // </rtc-template>
+
+  // <rtc-template block="bind_config">
+  // </rtc-template>
+  // <rtc-template block="bind_event">
+  m_FSMEventVarIn.bindEvent("Event01-02", &ModuleNameFsm::Top::Event01-02);
+  m_FSMEventVarIn.bindEvent("Event02-Final", &ModuleNameFsm::Top::Event02-Final);
+  // </rtc-template>
+
+  
+  return RTC::RTC_OK;
+}
+
+/*
+RTC::ReturnCode_t ModuleName::onFinalize()
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onStartup(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onShutdown(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onActivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onDeactivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onExecute(RTC::UniqueId ec_id)
+{
+  m_fsm.run_event();
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onAborting(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onError(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onReset(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onStateUpdate(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onRateChanged(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+
+
+extern "C"
+{
+ 
+  void ModuleNameInit(RTC::Manager* manager)
+  {
+    coil::Properties profile(modulename_spec);
+    manager->registerFactory(profile,
+                             RTC::Create<ModuleName>,
+                             RTC::Delete<ModuleName>);
+  }
+  
+};
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/src/ModuleNameComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/src/ModuleNameComp.cpp
@@ -1,0 +1,129 @@
+﻿// -*- C++ -*-
+/*!
+ * @file ModuleNameComp.cpp
+ * @brief Standalone component
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include <rtm/Manager.h>
+#include <iostream>
+#include <string>
+#include <stdlib.h>
+#include "ModuleName.h"
+
+class OverwriteInstanceName
+  : public RTM::RtcLifecycleActionListener
+{
+public:
+  OverwriteInstanceName(int argc, char** argv)
+    : m_name(""), m_count(0)
+  {
+    for (size_t i = 0; i < argc; ++i)
+      {
+        std::string opt = argv[i];
+        if (opt.find("--instance_name=") == std::string::npos) { continue; }
+
+        coil::replaceString(opt, "--instance_name=", "");
+        if (opt.empty()) { continue; }
+
+        m_name = opt;
+      }
+  }
+  virtual ~OverwriteInstanceName() {}
+  virtual void preCreate(std::string& args)
+  {
+    if (m_count != 0 || m_name.empty()) { return; }
+    args = args + "?instance_name=" + m_name;
+    ++m_count;
+  };
+  virtual void postCreate(RTC::RTObject_impl*) {};
+  virtual void preConfigure(coil::Properties&) {};
+  virtual void postConfigure(coil::Properties&) {};
+  virtual void preInitialize() {};
+  virtual void postInitialize() {};
+private:
+  std::string m_name;
+  int32_t m_count;
+};
+
+void MyModuleInit(RTC::Manager* manager)
+{
+  ModuleNameInit(manager);
+  RTC::RtcBase* comp;
+
+  // Create a component
+  comp = manager->createComponent("ModuleName");
+
+  if (comp==NULL)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
+
+  // Example
+  // The following procedure is examples how handle RT-Components.
+  // These should not be in this function.
+
+  // Get the component's object reference
+//  RTC::RTObject_var rtobj;
+//  rtobj = RTC::RTObject::_narrow(manager->getPOA()->servant_to_reference(comp));
+
+  // Get the port list of the component
+//  PortServiceList* portlist;
+//  portlist = rtobj->get_ports();
+
+  // getting port profiles
+//  std::cout << "Number of Ports: ";
+//  std::cout << portlist->length() << std::endl << std::endl; 
+//  for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
+//  {
+//    PortService_ptr port;
+//    port = (*portlist)[i];
+//    std::cout << "Port" << i << " (name): ";
+//    std::cout << port->get_port_profile()->name << std::endl;
+//    
+//    RTC::PortInterfaceProfileList iflist;
+//    iflist = port->get_port_profile()->interfaces;
+//    std::cout << "---interfaces---" << std::endl;
+//    for (CORBA::ULong i(0), n(iflist.length()); i < n; ++i)
+//    {
+//      std::cout << "I/F name: ";
+//      std::cout << iflist[i].instance_name << std::endl;
+//      std::cout << "I/F type: ";
+//      std::cout << iflist[i].type_name << std::endl;
+//      const char* pol;
+//      pol = iflist[i].polarity == 0 ? "PROVIDED" : "REQUIRED";
+//      std::cout << "Polarity: " << pol << std::endl;
+//    }
+//    std::cout << "---properties---" << std::endl;
+//    NVUtil::dump(port->get_port_profile()->properties);
+//    std::cout << "----------------" << std::endl << std::endl;
+//  }
+
+  return;
+}
+
+int main (int argc, char** argv)
+{
+  RTC::Manager* manager;
+  manager = RTC::Manager::init(argc, argv);
+  manager->addRtcLifecycleActionListener(new OverwriteInstanceName(argc, argv), true);
+
+  // Set module initialization proceduer
+  // This procedure will be invoked in activateManager() function.
+  manager->setModuleInitProc(MyModuleInit);
+
+  // Activate manager and register to naming service
+  manager->activateManager();
+
+  // run the manager in blocking mode
+  // runManager(false) is the default.
+  manager->runManager();
+
+  // If you want to run the manager in non-blocking mode, do like this
+  // manager->runManager(true);
+
+  return 0;
+}

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/src/ModuleNameFSM.cpp
@@ -1,0 +1,50 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameFSM.cpp
+ * @date $Date$
+ * $Id$
+ */
+
+#include "ModuleNameFSM.h"
+
+namespace ModuleNameFsm {
+
+// Top state
+RTC::ReturnCode_t Top::onInit() {
+  setState<State01>();
+  return RTC::RTC_OK;
+}
+
+RTC::ReturnCode_t Top::onEntry() {
+  return RTC::RTC_OK;
+}
+
+RTC::ReturnCode_t Top::onExit() {
+  return RTC::RTC_OK;
+}
+
+//============================================================
+// State State01
+// RTC::ReturnCode_t State01::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+
+void State01::Event01-02() {
+  setState<State02>();
+}
+
+
+//============================================================
+// State State02
+// RTC::ReturnCode_t State02::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+
+void State02::Event02-Final() {
+  setState<FinalState>();
+}
+
+
+} //end namespace 'ModuleNameFSM'

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/test/include/ModuleNameTest/ModuleNameTest.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/test/include/ModuleNameTest/ModuleNameTest.h
@@ -1,0 +1,268 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameTest.h
+ * @brief ModuleDescription
+ * @date  $Date$
+ *
+ * $Id$
+ */
+
+#ifndef MODULENAME_TEST__H
+#define MODULENAME_TEST_H
+
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/idl/ExtendedDataTypesSkel.h>
+#include <rtm/idl/InterfaceDataTypesSkel.h>
+
+// Service implementation headers
+// <rtc-template block="service_impl_h">
+
+// </rtc-template>
+
+// Service Consumer stub headers
+// <rtc-template block="consumer_stub_h">
+
+// </rtc-template>
+
+#include <rtm/Manager.h>
+#include <rtm/DataFlowComponentBase.h>
+#include <rtm/CorbaPort.h>
+#include <rtm/DataInPort.h>
+#include <rtm/DataOutPort.h>
+
+/*!
+ * @class ModuleNameTest
+ * @brief ModuleDescription
+ *
+ */
+class ModuleNameTest
+  : public RTC::DataFlowComponentBase
+{
+ public:
+  /*!
+   * @brief constructor
+   * @param manager Maneger Object
+   */
+  ModuleNameTest(RTC::Manager* manager);
+
+  /*!
+   * @brief destructor
+   */
+  ~ModuleNameTest() override;
+
+  // <rtc-template block="public_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="public_operation">
+  
+  // </rtc-template>
+
+  // <rtc-template block="activity">
+  /***
+   *
+   * The initialize action (on CREATED->ALIVE transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+   RTC::ReturnCode_t onInitialize() override;
+
+  /***
+   *
+   * The finalize action (on ALIVE->END transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onFinalize() override;
+
+  /***
+   *
+   * The startup action when ExecutionContext startup
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStartup(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The shutdown action when ExecutionContext stop
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onShutdown(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The activated action (Active state entry action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The deactivated action (Active state exit action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The execution action that is invoked periodically
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The aborting action when main logic error occurred.
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onAborting(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The error action in ERROR state
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onError(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The reset action that is invoked resetting
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onReset(RTC::UniqueId ec_id) override;
+  
+  /***
+   *
+   * The state update action that is invoked after onExecute() action
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStateUpdate(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The action that is invoked when execution context's rate is changed
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id) override;
+  // </rtc-template>
+
+  bool runTest();
+
+ protected:
+  // <rtc-template block="protected_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="protected_operation">
+  
+  // </rtc-template>
+
+  // Configuration variable declaration
+  // <rtc-template block="config_declare">
+
+  // </rtc-template>
+
+  // DataInPort declaration
+  // <rtc-template block="inport_declare">
+  
+  // </rtc-template>
+
+
+  // DataOutPort declaration
+  // <rtc-template block="outport_declare">
+    RTC::TimedLong m_Event01-02;
+    RTC::OutPort<RTC::TimedLong> m_Event01-02Out;
+    
+    RTC::TimedLong m_Event02-Final;
+    RTC::OutPort<RTC::TimedLong> m_Event02-FinalOut;
+    
+  
+  // </rtc-template>
+
+  // CORBA Port declaration
+  // <rtc-template block="corbaport_declare">
+  
+  // </rtc-template>
+
+  // Service declaration
+  // <rtc-template block="service_declare">
+  
+  // </rtc-template>
+
+  // Consumer declaration
+  // <rtc-template block="consumer_declare">
+  
+  // </rtc-template>
+
+ private:
+  // <rtc-template block="private_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="private_operation">
+  
+  // </rtc-template>
+
+};
+
+
+extern "C"
+{
+  DLL_EXPORT void ModuleNameTestInit(RTC::Manager* manager);
+};
+
+#endif // MODULENAME_TEST_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/test/src/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/test/src/CMakeLists.txt
@@ -1,0 +1,57 @@
+set(comp_srcs
+   ModuleNameTest.cpp
+   )
+set(standalone_srcs ModuleNameTestComp.cpp)
+
+if(${OPENRTM_VERSION_MAJOR} LESS 2)
+  set(OPENRTM_CFLAGS ${OPENRTM_CFLAGS} ${OMNIORB_CFLAGS})
+  set(OPENRTM_INCLUDE_DIRS ${OPENRTM_INCLUDE_DIRS} ${OMNIORB_INCLUDE_DIRS})
+  set(OPENRTM_LIBRARY_DIRS ${OPENRTM_LIBRARY_DIRS} ${OMNIORB_LIBRARY_DIRS})
+endif()
+
+if (DEFINED OPENRTM_INCLUDE_DIRS)
+  string(REGEX REPLACE "-I" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+endif (DEFINED OPENRTM_INCLUDE_DIRS)
+
+if (DEFINED OPENRTM_LIBRARY_DIRS)
+  string(REGEX REPLACE "-L" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+endif (DEFINED OPENRTM_LIBRARY_DIRS)
+
+if (DEFINED OPENRTM_LIBRARIES)
+  string(REGEX REPLACE "-l" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+endif (DEFINED OPENRTM_LIBRARIES)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME})
+include_directories(${PROJECT_SOURCE_DIR}/test/include)
+include_directories(${PROJECT_SOURCE_DIR}/test/include/${PROJECT_NAME}Test)
+include_directories(${PROJECT_BINARY_DIR})
+include_directories(${PROJECT_BINARY_DIR}/idl)
+include_directories(${OPENRTM_INCLUDE_DIRS})
+add_definitions(${OPENRTM_CFLAGS})
+
+MAP_ADD_STR(comp_test_hdrs "../" comp_headers)
+
+link_directories(${OPENRTM_LIBRARY_DIRS})
+
+if(NOT TARGET ALL_IDL_TGT)
+ add_custom_target(ALL_IDL_TGT)
+endif(NOT TARGET ALL_IDL_TGT)
+
+add_executable(${PROJECT_NAME}Test ${standalone_srcs}
+  ${comp_srcs} ${comp_headers} ${ALL_IDL_SRCS})
+set_source_files_properties(${ALL_IDL_SRCS} PROPERTIES GENERATED 1)
+add_dependencies(${PROJECT_NAME}Test ${PROJECT_NAME})
+target_link_libraries(${PROJECT_NAME}Test ${OPENRTM_LIBRARIES} ${PROJECT_NAME})
+set_property(TARGET ${PROJECT_NAME}Test PROPERTY CXX_STANDARD 11)
+
+add_test(NAME ${PROJECT_NAME}_test COMMAND $<TARGET_FILE:${PROJECT_NAME}Test> -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event01-02&fsm_event_name=Event01-02,${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event02-Final&fsm_event_name=Event02-Final,${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event01-02&fsm_event_name=Event01-02,${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event02-Final&fsm_event_name=Event02-Final" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/test/src/ModuleNameTest.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/test/src/ModuleNameTest.cpp
@@ -1,0 +1,175 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameTest.cpp
+ * @brief ModuleDescription
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include "ModuleNameTest.h"
+
+// Module specification
+// <rtc-template block="module_spec">
+static const char* modulename_spec[] =
+  {
+    "implementation_id", "ModuleNameTest",
+    "type_name",         "ModuleNameTest",
+    "description",       "ModuleDescription",
+    "version",           "1.0.0",
+    "vendor",            "VenderName",
+    "category",          "Category",
+    "activity_type",     "PERIODIC",
+    "kind",              "DataFlowComponent",
+    "max_instance",      "1",
+    "language",          "C++",
+    "lang_type",         "compile",
+    ""
+  };
+// </rtc-template>
+
+/*!
+ * @brief constructor
+ * @param manager Maneger Object
+ */
+ModuleNameTest::ModuleNameTest(RTC::Manager* manager)
+    // <rtc-template block="initializer">
+  : RTC::DataFlowComponentBase(manager)
+,
+    m_Event01-02Out("Event01-02", m_Event01-02),
+    m_Event02-FinalOut("Event02-Final", m_Event02-Final)
+    // </rtc-template>
+{
+}
+
+/*!
+ * @brief destructor
+ */
+ModuleNameTest::~ModuleNameTest()
+{
+}
+
+
+
+RTC::ReturnCode_t ModuleNameTest::onInitialize()
+{
+  // Registration: InPort/OutPort/Service
+  // <rtc-template block="registration">
+  // Set InPort buffers
+  
+  // Set OutPort buffer
+  addOutPort("Event01-02", m_Event01-02Out);
+  addOutPort("Event02-Final", m_Event02-FinalOut);
+  
+  // Set service provider to Ports
+  
+  // Set service consumers to Ports
+  
+  // Set CORBA Service Ports
+  
+  // </rtc-template>
+
+  // <rtc-template block="bind_config">
+  // </rtc-template>
+  
+  return RTC::RTC_OK;
+}
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onFinalize()
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onStartup(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onShutdown(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onActivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onDeactivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onExecute(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onAborting(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onError(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onReset(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onStateUpdate(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onRateChanged(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+
+bool ModuleNameTest::runTest()
+{
+    return true;
+}
+
+
+extern "C"
+{
+ 
+  void ModuleNameTestInit(RTC::Manager* manager)
+  {
+    coil::Properties profile(modulename_spec);
+    manager->registerFactory(profile,
+                             RTC::Create<ModuleNameTest>,
+                             RTC::Delete<ModuleNameTest>);
+  }
+  
+};
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/test/src/ModuleNameTestComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/test/src/ModuleNameTestComp.cpp
@@ -1,0 +1,135 @@
+﻿// -*- C++ -*-
+/*!
+ * @file ModuleNameTestComp.cpp
+ * @brief Standalone component
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include <rtm/Manager.h>
+#include <iostream>
+#include <string>
+#include <stdlib.h>
+#include <rtm/CORBA_RTCUtil.h>
+#include "ModuleNameTest.h"
+#include "ModuleName.h"
+
+
+void MyModuleInit(RTC::Manager* manager)
+{
+  ModuleNameTestInit(manager);
+  ModuleNameInit(manager);
+  RTC::RtcBase* comp;
+
+  // Create a component
+  comp = manager->createComponent("ModuleNameTest");
+
+  if (comp==nullptr)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
+
+  // Example
+  // The following procedure is examples how handle RT-Components.
+  // These should not be in this function.
+
+  // Get the component's object reference
+//  RTC::RTObject_var rtobj;
+//  rtobj = RTC::RTObject::_narrow(manager->getPOA()->servant_to_reference(comp));
+
+  // Get the port list of the component
+//  PortServiceList* portlist;
+//  portlist = rtobj->get_ports();
+
+  // getting port profiles
+//  std::cout << "Number of Ports: ";
+//  std::cout << portlist->length() << std::endl << std::endl; 
+//  for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
+//  {
+//    PortService_ptr port;
+//    port = (*portlist)[i];
+//    std::cout << "Port" << i << " (name): ";
+//    std::cout << port->get_port_profile()->name << std::endl;
+//    
+//    RTC::PortInterfaceProfileList iflist;
+//    iflist = port->get_port_profile()->interfaces;
+//    std::cout << "---interfaces---" << std::endl;
+//    for (CORBA::ULong i(0), n(iflist.length()); i < n; ++i)
+//    {
+//      std::cout << "I/F name: ";
+//      std::cout << iflist[i].instance_name << std::endl;
+//      std::cout << "I/F type: ";
+//      std::cout << iflist[i].type_name << std::endl;
+//      const char* pol;
+//      pol = iflist[i].polarity == 0 ? "PROVIDED" : "REQUIRED";
+//      std::cout << "Polarity: " << pol << std::endl;
+//    }
+//    std::cout << "---properties---" << std::endl;
+//    NVUtil::dump(port->get_port_profile()->properties);
+//    std::cout << "----------------" << std::endl << std::endl;
+//  }
+
+  return;
+}
+
+bool RunTest()
+{
+  RTC::RtcBase* comp;
+  RTC::Manager &mamager = RTC::Manager::instance();
+  comp = mamager.getComponent("ModuleNameTest0");
+  if (comp == nullptr)
+  {
+    std::cerr << "Component get failed." << std::endl;
+    return false;
+  }
+
+  ModuleNameTest* testcomp = dynamic_cast<ModuleNameTest*>(comp);
+  if (testcomp == nullptr)
+  {
+    std::cerr << "Component get failed." << std::endl;
+    return false;
+  }
+
+  return testcomp->runTest();
+}
+
+int main (int argc, char** argv)
+{
+  RTC::Manager* manager;
+  manager = RTC::Manager::init(argc, argv);
+
+  // Set module initialization proceduer
+  // This procedure will be invoked in activateManager() function.
+  manager->setModuleInitProc(MyModuleInit);
+
+  // Activate manager and register to naming service
+  manager->activateManager();
+
+  // run the manager in blocking mode
+  // runManager(false) is the default.
+  // manager->runManager();
+
+  // If you want to run the manager in non-blocking mode, do like this
+  manager->runManager(true);
+
+  bool ret = RunTest();
+
+#if RTM_MAJOR_VERSION >= 2
+  manager->terminate();
+  manager->join();
+#else
+  manager->shutdown();
+#endif
+
+  
+  if (ret)
+  {
+    return 0;
+  }
+  else
+  {
+    return 1;
+  }
+}

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/ModuleNameFSM.scxml
@@ -1,0 +1,12 @@
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=212 h=513  -->
+ <state id="InitialState"><!--   node-size-and-position x=55.86 y=43 w=100 h=75  -->
+  <transition id="13" target="State01"></transition>
+ </state>
+ <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->
+  <transition cond="Cond01" event="Event01-02" id="15" target="State02"></transition>
+ </state>
+ <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->
+  <transition cond="Cond02" event="Event02-Final" id="17" target="FinalState"></transition>
+ </state>
+ <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final>
+</scxml>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/README.md
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/README.md
@@ -1,0 +1,278 @@
+﻿# ModuleName
+
+## Overview
+
+ModuleDescription
+
+## Description
+
+
+
+### Input and Output
+
+
+
+### Algorithm etc
+
+
+
+### Basic Information
+
+|  |  |
+----|---- 
+| Module Name | ModuleName |
+| Description | ModuleDescription |
+| Version | 1.0.0 |
+| Vendor | VenderName |
+| Category | Category |
+| Comp. Type | STATIC |
+| Act. Type | PERIODIC |
+| Kind | DataFlowComponent |
+| MAX Inst. | 1 |
+
+### Activity definition
+
+<table>
+  <tr>
+    <td rowspan="4">on_initialize</td>
+    <td colspan="2">implemented</td>
+    <tr>
+      <td>Description</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PreCondition</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PostCondition</td>
+      <td></td>
+    </tr>
+  </tr>
+  <tr>
+    <td>on_finalize</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_startup</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_shutdown</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_activated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_deactivated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_execute</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_aborting</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_error</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_reset</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_state_update</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_rate_changed</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+### EventPorts definition
+
+|  |  |
+----|---- 
+| Port Name | FSMEventPort |
+| FSM Type | StaticFSM |
+
+#### Node list
+
+<table>
+  <tr>
+    <td>State Name</td>
+    <td>Event Name</td>
+    <td>Target State</td>
+  </tr>
+  <tr>
+    <td>InitialState</td>
+    <td colspan="2">Initial State</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State01</td>
+    <td>Event01-02</td>
+    <td>State02</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State02</td>
+    <td>Event02-Final</td>
+    <td>FinalState</td>
+  </tr>
+  <tr>
+    <td>FinalState</td>
+    <td colspan="2">Final State</td>
+  </tr>
+
+</table>
+
+#### Event list
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">InitialState</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### Event01-02
+
+Abst01-02
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td>RTC::TimedLong</td>
+    <td>Type01-02</td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2">Num01-02</td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2">Unit01-02</td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2">Period01-02</td>
+  </tr>
+</table>
+
+Detail01-02
+
+##### Event02-Final
+
+Abst02-Final
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">FinalState</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td>RTC::TimedString</td>
+    <td>Type02-Final</td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2">Num02-Final</td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2">Unit02-Final</td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2">Period02-Final</td>
+  </tr>
+</table>
+
+Detail02-Final
+
+
+
+### InPorts definition
+
+
+### OutPorts definition
+
+
+### Service Port definition
+
+
+### Configuration definition
+
+
+## Demo
+
+## Requirement
+
+## Setup
+
+### Windows
+
+### Ubuntu
+
+## Usage
+
+## Running the tests
+
+## LICENCE
+
+
+
+
+## References
+
+
+
+
+## Author
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/RTC.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<rtc:RtcProfile rtc:version="0.3" rtc:id="RTC:VenderName:Category:ModuleName:1.0.0" xmlns:rtc="http://www.openrtp.org/namespaces/rtc" xmlns:rtcExt="http://www.openrtp.org/namespaces/rtc_ext" xmlns:rtcDoc="http://www.openrtp.org/namespaces/rtc_doc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <rtc:BasicInfo xsi:type="rtcExt:basic_info_ext" rtcExt:saveProject="FSMTest" rtc:updateDate="2019-12-20T00:07:52.000+09:00" rtc:creationDate="2019-12-19T22:49:56.000+09:00" rtc:version="1.0.0" rtc:vendor="VenderName" rtc:maxInstances="1" rtc:executionType="PeriodicExecutionContext" rtc:executionRate="1000.0" rtc:description="ModuleDescription" rtc:category="Category" rtc:componentKind="DataFlowComponent" rtc:activityType="PERIODIC" rtc:componentType="STATIC" rtc:name="ModuleName">
+        <rtcExt:Properties rtcExt:value="true" rtcExt:name="FSM"/>
+        <rtcExt:Properties rtcExt:value="StaticFSM" rtcExt:name="FSMType"/>
+    </rtc:BasicInfo>
+    <rtc:Actions>
+        <rtc:OnInitialize xsi:type="rtcDoc:action_status_doc" rtc:implemented="true"/>
+        <rtc:OnFinalize xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStartup xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnShutdown xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnActivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnDeactivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAborting xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnError xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnReset xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnExecute xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStateUpdate xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnRateChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAction xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+    </rtc:Actions>
+    <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedLong" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01-02">
+            <rtcDoc:Doc rtcDoc:operation="Period01-02" rtcDoc:unit="Unit01-02" rtcDoc:semantics="Detail01-02" rtcDoc:number="Num01-02" rtcDoc:type="Type01-02" rtcDoc:description="Abst01-02"/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedString" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02-Final">
+            <rtcDoc:Doc rtcDoc:operation="Period02-Final" rtcDoc:unit="Unit02-Final" rtcDoc:semantics="Detail02-Final" rtcDoc:number="Num02-Final" rtcDoc:type="Type02-Final" rtcDoc:description="Abst02-Final"/>
+        </rtc:Event>
+    </rtc:DataPorts>
+    <rtc:Language xsi:type="rtcExt:language_ext" rtc:kind="C++"/>
+</rtc:RtcProfile>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/include/ModuleName/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/include/ModuleName/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(hdrs ModuleName.h
+    ModuleNameFSM.h
+    PARENT_SCOPE
+    )

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/include/ModuleName/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/include/ModuleName/ModuleName.h
@@ -1,0 +1,280 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleName.h
+ * @brief ModuleDescription
+ * @date  $Date$
+ *
+ * $Id$
+ */
+
+#ifndef MODULENAME_H
+#define MODULENAME_H
+
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/idl/ExtendedDataTypesSkel.h>
+#include <rtm/idl/InterfaceDataTypesSkel.h>
+
+// Service implementation headers
+// <rtc-template block="service_impl_h">
+
+// </rtc-template>
+
+// Service Consumer stub headers
+// <rtc-template block="consumer_stub_h">
+
+// </rtc-template>
+
+#include <rtm/Manager.h>
+#include <rtm/DataFlowComponentBase.h>
+#include <rtm/CorbaPort.h>
+#include <rtm/DataInPort.h>
+#include <rtm/DataOutPort.h>
+
+// FSM headers
+
+#include <rtm/EventPort.h>
+// <rtc-template block="fsm_h">
+#include "ModuleNameFSM.h"
+// </rtc-template>
+
+
+/*!
+ * @class ModuleName
+ * @brief ModuleDescription
+ *
+ */
+class ModuleName
+  : public RTC::DataFlowComponentBase
+{
+ public:
+  /*!
+   * @brief constructor
+   * @param manager Maneger Object
+   */
+  ModuleName(RTC::Manager* manager);
+
+  /*!
+   * @brief destructor
+   */
+  ~ModuleName() override;
+
+  // <rtc-template block="public_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="public_operation">
+  
+  // </rtc-template>
+
+  // <rtc-template block="activity">
+  /***
+   *
+   * The initialize action (on CREATED->ALIVE transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+   RTC::ReturnCode_t onInitialize() override;
+
+  /***
+   *
+   * The finalize action (on ALIVE->END transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onFinalize() override;
+
+  /***
+   *
+   * The startup action when ExecutionContext startup
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStartup(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The shutdown action when ExecutionContext stop
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onShutdown(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The activated action (Active state entry action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The deactivated action (Active state exit action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The execution action that is invoked periodically
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The aborting action when main logic error occurred.
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onAborting(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The error action in ERROR state
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onError(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The reset action that is invoked resetting
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onReset(RTC::UniqueId ec_id) override;
+  
+  /***
+   *
+   * The state update action that is invoked after onExecute() action
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStateUpdate(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The action that is invoked when execution context's rate is changed
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id) override;
+  // </rtc-template>
+
+
+ protected:
+  // <rtc-template block="protected_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="protected_operation">
+  
+  // </rtc-template>
+
+  // Configuration variable declaration
+  // <rtc-template block="config_declare">
+
+  // </rtc-template>
+
+  // DataInPort declaration
+  // <rtc-template block="inport_declare">
+  
+  // </rtc-template>
+
+
+  // DataOutPort declaration
+  // <rtc-template block="outport_declare">
+  
+  // </rtc-template>
+
+  // CORBA Port declaration
+  // <rtc-template block="corbaport_declare">
+  
+  // </rtc-template>
+
+  // Service declaration
+  // <rtc-template block="service_declare">
+  
+  // </rtc-template>
+
+  // Consumer declaration
+  // <rtc-template block="consumer_declare">
+  
+  // </rtc-template>
+
+  // State machine declaration
+  // <rtc-template block="fsm_declare">
+  RTC::Machine<ModuleNameFsm::Top> m_fsm;
+  // </rtc-template>
+  
+  // EventPort declaration
+  // <rtc-template block="event_declare">
+  
+  RTC::EventInPort< RTC::Machine<ModuleNameFsm::Top> > m_FSMEventVarIn;
+  // </rtc-template>
+
+ private:
+  // <rtc-template block="private_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="private_operation">
+  
+  // </rtc-template>
+
+};
+
+
+extern "C"
+{
+  DLL_EXPORT void ModuleNameInit(RTC::Manager* manager);
+};
+
+#endif // MODULENAME_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/include/ModuleName/ModuleNameFSM.h
@@ -1,0 +1,87 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameFSM.h
+ * @date  $Date$
+ * $Id$
+ */
+
+#ifndef MODULENAMEFSM_H
+#define MODULENAMEFSM_H
+
+#include <rtm/StaticFSM.h>
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/RTC.h>
+
+class ModuleName;
+
+namespace ModuleNameFsm {
+
+  /*!
+   * @if jp
+   * @class TOP状態
+   *
+   *
+   * @else
+   * @brief TOP state
+   *
+   * @endif
+   */
+  FSM_TOPSTATE(Top) {
+    // Top state variables (visible to all substates)
+  
+    FSM_STATE(Top);
+
+    // Machine's event protocol
+    /*!
+     * Abst01-02
+     * - Type: Type01-02
+     * - Number: Num01-02
+     * - Semantics: Detail01-02
+     * - Unit: Unit01-02
+     * - Operation Cycle: Period01-02
+     */
+    virtual void Event01-02(RTC::TimedLong data) {}
+    
+    /*!
+     * Abst02-Final
+     * - Type: Type02-Final
+     * - Number: Num02-Final
+     * - Semantics: Detail02-Final
+     * - Unit: Unit02-Final
+     * - Operation Cycle: Period02-Final
+     */
+    virtual void Event02-Final(RTC::TimedString data) {}
+    
+  
+   private:
+     RTC::ReturnCode_t onInit() override;
+     RTC::ReturnCode_t onEntry() override;
+     RTC::ReturnCode_t onExit() override;
+  };
+
+  FSM_SUBSTATE(State01, Top) {
+    FSM_STATE(State01);
+  
+
+    // Event handler
+    void Event01-02(RTC::TimedLong data) override;
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+  };
+
+  FSM_SUBSTATE(State02, Top) {
+    FSM_STATE(State02);
+  
+
+    // Event handler
+    void Event02-Final(RTC::TimedString data) override;
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+  };
+
+
+} //end namespace 'ModuleNameFSM'
+
+#endif // MODULENAMEFSM_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/src/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/src/CMakeLists.txt
@@ -1,0 +1,64 @@
+set(comp_srcs ModuleName.cpp ModuleNameFSM.cpp)
+set(standalone_srcs ModuleNameComp.cpp)
+
+if(${OPENRTM_VERSION_MAJOR} LESS 2)
+  set(OPENRTM_CFLAGS ${OPENRTM_CFLAGS} ${OMNIORB_CFLAGS})
+  set(OPENRTM_INCLUDE_DIRS ${OPENRTM_INCLUDE_DIRS} ${OMNIORB_INCLUDE_DIRS})
+  set(OPENRTM_LIBRARY_DIRS ${OPENRTM_LIBRARY_DIRS} ${OMNIORB_LIBRARY_DIRS})
+endif()
+
+if (DEFINED OPENRTM_INCLUDE_DIRS)
+  string(REGEX REPLACE "-I" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+endif (DEFINED OPENRTM_INCLUDE_DIRS)
+
+if (DEFINED OPENRTM_LIBRARY_DIRS)
+  string(REGEX REPLACE "-L" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+endif (DEFINED OPENRTM_LIBRARY_DIRS)
+
+if (DEFINED OPENRTM_LIBRARIES)
+  string(REGEX REPLACE "-l" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+endif (DEFINED OPENRTM_LIBRARIES)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME})
+include_directories(${PROJECT_BINARY_DIR})
+include_directories(${PROJECT_BINARY_DIR}/idl)
+include_directories(${OPENRTM_INCLUDE_DIRS})
+add_definitions(${OPENRTM_CFLAGS})
+
+MAP_ADD_STR(comp_hdrs "../" comp_headers)
+
+link_directories(${OPENRTM_LIBRARY_DIRS})
+
+add_library(${PROJECT_NAME} ${LIB_TYPE} ${comp_srcs}
+  ${comp_headers} ${ALL_IDL_SRCS})
+set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
+set_source_files_properties(${ALL_IDL_SRCS} PROPERTIES GENERATED 1)
+if(NOT TARGET ALL_IDL_TGT)
+ add_custom_target(ALL_IDL_TGT)
+endif(NOT TARGET ALL_IDL_TGT)
+add_dependencies(${PROJECT_NAME} ALL_IDL_TGT)
+target_link_libraries(${PROJECT_NAME} ${OPENRTM_LIBRARIES})
+
+add_executable(${PROJECT_NAME}Comp ${standalone_srcs}
+  ${comp_srcs} ${comp_headers} ${ALL_IDL_SRCS})
+add_dependencies(${PROJECT_NAME}Comp ALL_IDL_TGT)
+target_link_libraries(${PROJECT_NAME}Comp ${OPENRTM_LIBRARIES})
+
+install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}Comp
+    EXPORT ${PROJECT_NAME}
+    RUNTIME DESTINATION ${INSTALL_PREFIX} COMPONENT component
+    LIBRARY DESTINATION ${INSTALL_PREFIX} COMPONENT component
+    ARCHIVE DESTINATION ${INSTALL_PREFIX} COMPONENT component)
+
+install(FILES ${PROJECT_SOURCE_DIR}/RTC.xml DESTINATION ${INSTALL_PREFIX}
+        COMPONENT component)

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/src/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/src/ModuleName.cpp
@@ -1,0 +1,180 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleName.cpp
+ * @brief ModuleDescription
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include "ModuleName.h"
+
+// Module specification
+// <rtc-template block="module_spec">
+static const char* modulename_spec[] =
+  {
+    "implementation_id", "ModuleName",
+    "type_name",         "ModuleName",
+    "description",       "ModuleDescription",
+    "version",           "1.0.0",
+    "vendor",            "VenderName",
+    "category",          "Category",
+    "activity_type",     "PERIODIC",
+    "kind",              "DataFlowComponent",
+    "max_instance",      "1",
+    "language",          "C++",
+    "lang_type",         "compile",
+    ""
+  };
+// </rtc-template>
+
+/*!
+ * @brief constructor
+ * @param manager Maneger Object
+ */
+ModuleName::ModuleName(RTC::Manager* manager)
+    // <rtc-template block="initializer">
+  : RTC::DataFlowComponentBase(manager),
+    m_fsm(this),
+    m_FSMEventIn("event", m_fsm)
+
+    // </rtc-template>
+{
+}
+
+/*!
+ * @brief destructor
+ */
+ModuleName::~ModuleName()
+{
+}
+
+
+
+RTC::ReturnCode_t ModuleName::onInitialize()
+{
+#ifdef ORB_IS_TAO
+  ::CORBA_Util::toRepositoryIdOfStruct<TimedLong>();
+#endif
+  // Registration: InPort/OutPort/Service
+  // <rtc-template block="registration">
+  // Set InPort buffers
+  
+  // Set OutPort buffer
+
+  // Set EventPort buffer
+  addInPort("event", m_FSMEventVarIn);
+  
+  // Set service provider to Ports
+  
+  // Set service consumers to Ports
+  
+  // Set CORBA Service Ports
+  
+  // </rtc-template>
+
+  // <rtc-template block="bind_config">
+  // </rtc-template>
+  // <rtc-template block="bind_event">
+  m_FSMEventVarIn.bindEvent("Event01-02", &ModuleNameFsm::Top::Event01-02);
+  m_FSMEventVarIn.bindEvent("Event02-Final", &ModuleNameFsm::Top::Event02-Final);
+  // </rtc-template>
+
+  
+  return RTC::RTC_OK;
+}
+
+/*
+RTC::ReturnCode_t ModuleName::onFinalize()
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onStartup(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onShutdown(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onActivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onDeactivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onExecute(RTC::UniqueId ec_id)
+{
+  m_fsm.run_event();
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onAborting(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onError(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onReset(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onStateUpdate(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onRateChanged(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+
+
+extern "C"
+{
+ 
+  void ModuleNameInit(RTC::Manager* manager)
+  {
+    coil::Properties profile(modulename_spec);
+    manager->registerFactory(profile,
+                             RTC::Create<ModuleName>,
+                             RTC::Delete<ModuleName>);
+  }
+  
+};
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/src/ModuleNameComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/src/ModuleNameComp.cpp
@@ -1,0 +1,129 @@
+﻿// -*- C++ -*-
+/*!
+ * @file ModuleNameComp.cpp
+ * @brief Standalone component
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include <rtm/Manager.h>
+#include <iostream>
+#include <string>
+#include <stdlib.h>
+#include "ModuleName.h"
+
+class OverwriteInstanceName
+  : public RTM::RtcLifecycleActionListener
+{
+public:
+  OverwriteInstanceName(int argc, char** argv)
+    : m_name(""), m_count(0)
+  {
+    for (size_t i = 0; i < argc; ++i)
+      {
+        std::string opt = argv[i];
+        if (opt.find("--instance_name=") == std::string::npos) { continue; }
+
+        coil::replaceString(opt, "--instance_name=", "");
+        if (opt.empty()) { continue; }
+
+        m_name = opt;
+      }
+  }
+  virtual ~OverwriteInstanceName() {}
+  virtual void preCreate(std::string& args)
+  {
+    if (m_count != 0 || m_name.empty()) { return; }
+    args = args + "?instance_name=" + m_name;
+    ++m_count;
+  };
+  virtual void postCreate(RTC::RTObject_impl*) {};
+  virtual void preConfigure(coil::Properties&) {};
+  virtual void postConfigure(coil::Properties&) {};
+  virtual void preInitialize() {};
+  virtual void postInitialize() {};
+private:
+  std::string m_name;
+  int32_t m_count;
+};
+
+void MyModuleInit(RTC::Manager* manager)
+{
+  ModuleNameInit(manager);
+  RTC::RtcBase* comp;
+
+  // Create a component
+  comp = manager->createComponent("ModuleName");
+
+  if (comp==NULL)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
+
+  // Example
+  // The following procedure is examples how handle RT-Components.
+  // These should not be in this function.
+
+  // Get the component's object reference
+//  RTC::RTObject_var rtobj;
+//  rtobj = RTC::RTObject::_narrow(manager->getPOA()->servant_to_reference(comp));
+
+  // Get the port list of the component
+//  PortServiceList* portlist;
+//  portlist = rtobj->get_ports();
+
+  // getting port profiles
+//  std::cout << "Number of Ports: ";
+//  std::cout << portlist->length() << std::endl << std::endl; 
+//  for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
+//  {
+//    PortService_ptr port;
+//    port = (*portlist)[i];
+//    std::cout << "Port" << i << " (name): ";
+//    std::cout << port->get_port_profile()->name << std::endl;
+//    
+//    RTC::PortInterfaceProfileList iflist;
+//    iflist = port->get_port_profile()->interfaces;
+//    std::cout << "---interfaces---" << std::endl;
+//    for (CORBA::ULong i(0), n(iflist.length()); i < n; ++i)
+//    {
+//      std::cout << "I/F name: ";
+//      std::cout << iflist[i].instance_name << std::endl;
+//      std::cout << "I/F type: ";
+//      std::cout << iflist[i].type_name << std::endl;
+//      const char* pol;
+//      pol = iflist[i].polarity == 0 ? "PROVIDED" : "REQUIRED";
+//      std::cout << "Polarity: " << pol << std::endl;
+//    }
+//    std::cout << "---properties---" << std::endl;
+//    NVUtil::dump(port->get_port_profile()->properties);
+//    std::cout << "----------------" << std::endl << std::endl;
+//  }
+
+  return;
+}
+
+int main (int argc, char** argv)
+{
+  RTC::Manager* manager;
+  manager = RTC::Manager::init(argc, argv);
+  manager->addRtcLifecycleActionListener(new OverwriteInstanceName(argc, argv), true);
+
+  // Set module initialization proceduer
+  // This procedure will be invoked in activateManager() function.
+  manager->setModuleInitProc(MyModuleInit);
+
+  // Activate manager and register to naming service
+  manager->activateManager();
+
+  // run the manager in blocking mode
+  // runManager(false) is the default.
+  manager->runManager();
+
+  // If you want to run the manager in non-blocking mode, do like this
+  // manager->runManager(true);
+
+  return 0;
+}

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/src/ModuleNameFSM.cpp
@@ -1,0 +1,50 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameFSM.cpp
+ * @date $Date$
+ * $Id$
+ */
+
+#include "ModuleNameFSM.h"
+
+namespace ModuleNameFsm {
+
+// Top state
+RTC::ReturnCode_t Top::onInit() {
+  setState<State01>();
+  return RTC::RTC_OK;
+}
+
+RTC::ReturnCode_t Top::onEntry() {
+  return RTC::RTC_OK;
+}
+
+RTC::ReturnCode_t Top::onExit() {
+  return RTC::RTC_OK;
+}
+
+//============================================================
+// State State01
+// RTC::ReturnCode_t State01::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+
+void State01::Event01-02(RTC::TimedLong data) {
+  setState<State02>();
+}
+
+
+//============================================================
+// State State02
+// RTC::ReturnCode_t State02::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+
+void State02::Event02-Final(RTC::TimedString data) {
+  setState<FinalState>();
+}
+
+
+} //end namespace 'ModuleNameFSM'

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/test/include/ModuleNameTest/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/test/include/ModuleNameTest/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(hdrs
+    ModuleNameTest.h
+    PARENT_SCOPE
+    )

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/test/include/ModuleNameTest/ModuleNameTest.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/test/include/ModuleNameTest/ModuleNameTest.h
@@ -1,0 +1,268 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameTest.h
+ * @brief ModuleDescription
+ * @date  $Date$
+ *
+ * $Id$
+ */
+
+#ifndef MODULENAME_TEST__H
+#define MODULENAME_TEST_H
+
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/idl/ExtendedDataTypesSkel.h>
+#include <rtm/idl/InterfaceDataTypesSkel.h>
+
+// Service implementation headers
+// <rtc-template block="service_impl_h">
+
+// </rtc-template>
+
+// Service Consumer stub headers
+// <rtc-template block="consumer_stub_h">
+
+// </rtc-template>
+
+#include <rtm/Manager.h>
+#include <rtm/DataFlowComponentBase.h>
+#include <rtm/CorbaPort.h>
+#include <rtm/DataInPort.h>
+#include <rtm/DataOutPort.h>
+
+/*!
+ * @class ModuleNameTest
+ * @brief ModuleDescription
+ *
+ */
+class ModuleNameTest
+  : public RTC::DataFlowComponentBase
+{
+ public:
+  /*!
+   * @brief constructor
+   * @param manager Maneger Object
+   */
+  ModuleNameTest(RTC::Manager* manager);
+
+  /*!
+   * @brief destructor
+   */
+  ~ModuleNameTest() override;
+
+  // <rtc-template block="public_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="public_operation">
+  
+  // </rtc-template>
+
+  // <rtc-template block="activity">
+  /***
+   *
+   * The initialize action (on CREATED->ALIVE transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+   RTC::ReturnCode_t onInitialize() override;
+
+  /***
+   *
+   * The finalize action (on ALIVE->END transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onFinalize() override;
+
+  /***
+   *
+   * The startup action when ExecutionContext startup
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStartup(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The shutdown action when ExecutionContext stop
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onShutdown(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The activated action (Active state entry action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The deactivated action (Active state exit action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The execution action that is invoked periodically
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The aborting action when main logic error occurred.
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onAborting(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The error action in ERROR state
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onError(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The reset action that is invoked resetting
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onReset(RTC::UniqueId ec_id) override;
+  
+  /***
+   *
+   * The state update action that is invoked after onExecute() action
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStateUpdate(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The action that is invoked when execution context's rate is changed
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id) override;
+  // </rtc-template>
+
+  bool runTest();
+
+ protected:
+  // <rtc-template block="protected_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="protected_operation">
+  
+  // </rtc-template>
+
+  // Configuration variable declaration
+  // <rtc-template block="config_declare">
+
+  // </rtc-template>
+
+  // DataInPort declaration
+  // <rtc-template block="inport_declare">
+  
+  // </rtc-template>
+
+
+  // DataOutPort declaration
+  // <rtc-template block="outport_declare">
+    RTC::TimedLong m_Event01-02;
+    RTC::OutPort<RTC::TimedLong> m_Event01-02Out;
+    
+    RTC::TimedString m_Event02-Final;
+    RTC::OutPort<RTC::TimedString> m_Event02-FinalOut;
+    
+  
+  // </rtc-template>
+
+  // CORBA Port declaration
+  // <rtc-template block="corbaport_declare">
+  
+  // </rtc-template>
+
+  // Service declaration
+  // <rtc-template block="service_declare">
+  
+  // </rtc-template>
+
+  // Consumer declaration
+  // <rtc-template block="consumer_declare">
+  
+  // </rtc-template>
+
+ private:
+  // <rtc-template block="private_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="private_operation">
+  
+  // </rtc-template>
+
+};
+
+
+extern "C"
+{
+  DLL_EXPORT void ModuleNameTestInit(RTC::Manager* manager);
+};
+
+#endif // MODULENAME_TEST_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/test/src/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/test/src/CMakeLists.txt
@@ -1,0 +1,57 @@
+set(comp_srcs
+   ModuleNameTest.cpp
+   )
+set(standalone_srcs ModuleNameTestComp.cpp)
+
+if(${OPENRTM_VERSION_MAJOR} LESS 2)
+  set(OPENRTM_CFLAGS ${OPENRTM_CFLAGS} ${OMNIORB_CFLAGS})
+  set(OPENRTM_INCLUDE_DIRS ${OPENRTM_INCLUDE_DIRS} ${OMNIORB_INCLUDE_DIRS})
+  set(OPENRTM_LIBRARY_DIRS ${OPENRTM_LIBRARY_DIRS} ${OMNIORB_LIBRARY_DIRS})
+endif()
+
+if (DEFINED OPENRTM_INCLUDE_DIRS)
+  string(REGEX REPLACE "-I" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+endif (DEFINED OPENRTM_INCLUDE_DIRS)
+
+if (DEFINED OPENRTM_LIBRARY_DIRS)
+  string(REGEX REPLACE "-L" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+endif (DEFINED OPENRTM_LIBRARY_DIRS)
+
+if (DEFINED OPENRTM_LIBRARIES)
+  string(REGEX REPLACE "-l" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+endif (DEFINED OPENRTM_LIBRARIES)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME})
+include_directories(${PROJECT_SOURCE_DIR}/test/include)
+include_directories(${PROJECT_SOURCE_DIR}/test/include/${PROJECT_NAME}Test)
+include_directories(${PROJECT_BINARY_DIR})
+include_directories(${PROJECT_BINARY_DIR}/idl)
+include_directories(${OPENRTM_INCLUDE_DIRS})
+add_definitions(${OPENRTM_CFLAGS})
+
+MAP_ADD_STR(comp_test_hdrs "../" comp_headers)
+
+link_directories(${OPENRTM_LIBRARY_DIRS})
+
+if(NOT TARGET ALL_IDL_TGT)
+ add_custom_target(ALL_IDL_TGT)
+endif(NOT TARGET ALL_IDL_TGT)
+
+add_executable(${PROJECT_NAME}Test ${standalone_srcs}
+  ${comp_srcs} ${comp_headers} ${ALL_IDL_SRCS})
+set_source_files_properties(${ALL_IDL_SRCS} PROPERTIES GENERATED 1)
+add_dependencies(${PROJECT_NAME}Test ${PROJECT_NAME})
+target_link_libraries(${PROJECT_NAME}Test ${OPENRTM_LIBRARIES} ${PROJECT_NAME})
+set_property(TARGET ${PROJECT_NAME}Test PROPERTY CXX_STANDARD 11)
+
+add_test(NAME ${PROJECT_NAME}_test COMMAND $<TARGET_FILE:${PROJECT_NAME}Test> -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event01-02&fsm_event_name=Event01-02,${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event02-Final&fsm_event_name=Event02-Final" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/test/src/ModuleNameTest.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/test/src/ModuleNameTest.cpp
@@ -1,0 +1,175 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameTest.cpp
+ * @brief ModuleDescription
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include "ModuleNameTest.h"
+
+// Module specification
+// <rtc-template block="module_spec">
+static const char* modulename_spec[] =
+  {
+    "implementation_id", "ModuleNameTest",
+    "type_name",         "ModuleNameTest",
+    "description",       "ModuleDescription",
+    "version",           "1.0.0",
+    "vendor",            "VenderName",
+    "category",          "Category",
+    "activity_type",     "PERIODIC",
+    "kind",              "DataFlowComponent",
+    "max_instance",      "1",
+    "language",          "C++",
+    "lang_type",         "compile",
+    ""
+  };
+// </rtc-template>
+
+/*!
+ * @brief constructor
+ * @param manager Maneger Object
+ */
+ModuleNameTest::ModuleNameTest(RTC::Manager* manager)
+    // <rtc-template block="initializer">
+  : RTC::DataFlowComponentBase(manager)
+,
+    m_Event01-02Out("Event01-02", m_Event01-02),
+    m_Event02-FinalOut("Event02-Final", m_Event02-Final)
+    // </rtc-template>
+{
+}
+
+/*!
+ * @brief destructor
+ */
+ModuleNameTest::~ModuleNameTest()
+{
+}
+
+
+
+RTC::ReturnCode_t ModuleNameTest::onInitialize()
+{
+  // Registration: InPort/OutPort/Service
+  // <rtc-template block="registration">
+  // Set InPort buffers
+  
+  // Set OutPort buffer
+  addOutPort("Event01-02", m_Event01-02Out);
+  addOutPort("Event02-Final", m_Event02-FinalOut);
+  
+  // Set service provider to Ports
+  
+  // Set service consumers to Ports
+  
+  // Set CORBA Service Ports
+  
+  // </rtc-template>
+
+  // <rtc-template block="bind_config">
+  // </rtc-template>
+  
+  return RTC::RTC_OK;
+}
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onFinalize()
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onStartup(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onShutdown(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onActivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onDeactivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onExecute(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onAborting(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onError(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onReset(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onStateUpdate(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onRateChanged(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+
+bool ModuleNameTest::runTest()
+{
+    return true;
+}
+
+
+extern "C"
+{
+ 
+  void ModuleNameTestInit(RTC::Manager* manager)
+  {
+    coil::Properties profile(modulename_spec);
+    manager->registerFactory(profile,
+                             RTC::Create<ModuleNameTest>,
+                             RTC::Delete<ModuleNameTest>);
+  }
+  
+};
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/test/src/ModuleNameTestComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/test/src/ModuleNameTestComp.cpp
@@ -1,0 +1,135 @@
+﻿// -*- C++ -*-
+/*!
+ * @file ModuleNameTestComp.cpp
+ * @brief Standalone component
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include <rtm/Manager.h>
+#include <iostream>
+#include <string>
+#include <stdlib.h>
+#include <rtm/CORBA_RTCUtil.h>
+#include "ModuleNameTest.h"
+#include "ModuleName.h"
+
+
+void MyModuleInit(RTC::Manager* manager)
+{
+  ModuleNameTestInit(manager);
+  ModuleNameInit(manager);
+  RTC::RtcBase* comp;
+
+  // Create a component
+  comp = manager->createComponent("ModuleNameTest");
+
+  if (comp==nullptr)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
+
+  // Example
+  // The following procedure is examples how handle RT-Components.
+  // These should not be in this function.
+
+  // Get the component's object reference
+//  RTC::RTObject_var rtobj;
+//  rtobj = RTC::RTObject::_narrow(manager->getPOA()->servant_to_reference(comp));
+
+  // Get the port list of the component
+//  PortServiceList* portlist;
+//  portlist = rtobj->get_ports();
+
+  // getting port profiles
+//  std::cout << "Number of Ports: ";
+//  std::cout << portlist->length() << std::endl << std::endl; 
+//  for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
+//  {
+//    PortService_ptr port;
+//    port = (*portlist)[i];
+//    std::cout << "Port" << i << " (name): ";
+//    std::cout << port->get_port_profile()->name << std::endl;
+//    
+//    RTC::PortInterfaceProfileList iflist;
+//    iflist = port->get_port_profile()->interfaces;
+//    std::cout << "---interfaces---" << std::endl;
+//    for (CORBA::ULong i(0), n(iflist.length()); i < n; ++i)
+//    {
+//      std::cout << "I/F name: ";
+//      std::cout << iflist[i].instance_name << std::endl;
+//      std::cout << "I/F type: ";
+//      std::cout << iflist[i].type_name << std::endl;
+//      const char* pol;
+//      pol = iflist[i].polarity == 0 ? "PROVIDED" : "REQUIRED";
+//      std::cout << "Polarity: " << pol << std::endl;
+//    }
+//    std::cout << "---properties---" << std::endl;
+//    NVUtil::dump(port->get_port_profile()->properties);
+//    std::cout << "----------------" << std::endl << std::endl;
+//  }
+
+  return;
+}
+
+bool RunTest()
+{
+  RTC::RtcBase* comp;
+  RTC::Manager &mamager = RTC::Manager::instance();
+  comp = mamager.getComponent("ModuleNameTest0");
+  if (comp == nullptr)
+  {
+    std::cerr << "Component get failed." << std::endl;
+    return false;
+  }
+
+  ModuleNameTest* testcomp = dynamic_cast<ModuleNameTest*>(comp);
+  if (testcomp == nullptr)
+  {
+    std::cerr << "Component get failed." << std::endl;
+    return false;
+  }
+
+  return testcomp->runTest();
+}
+
+int main (int argc, char** argv)
+{
+  RTC::Manager* manager;
+  manager = RTC::Manager::init(argc, argv);
+
+  // Set module initialization proceduer
+  // This procedure will be invoked in activateManager() function.
+  manager->setModuleInitProc(MyModuleInit);
+
+  // Activate manager and register to naming service
+  manager->activateManager();
+
+  // run the manager in blocking mode
+  // runManager(false) is the default.
+  // manager->runManager();
+
+  // If you want to run the manager in non-blocking mode, do like this
+  manager->runManager(true);
+
+  bool ret = RunTest();
+
+#if RTM_MAJOR_VERSION >= 2
+  manager->terminate();
+  manager->join();
+#else
+  manager->shutdown();
+#endif
+
+  
+  if (ret)
+  {
+    return 0;
+  }
+  else
+  {
+    return 1;
+  }
+}

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/ModuleNameFSM.scxml
@@ -1,0 +1,12 @@
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=140 h=513  -->
+ <state id="InitialState"><!--   node-size-and-position x=20 y=43 w=100 h=75  -->
+  <transition id="13" target="State01"></transition>
+ </state>
+ <state id="State01"><!--   node-size-and-position x=32.5 y=168 w=75 h=75  -->
+  <transition event="Event01-02" id="15" target="State02"></transition>
+ </state>
+ <state id="State02"><!--   node-size-and-position x=32.5 y=293 w=75 h=75  -->
+  <transition event="Event02-Final" id="17" target="FinalState"></transition>
+ </state>
+ <final id="FinalState"><!--   node-size-and-position x=30 y=418 w=80 h=75  --></final>
+</scxml>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/README.md
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/README.md
@@ -1,0 +1,278 @@
+﻿# ModuleName
+
+## Overview
+
+ModuleDescription
+
+## Description
+
+
+
+### Input and Output
+
+
+
+### Algorithm etc
+
+
+
+### Basic Information
+
+|  |  |
+----|---- 
+| Module Name | ModuleName |
+| Description | ModuleDescription |
+| Version | 1.0.0 |
+| Vendor | VenderName |
+| Category | Category |
+| Comp. Type | STATIC |
+| Act. Type | PERIODIC |
+| Kind | DataFlowComponent |
+| MAX Inst. | 1 |
+
+### Activity definition
+
+<table>
+  <tr>
+    <td rowspan="4">on_initialize</td>
+    <td colspan="2">implemented</td>
+    <tr>
+      <td>Description</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PreCondition</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PostCondition</td>
+      <td></td>
+    </tr>
+  </tr>
+  <tr>
+    <td>on_finalize</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_startup</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_shutdown</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_activated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_deactivated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_execute</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_aborting</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_error</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_reset</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_state_update</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_rate_changed</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+### EventPorts definition
+
+|  |  |
+----|---- 
+| Port Name | FSMEventPort |
+| FSM Type | StaticFSM |
+
+#### Node list
+
+<table>
+  <tr>
+    <td>State Name</td>
+    <td>Event Name</td>
+    <td>Target State</td>
+  </tr>
+  <tr>
+    <td>InitialState</td>
+    <td colspan="2">Initial State</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State01</td>
+    <td>Event01-02</td>
+    <td>State02</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State02</td>
+    <td>Event02-Final</td>
+    <td>FinalState</td>
+  </tr>
+  <tr>
+    <td>FinalState</td>
+    <td colspan="2">Final State</td>
+  </tr>
+
+</table>
+
+#### Event list
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">InitialState</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### Event01-02
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### Event02-Final
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">FinalState</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+
+
+### InPorts definition
+
+
+### OutPorts definition
+
+
+### Service Port definition
+
+
+### Configuration definition
+
+
+## Demo
+
+## Requirement
+
+## Setup
+
+### Windows
+
+### Ubuntu
+
+## Usage
+
+## Running the tests
+
+## LICENCE
+
+
+
+
+## References
+
+
+
+
+## Author
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/RTC.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<rtc:RtcProfile rtc:version="0.3" rtc:id="RTC:VenderName:Category:ModuleName:1.0.0" xmlns:rtc="http://www.openrtp.org/namespaces/rtc" xmlns:rtcExt="http://www.openrtp.org/namespaces/rtc_ext" xmlns:rtcDoc="http://www.openrtp.org/namespaces/rtc_doc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <rtc:BasicInfo xsi:type="rtcExt:basic_info_ext" rtcExt:saveProject="FSMTest" rtc:updateDate="2019-12-19T22:51:23.000+09:00" rtc:creationDate="2019-12-19T22:49:56.000+09:00" rtc:version="1.0.0" rtc:vendor="VenderName" rtc:maxInstances="1" rtc:executionType="PeriodicExecutionContext" rtc:executionRate="1000.0" rtc:description="ModuleDescription" rtc:category="Category" rtc:componentKind="DataFlowComponent" rtc:activityType="PERIODIC" rtc:componentType="STATIC" rtc:name="ModuleName">
+        <rtcExt:Properties rtcExt:value="true" rtcExt:name="FSM"/>
+        <rtcExt:Properties rtcExt:value="StaticFSM" rtcExt:name="FSMType"/>
+    </rtc:BasicInfo>
+    <rtc:Actions>
+        <rtc:OnInitialize xsi:type="rtcDoc:action_status_doc" rtc:implemented="true"/>
+        <rtc:OnFinalize xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStartup xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnShutdown xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnActivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnDeactivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAborting xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnError xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnReset xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnExecute xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStateUpdate xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnRateChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAction xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+    </rtc:Actions>
+    <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="" rtc:name="Event01-02">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="" rtc:name="Event02-Final">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+    </rtc:DataPorts>
+    <rtc:Language xsi:type="rtcExt:language_ext" rtc:kind="C++"/>
+</rtc:RtcProfile>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/include/ModuleName/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/include/ModuleName/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(hdrs ModuleName.h
+    ModuleNameFSM.h
+    PARENT_SCOPE
+    )

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/include/ModuleName/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/include/ModuleName/ModuleName.h
@@ -1,0 +1,280 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleName.h
+ * @brief ModuleDescription
+ * @date  $Date$
+ *
+ * $Id$
+ */
+
+#ifndef MODULENAME_H
+#define MODULENAME_H
+
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/idl/ExtendedDataTypesSkel.h>
+#include <rtm/idl/InterfaceDataTypesSkel.h>
+
+// Service implementation headers
+// <rtc-template block="service_impl_h">
+
+// </rtc-template>
+
+// Service Consumer stub headers
+// <rtc-template block="consumer_stub_h">
+
+// </rtc-template>
+
+#include <rtm/Manager.h>
+#include <rtm/DataFlowComponentBase.h>
+#include <rtm/CorbaPort.h>
+#include <rtm/DataInPort.h>
+#include <rtm/DataOutPort.h>
+
+// FSM headers
+
+#include <rtm/EventPort.h>
+// <rtc-template block="fsm_h">
+#include "ModuleNameFSM.h"
+// </rtc-template>
+
+
+/*!
+ * @class ModuleName
+ * @brief ModuleDescription
+ *
+ */
+class ModuleName
+  : public RTC::DataFlowComponentBase
+{
+ public:
+  /*!
+   * @brief constructor
+   * @param manager Maneger Object
+   */
+  ModuleName(RTC::Manager* manager);
+
+  /*!
+   * @brief destructor
+   */
+  ~ModuleName() override;
+
+  // <rtc-template block="public_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="public_operation">
+  
+  // </rtc-template>
+
+  // <rtc-template block="activity">
+  /***
+   *
+   * The initialize action (on CREATED->ALIVE transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+   RTC::ReturnCode_t onInitialize() override;
+
+  /***
+   *
+   * The finalize action (on ALIVE->END transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onFinalize() override;
+
+  /***
+   *
+   * The startup action when ExecutionContext startup
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStartup(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The shutdown action when ExecutionContext stop
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onShutdown(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The activated action (Active state entry action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The deactivated action (Active state exit action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The execution action that is invoked periodically
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The aborting action when main logic error occurred.
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onAborting(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The error action in ERROR state
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onError(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The reset action that is invoked resetting
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onReset(RTC::UniqueId ec_id) override;
+  
+  /***
+   *
+   * The state update action that is invoked after onExecute() action
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStateUpdate(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The action that is invoked when execution context's rate is changed
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id) override;
+  // </rtc-template>
+
+
+ protected:
+  // <rtc-template block="protected_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="protected_operation">
+  
+  // </rtc-template>
+
+  // Configuration variable declaration
+  // <rtc-template block="config_declare">
+
+  // </rtc-template>
+
+  // DataInPort declaration
+  // <rtc-template block="inport_declare">
+  
+  // </rtc-template>
+
+
+  // DataOutPort declaration
+  // <rtc-template block="outport_declare">
+  
+  // </rtc-template>
+
+  // CORBA Port declaration
+  // <rtc-template block="corbaport_declare">
+  
+  // </rtc-template>
+
+  // Service declaration
+  // <rtc-template block="service_declare">
+  
+  // </rtc-template>
+
+  // Consumer declaration
+  // <rtc-template block="consumer_declare">
+  
+  // </rtc-template>
+
+  // State machine declaration
+  // <rtc-template block="fsm_declare">
+  RTC::Machine<ModuleNameFsm::Top> m_fsm;
+  // </rtc-template>
+  
+  // EventPort declaration
+  // <rtc-template block="event_declare">
+  
+  RTC::EventInPort< RTC::Machine<ModuleNameFsm::Top> > m_FSMEventVarIn;
+  // </rtc-template>
+
+ private:
+  // <rtc-template block="private_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="private_operation">
+  
+  // </rtc-template>
+
+};
+
+
+extern "C"
+{
+  DLL_EXPORT void ModuleNameInit(RTC::Manager* manager);
+};
+
+#endif // MODULENAME_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/include/ModuleName/ModuleNameFSM.h
@@ -1,0 +1,75 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameFSM.h
+ * @date  $Date$
+ * $Id$
+ */
+
+#ifndef MODULENAMEFSM_H
+#define MODULENAMEFSM_H
+
+#include <rtm/StaticFSM.h>
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/RTC.h>
+
+class ModuleName;
+
+namespace ModuleNameFsm {
+
+  /*!
+   * @if jp
+   * @class TOP状態
+   *
+   *
+   * @else
+   * @brief TOP state
+   *
+   * @endif
+   */
+  FSM_TOPSTATE(Top) {
+    // Top state variables (visible to all substates)
+  
+    FSM_STATE(Top);
+
+    // Machine's event protocol
+    /*!
+     */
+    virtual void Event01-02() {}
+    
+    /*!
+     */
+    virtual void Event02-Final() {}
+    
+  
+   private:
+     RTC::ReturnCode_t onInit() override;
+     RTC::ReturnCode_t onEntry() override;
+     RTC::ReturnCode_t onExit() override;
+  };
+
+  FSM_SUBSTATE(State01, Top) {
+    FSM_STATE(State01);
+  
+
+    // Event handler
+    void Event01-02() override;
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+  };
+
+  FSM_SUBSTATE(State02, Top) {
+    FSM_STATE(State02);
+  
+
+    // Event handler
+    void Event02-Final() override;
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+  };
+
+
+} //end namespace 'ModuleNameFSM'
+
+#endif // MODULENAMEFSM_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/src/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/src/CMakeLists.txt
@@ -1,0 +1,64 @@
+set(comp_srcs ModuleName.cpp ModuleNameFSM.cpp)
+set(standalone_srcs ModuleNameComp.cpp)
+
+if(${OPENRTM_VERSION_MAJOR} LESS 2)
+  set(OPENRTM_CFLAGS ${OPENRTM_CFLAGS} ${OMNIORB_CFLAGS})
+  set(OPENRTM_INCLUDE_DIRS ${OPENRTM_INCLUDE_DIRS} ${OMNIORB_INCLUDE_DIRS})
+  set(OPENRTM_LIBRARY_DIRS ${OPENRTM_LIBRARY_DIRS} ${OMNIORB_LIBRARY_DIRS})
+endif()
+
+if (DEFINED OPENRTM_INCLUDE_DIRS)
+  string(REGEX REPLACE "-I" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+endif (DEFINED OPENRTM_INCLUDE_DIRS)
+
+if (DEFINED OPENRTM_LIBRARY_DIRS)
+  string(REGEX REPLACE "-L" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+endif (DEFINED OPENRTM_LIBRARY_DIRS)
+
+if (DEFINED OPENRTM_LIBRARIES)
+  string(REGEX REPLACE "-l" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+endif (DEFINED OPENRTM_LIBRARIES)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME})
+include_directories(${PROJECT_BINARY_DIR})
+include_directories(${PROJECT_BINARY_DIR}/idl)
+include_directories(${OPENRTM_INCLUDE_DIRS})
+add_definitions(${OPENRTM_CFLAGS})
+
+MAP_ADD_STR(comp_hdrs "../" comp_headers)
+
+link_directories(${OPENRTM_LIBRARY_DIRS})
+
+add_library(${PROJECT_NAME} ${LIB_TYPE} ${comp_srcs}
+  ${comp_headers} ${ALL_IDL_SRCS})
+set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
+set_source_files_properties(${ALL_IDL_SRCS} PROPERTIES GENERATED 1)
+if(NOT TARGET ALL_IDL_TGT)
+ add_custom_target(ALL_IDL_TGT)
+endif(NOT TARGET ALL_IDL_TGT)
+add_dependencies(${PROJECT_NAME} ALL_IDL_TGT)
+target_link_libraries(${PROJECT_NAME} ${OPENRTM_LIBRARIES})
+
+add_executable(${PROJECT_NAME}Comp ${standalone_srcs}
+  ${comp_srcs} ${comp_headers} ${ALL_IDL_SRCS})
+add_dependencies(${PROJECT_NAME}Comp ALL_IDL_TGT)
+target_link_libraries(${PROJECT_NAME}Comp ${OPENRTM_LIBRARIES})
+
+install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}Comp
+    EXPORT ${PROJECT_NAME}
+    RUNTIME DESTINATION ${INSTALL_PREFIX} COMPONENT component
+    LIBRARY DESTINATION ${INSTALL_PREFIX} COMPONENT component
+    ARCHIVE DESTINATION ${INSTALL_PREFIX} COMPONENT component)
+
+install(FILES ${PROJECT_SOURCE_DIR}/RTC.xml DESTINATION ${INSTALL_PREFIX}
+        COMPONENT component)

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/src/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/src/ModuleName.cpp
@@ -1,0 +1,180 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleName.cpp
+ * @brief ModuleDescription
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include "ModuleName.h"
+
+// Module specification
+// <rtc-template block="module_spec">
+static const char* modulename_spec[] =
+  {
+    "implementation_id", "ModuleName",
+    "type_name",         "ModuleName",
+    "description",       "ModuleDescription",
+    "version",           "1.0.0",
+    "vendor",            "VenderName",
+    "category",          "Category",
+    "activity_type",     "PERIODIC",
+    "kind",              "DataFlowComponent",
+    "max_instance",      "1",
+    "language",          "C++",
+    "lang_type",         "compile",
+    ""
+  };
+// </rtc-template>
+
+/*!
+ * @brief constructor
+ * @param manager Maneger Object
+ */
+ModuleName::ModuleName(RTC::Manager* manager)
+    // <rtc-template block="initializer">
+  : RTC::DataFlowComponentBase(manager),
+    m_fsm(this),
+    m_FSMEventIn("event", m_fsm)
+
+    // </rtc-template>
+{
+}
+
+/*!
+ * @brief destructor
+ */
+ModuleName::~ModuleName()
+{
+}
+
+
+
+RTC::ReturnCode_t ModuleName::onInitialize()
+{
+#ifdef ORB_IS_TAO
+  ::CORBA_Util::toRepositoryIdOfStruct<TimedLong>();
+#endif
+  // Registration: InPort/OutPort/Service
+  // <rtc-template block="registration">
+  // Set InPort buffers
+  
+  // Set OutPort buffer
+
+  // Set EventPort buffer
+  addInPort("event", m_FSMEventVarIn);
+  
+  // Set service provider to Ports
+  
+  // Set service consumers to Ports
+  
+  // Set CORBA Service Ports
+  
+  // </rtc-template>
+
+  // <rtc-template block="bind_config">
+  // </rtc-template>
+  // <rtc-template block="bind_event">
+  m_FSMEventVarIn.bindEvent("Event01-02", &ModuleNameFsm::Top::Event01-02);
+  m_FSMEventVarIn.bindEvent("Event02-Final", &ModuleNameFsm::Top::Event02-Final);
+  // </rtc-template>
+
+  
+  return RTC::RTC_OK;
+}
+
+/*
+RTC::ReturnCode_t ModuleName::onFinalize()
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onStartup(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onShutdown(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onActivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onDeactivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onExecute(RTC::UniqueId ec_id)
+{
+  m_fsm.run_event();
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onAborting(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onError(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onReset(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onStateUpdate(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onRateChanged(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+
+
+extern "C"
+{
+ 
+  void ModuleNameInit(RTC::Manager* manager)
+  {
+    coil::Properties profile(modulename_spec);
+    manager->registerFactory(profile,
+                             RTC::Create<ModuleName>,
+                             RTC::Delete<ModuleName>);
+  }
+  
+};
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/src/ModuleNameComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/src/ModuleNameComp.cpp
@@ -1,0 +1,129 @@
+﻿// -*- C++ -*-
+/*!
+ * @file ModuleNameComp.cpp
+ * @brief Standalone component
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include <rtm/Manager.h>
+#include <iostream>
+#include <string>
+#include <stdlib.h>
+#include "ModuleName.h"
+
+class OverwriteInstanceName
+  : public RTM::RtcLifecycleActionListener
+{
+public:
+  OverwriteInstanceName(int argc, char** argv)
+    : m_name(""), m_count(0)
+  {
+    for (size_t i = 0; i < argc; ++i)
+      {
+        std::string opt = argv[i];
+        if (opt.find("--instance_name=") == std::string::npos) { continue; }
+
+        coil::replaceString(opt, "--instance_name=", "");
+        if (opt.empty()) { continue; }
+
+        m_name = opt;
+      }
+  }
+  virtual ~OverwriteInstanceName() {}
+  virtual void preCreate(std::string& args)
+  {
+    if (m_count != 0 || m_name.empty()) { return; }
+    args = args + "?instance_name=" + m_name;
+    ++m_count;
+  };
+  virtual void postCreate(RTC::RTObject_impl*) {};
+  virtual void preConfigure(coil::Properties&) {};
+  virtual void postConfigure(coil::Properties&) {};
+  virtual void preInitialize() {};
+  virtual void postInitialize() {};
+private:
+  std::string m_name;
+  int32_t m_count;
+};
+
+void MyModuleInit(RTC::Manager* manager)
+{
+  ModuleNameInit(manager);
+  RTC::RtcBase* comp;
+
+  // Create a component
+  comp = manager->createComponent("ModuleName");
+
+  if (comp==NULL)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
+
+  // Example
+  // The following procedure is examples how handle RT-Components.
+  // These should not be in this function.
+
+  // Get the component's object reference
+//  RTC::RTObject_var rtobj;
+//  rtobj = RTC::RTObject::_narrow(manager->getPOA()->servant_to_reference(comp));
+
+  // Get the port list of the component
+//  PortServiceList* portlist;
+//  portlist = rtobj->get_ports();
+
+  // getting port profiles
+//  std::cout << "Number of Ports: ";
+//  std::cout << portlist->length() << std::endl << std::endl; 
+//  for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
+//  {
+//    PortService_ptr port;
+//    port = (*portlist)[i];
+//    std::cout << "Port" << i << " (name): ";
+//    std::cout << port->get_port_profile()->name << std::endl;
+//    
+//    RTC::PortInterfaceProfileList iflist;
+//    iflist = port->get_port_profile()->interfaces;
+//    std::cout << "---interfaces---" << std::endl;
+//    for (CORBA::ULong i(0), n(iflist.length()); i < n; ++i)
+//    {
+//      std::cout << "I/F name: ";
+//      std::cout << iflist[i].instance_name << std::endl;
+//      std::cout << "I/F type: ";
+//      std::cout << iflist[i].type_name << std::endl;
+//      const char* pol;
+//      pol = iflist[i].polarity == 0 ? "PROVIDED" : "REQUIRED";
+//      std::cout << "Polarity: " << pol << std::endl;
+//    }
+//    std::cout << "---properties---" << std::endl;
+//    NVUtil::dump(port->get_port_profile()->properties);
+//    std::cout << "----------------" << std::endl << std::endl;
+//  }
+
+  return;
+}
+
+int main (int argc, char** argv)
+{
+  RTC::Manager* manager;
+  manager = RTC::Manager::init(argc, argv);
+  manager->addRtcLifecycleActionListener(new OverwriteInstanceName(argc, argv), true);
+
+  // Set module initialization proceduer
+  // This procedure will be invoked in activateManager() function.
+  manager->setModuleInitProc(MyModuleInit);
+
+  // Activate manager and register to naming service
+  manager->activateManager();
+
+  // run the manager in blocking mode
+  // runManager(false) is the default.
+  manager->runManager();
+
+  // If you want to run the manager in non-blocking mode, do like this
+  // manager->runManager(true);
+
+  return 0;
+}

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/src/ModuleNameFSM.cpp
@@ -1,0 +1,50 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameFSM.cpp
+ * @date $Date$
+ * $Id$
+ */
+
+#include "ModuleNameFSM.h"
+
+namespace ModuleNameFsm {
+
+// Top state
+RTC::ReturnCode_t Top::onInit() {
+  setState<State01>();
+  return RTC::RTC_OK;
+}
+
+RTC::ReturnCode_t Top::onEntry() {
+  return RTC::RTC_OK;
+}
+
+RTC::ReturnCode_t Top::onExit() {
+  return RTC::RTC_OK;
+}
+
+//============================================================
+// State State01
+// RTC::ReturnCode_t State01::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+
+void State01::Event01-02() {
+  setState<State02>();
+}
+
+
+//============================================================
+// State State02
+// RTC::ReturnCode_t State02::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+
+void State02::Event02-Final() {
+  setState<FinalState>();
+}
+
+
+} //end namespace 'ModuleNameFSM'

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/test/include/ModuleNameTest/ModuleNameTest.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/test/include/ModuleNameTest/ModuleNameTest.h
@@ -1,0 +1,268 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameTest.h
+ * @brief ModuleDescription
+ * @date  $Date$
+ *
+ * $Id$
+ */
+
+#ifndef MODULENAME_TEST__H
+#define MODULENAME_TEST_H
+
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/idl/ExtendedDataTypesSkel.h>
+#include <rtm/idl/InterfaceDataTypesSkel.h>
+
+// Service implementation headers
+// <rtc-template block="service_impl_h">
+
+// </rtc-template>
+
+// Service Consumer stub headers
+// <rtc-template block="consumer_stub_h">
+
+// </rtc-template>
+
+#include <rtm/Manager.h>
+#include <rtm/DataFlowComponentBase.h>
+#include <rtm/CorbaPort.h>
+#include <rtm/DataInPort.h>
+#include <rtm/DataOutPort.h>
+
+/*!
+ * @class ModuleNameTest
+ * @brief ModuleDescription
+ *
+ */
+class ModuleNameTest
+  : public RTC::DataFlowComponentBase
+{
+ public:
+  /*!
+   * @brief constructor
+   * @param manager Maneger Object
+   */
+  ModuleNameTest(RTC::Manager* manager);
+
+  /*!
+   * @brief destructor
+   */
+  ~ModuleNameTest() override;
+
+  // <rtc-template block="public_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="public_operation">
+  
+  // </rtc-template>
+
+  // <rtc-template block="activity">
+  /***
+   *
+   * The initialize action (on CREATED->ALIVE transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+   RTC::ReturnCode_t onInitialize() override;
+
+  /***
+   *
+   * The finalize action (on ALIVE->END transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onFinalize() override;
+
+  /***
+   *
+   * The startup action when ExecutionContext startup
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStartup(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The shutdown action when ExecutionContext stop
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onShutdown(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The activated action (Active state entry action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The deactivated action (Active state exit action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The execution action that is invoked periodically
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The aborting action when main logic error occurred.
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onAborting(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The error action in ERROR state
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onError(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The reset action that is invoked resetting
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onReset(RTC::UniqueId ec_id) override;
+  
+  /***
+   *
+   * The state update action that is invoked after onExecute() action
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStateUpdate(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The action that is invoked when execution context's rate is changed
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id) override;
+  // </rtc-template>
+
+  bool runTest();
+
+ protected:
+  // <rtc-template block="protected_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="protected_operation">
+  
+  // </rtc-template>
+
+  // Configuration variable declaration
+  // <rtc-template block="config_declare">
+
+  // </rtc-template>
+
+  // DataInPort declaration
+  // <rtc-template block="inport_declare">
+  
+  // </rtc-template>
+
+
+  // DataOutPort declaration
+  // <rtc-template block="outport_declare">
+    RTC::TimedLong m_Event01-02;
+    RTC::OutPort<RTC::TimedLong> m_Event01-02Out;
+    
+    RTC::TimedLong m_Event02-Final;
+    RTC::OutPort<RTC::TimedLong> m_Event02-FinalOut;
+    
+  
+  // </rtc-template>
+
+  // CORBA Port declaration
+  // <rtc-template block="corbaport_declare">
+  
+  // </rtc-template>
+
+  // Service declaration
+  // <rtc-template block="service_declare">
+  
+  // </rtc-template>
+
+  // Consumer declaration
+  // <rtc-template block="consumer_declare">
+  
+  // </rtc-template>
+
+ private:
+  // <rtc-template block="private_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="private_operation">
+  
+  // </rtc-template>
+
+};
+
+
+extern "C"
+{
+  DLL_EXPORT void ModuleNameTestInit(RTC::Manager* manager);
+};
+
+#endif // MODULENAME_TEST_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/test/src/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/test/src/CMakeLists.txt
@@ -1,0 +1,57 @@
+set(comp_srcs
+   ModuleNameTest.cpp
+   )
+set(standalone_srcs ModuleNameTestComp.cpp)
+
+if(${OPENRTM_VERSION_MAJOR} LESS 2)
+  set(OPENRTM_CFLAGS ${OPENRTM_CFLAGS} ${OMNIORB_CFLAGS})
+  set(OPENRTM_INCLUDE_DIRS ${OPENRTM_INCLUDE_DIRS} ${OMNIORB_INCLUDE_DIRS})
+  set(OPENRTM_LIBRARY_DIRS ${OPENRTM_LIBRARY_DIRS} ${OMNIORB_LIBRARY_DIRS})
+endif()
+
+if (DEFINED OPENRTM_INCLUDE_DIRS)
+  string(REGEX REPLACE "-I" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+endif (DEFINED OPENRTM_INCLUDE_DIRS)
+
+if (DEFINED OPENRTM_LIBRARY_DIRS)
+  string(REGEX REPLACE "-L" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+endif (DEFINED OPENRTM_LIBRARY_DIRS)
+
+if (DEFINED OPENRTM_LIBRARIES)
+  string(REGEX REPLACE "-l" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+endif (DEFINED OPENRTM_LIBRARIES)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME})
+include_directories(${PROJECT_SOURCE_DIR}/test/include)
+include_directories(${PROJECT_SOURCE_DIR}/test/include/${PROJECT_NAME}Test)
+include_directories(${PROJECT_BINARY_DIR})
+include_directories(${PROJECT_BINARY_DIR}/idl)
+include_directories(${OPENRTM_INCLUDE_DIRS})
+add_definitions(${OPENRTM_CFLAGS})
+
+MAP_ADD_STR(comp_test_hdrs "../" comp_headers)
+
+link_directories(${OPENRTM_LIBRARY_DIRS})
+
+if(NOT TARGET ALL_IDL_TGT)
+ add_custom_target(ALL_IDL_TGT)
+endif(NOT TARGET ALL_IDL_TGT)
+
+add_executable(${PROJECT_NAME}Test ${standalone_srcs}
+  ${comp_srcs} ${comp_headers} ${ALL_IDL_SRCS})
+set_source_files_properties(${ALL_IDL_SRCS} PROPERTIES GENERATED 1)
+add_dependencies(${PROJECT_NAME}Test ${PROJECT_NAME})
+target_link_libraries(${PROJECT_NAME}Test ${OPENRTM_LIBRARIES} ${PROJECT_NAME})
+set_property(TARGET ${PROJECT_NAME}Test PROPERTY CXX_STANDARD 11)
+
+add_test(NAME ${PROJECT_NAME}_test COMMAND $<TARGET_FILE:${PROJECT_NAME}Test> -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event01-02&fsm_event_name=Event01-02,${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event02-Final&fsm_event_name=Event02-Final" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/test/src/ModuleNameTest.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/test/src/ModuleNameTest.cpp
@@ -1,0 +1,175 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameTest.cpp
+ * @brief ModuleDescription
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include "ModuleNameTest.h"
+
+// Module specification
+// <rtc-template block="module_spec">
+static const char* modulename_spec[] =
+  {
+    "implementation_id", "ModuleNameTest",
+    "type_name",         "ModuleNameTest",
+    "description",       "ModuleDescription",
+    "version",           "1.0.0",
+    "vendor",            "VenderName",
+    "category",          "Category",
+    "activity_type",     "PERIODIC",
+    "kind",              "DataFlowComponent",
+    "max_instance",      "1",
+    "language",          "C++",
+    "lang_type",         "compile",
+    ""
+  };
+// </rtc-template>
+
+/*!
+ * @brief constructor
+ * @param manager Maneger Object
+ */
+ModuleNameTest::ModuleNameTest(RTC::Manager* manager)
+    // <rtc-template block="initializer">
+  : RTC::DataFlowComponentBase(manager)
+,
+    m_Event01-02Out("Event01-02", m_Event01-02),
+    m_Event02-FinalOut("Event02-Final", m_Event02-Final)
+    // </rtc-template>
+{
+}
+
+/*!
+ * @brief destructor
+ */
+ModuleNameTest::~ModuleNameTest()
+{
+}
+
+
+
+RTC::ReturnCode_t ModuleNameTest::onInitialize()
+{
+  // Registration: InPort/OutPort/Service
+  // <rtc-template block="registration">
+  // Set InPort buffers
+  
+  // Set OutPort buffer
+  addOutPort("Event01-02", m_Event01-02Out);
+  addOutPort("Event02-Final", m_Event02-FinalOut);
+  
+  // Set service provider to Ports
+  
+  // Set service consumers to Ports
+  
+  // Set CORBA Service Ports
+  
+  // </rtc-template>
+
+  // <rtc-template block="bind_config">
+  // </rtc-template>
+  
+  return RTC::RTC_OK;
+}
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onFinalize()
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onStartup(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onShutdown(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onActivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onDeactivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onExecute(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onAborting(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onError(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onReset(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onStateUpdate(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onRateChanged(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+
+bool ModuleNameTest::runTest()
+{
+    return true;
+}
+
+
+extern "C"
+{
+ 
+  void ModuleNameTestInit(RTC::Manager* manager)
+  {
+    coil::Properties profile(modulename_spec);
+    manager->registerFactory(profile,
+                             RTC::Create<ModuleNameTest>,
+                             RTC::Delete<ModuleNameTest>);
+  }
+  
+};
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/test/src/ModuleNameTestComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/test/src/ModuleNameTestComp.cpp
@@ -1,0 +1,135 @@
+﻿// -*- C++ -*-
+/*!
+ * @file ModuleNameTestComp.cpp
+ * @brief Standalone component
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include <rtm/Manager.h>
+#include <iostream>
+#include <string>
+#include <stdlib.h>
+#include <rtm/CORBA_RTCUtil.h>
+#include "ModuleNameTest.h"
+#include "ModuleName.h"
+
+
+void MyModuleInit(RTC::Manager* manager)
+{
+  ModuleNameTestInit(manager);
+  ModuleNameInit(manager);
+  RTC::RtcBase* comp;
+
+  // Create a component
+  comp = manager->createComponent("ModuleNameTest");
+
+  if (comp==nullptr)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
+
+  // Example
+  // The following procedure is examples how handle RT-Components.
+  // These should not be in this function.
+
+  // Get the component's object reference
+//  RTC::RTObject_var rtobj;
+//  rtobj = RTC::RTObject::_narrow(manager->getPOA()->servant_to_reference(comp));
+
+  // Get the port list of the component
+//  PortServiceList* portlist;
+//  portlist = rtobj->get_ports();
+
+  // getting port profiles
+//  std::cout << "Number of Ports: ";
+//  std::cout << portlist->length() << std::endl << std::endl; 
+//  for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
+//  {
+//    PortService_ptr port;
+//    port = (*portlist)[i];
+//    std::cout << "Port" << i << " (name): ";
+//    std::cout << port->get_port_profile()->name << std::endl;
+//    
+//    RTC::PortInterfaceProfileList iflist;
+//    iflist = port->get_port_profile()->interfaces;
+//    std::cout << "---interfaces---" << std::endl;
+//    for (CORBA::ULong i(0), n(iflist.length()); i < n; ++i)
+//    {
+//      std::cout << "I/F name: ";
+//      std::cout << iflist[i].instance_name << std::endl;
+//      std::cout << "I/F type: ";
+//      std::cout << iflist[i].type_name << std::endl;
+//      const char* pol;
+//      pol = iflist[i].polarity == 0 ? "PROVIDED" : "REQUIRED";
+//      std::cout << "Polarity: " << pol << std::endl;
+//    }
+//    std::cout << "---properties---" << std::endl;
+//    NVUtil::dump(port->get_port_profile()->properties);
+//    std::cout << "----------------" << std::endl << std::endl;
+//  }
+
+  return;
+}
+
+bool RunTest()
+{
+  RTC::RtcBase* comp;
+  RTC::Manager &mamager = RTC::Manager::instance();
+  comp = mamager.getComponent("ModuleNameTest0");
+  if (comp == nullptr)
+  {
+    std::cerr << "Component get failed." << std::endl;
+    return false;
+  }
+
+  ModuleNameTest* testcomp = dynamic_cast<ModuleNameTest*>(comp);
+  if (testcomp == nullptr)
+  {
+    std::cerr << "Component get failed." << std::endl;
+    return false;
+  }
+
+  return testcomp->runTest();
+}
+
+int main (int argc, char** argv)
+{
+  RTC::Manager* manager;
+  manager = RTC::Manager::init(argc, argv);
+
+  // Set module initialization proceduer
+  // This procedure will be invoked in activateManager() function.
+  manager->setModuleInitProc(MyModuleInit);
+
+  // Activate manager and register to naming service
+  manager->activateManager();
+
+  // run the manager in blocking mode
+  // runManager(false) is the default.
+  // manager->runManager();
+
+  // If you want to run the manager in non-blocking mode, do like this
+  manager->runManager(true);
+
+  bool ret = RunTest();
+
+#if RTM_MAJOR_VERSION >= 2
+  manager->terminate();
+  manager->join();
+#else
+  manager->shutdown();
+#endif
+
+  
+  if (ret)
+  {
+    return 0;
+  }
+  else
+  {
+    return 1;
+  }
+}

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/ModuleNameFSM.scxml
@@ -1,0 +1,12 @@
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=212 h=513  -->
+ <state id="InitialState"><!--   node-size-and-position x=55.86 y=43 w=100 h=75  -->
+  <transition id="13" target="State01"></transition>
+ </state>
+ <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->
+  <transition cond="Cond01" event="Event01-02" id="15" target="State02"></transition>
+ </state>
+ <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->
+  <transition cond="Cond02" event="Event02-Final" id="17" target="FinalState"></transition>
+ </state>
+ <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final>
+</scxml>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/README.md
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/README.md
@@ -1,0 +1,278 @@
+﻿# ModuleName
+
+## Overview
+
+ModuleDescription
+
+## Description
+
+
+
+### Input and Output
+
+
+
+### Algorithm etc
+
+
+
+### Basic Information
+
+|  |  |
+----|---- 
+| Module Name | ModuleName |
+| Description | ModuleDescription |
+| Version | 1.0.0 |
+| Vendor | VenderName |
+| Category | Category |
+| Comp. Type | STATIC |
+| Act. Type | PERIODIC |
+| Kind | DataFlowComponent |
+| MAX Inst. | 1 |
+
+### Activity definition
+
+<table>
+  <tr>
+    <td rowspan="4">on_initialize</td>
+    <td colspan="2">implemented</td>
+    <tr>
+      <td>Description</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PreCondition</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PostCondition</td>
+      <td></td>
+    </tr>
+  </tr>
+  <tr>
+    <td>on_finalize</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_startup</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_shutdown</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_activated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_deactivated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_execute</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_aborting</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_error</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_reset</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_state_update</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_rate_changed</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+### EventPorts definition
+
+|  |  |
+----|---- 
+| Port Name | FSMEventPort |
+| FSM Type | StaticFSM |
+
+#### Node list
+
+<table>
+  <tr>
+    <td>State Name</td>
+    <td>Event Name</td>
+    <td>Target State</td>
+  </tr>
+  <tr>
+    <td>InitialState</td>
+    <td colspan="2">Initial State</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State01</td>
+    <td>Event01-02</td>
+    <td>State02</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State02</td>
+    <td>Event02-Final</td>
+    <td>FinalState</td>
+  </tr>
+  <tr>
+    <td>FinalState</td>
+    <td colspan="2">Final State</td>
+  </tr>
+
+</table>
+
+#### Event list
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">InitialState</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### Event01-02
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td>RTC::TimedLong</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### Event02-Final
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">FinalState</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td>RTC::TimedString</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+
+
+### InPorts definition
+
+
+### OutPorts definition
+
+
+### Service Port definition
+
+
+### Configuration definition
+
+
+## Demo
+
+## Requirement
+
+## Setup
+
+### Windows
+
+### Ubuntu
+
+## Usage
+
+## Running the tests
+
+## LICENCE
+
+
+
+
+## References
+
+
+
+
+## Author
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/RTC.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<rtc:RtcProfile rtc:version="0.3" rtc:id="RTC:VenderName:Category:ModuleName:1.0.0" xmlns:rtc="http://www.openrtp.org/namespaces/rtc" xmlns:rtcExt="http://www.openrtp.org/namespaces/rtc_ext" xmlns:rtcDoc="http://www.openrtp.org/namespaces/rtc_doc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <rtc:BasicInfo xsi:type="rtcExt:basic_info_ext" rtcExt:saveProject="FSMTest" rtc:updateDate="2019-12-20T00:07:52.000+09:00" rtc:creationDate="2019-12-19T22:49:56.000+09:00" rtc:version="1.0.0" rtc:vendor="VenderName" rtc:maxInstances="1" rtc:executionType="PeriodicExecutionContext" rtc:executionRate="1000.0" rtc:description="ModuleDescription" rtc:category="Category" rtc:componentKind="DataFlowComponent" rtc:activityType="PERIODIC" rtc:componentType="STATIC" rtc:name="ModuleName">
+        <rtcExt:Properties rtcExt:value="true" rtcExt:name="FSM"/>
+        <rtcExt:Properties rtcExt:value="StaticFSM" rtcExt:name="FSMType"/>
+    </rtc:BasicInfo>
+    <rtc:Actions>
+        <rtc:OnInitialize xsi:type="rtcDoc:action_status_doc" rtc:implemented="true"/>
+        <rtc:OnFinalize xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStartup xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnShutdown xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnActivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnDeactivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAborting xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnError xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnReset xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnExecute xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStateUpdate xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnRateChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAction xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+    </rtc:Actions>
+    <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedLong" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01-02">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedString" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02-Final">
+            <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
+        </rtc:Event>
+    </rtc:DataPorts>
+    <rtc:Language xsi:type="rtcExt:language_ext" rtc:kind="C++"/>
+</rtc:RtcProfile>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/include/ModuleName/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/include/ModuleName/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(hdrs ModuleName.h
+    ModuleNameFSM.h
+    PARENT_SCOPE
+    )

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/include/ModuleName/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/include/ModuleName/ModuleName.h
@@ -1,0 +1,280 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleName.h
+ * @brief ModuleDescription
+ * @date  $Date$
+ *
+ * $Id$
+ */
+
+#ifndef MODULENAME_H
+#define MODULENAME_H
+
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/idl/ExtendedDataTypesSkel.h>
+#include <rtm/idl/InterfaceDataTypesSkel.h>
+
+// Service implementation headers
+// <rtc-template block="service_impl_h">
+
+// </rtc-template>
+
+// Service Consumer stub headers
+// <rtc-template block="consumer_stub_h">
+
+// </rtc-template>
+
+#include <rtm/Manager.h>
+#include <rtm/DataFlowComponentBase.h>
+#include <rtm/CorbaPort.h>
+#include <rtm/DataInPort.h>
+#include <rtm/DataOutPort.h>
+
+// FSM headers
+
+#include <rtm/EventPort.h>
+// <rtc-template block="fsm_h">
+#include "ModuleNameFSM.h"
+// </rtc-template>
+
+
+/*!
+ * @class ModuleName
+ * @brief ModuleDescription
+ *
+ */
+class ModuleName
+  : public RTC::DataFlowComponentBase
+{
+ public:
+  /*!
+   * @brief constructor
+   * @param manager Maneger Object
+   */
+  ModuleName(RTC::Manager* manager);
+
+  /*!
+   * @brief destructor
+   */
+  ~ModuleName() override;
+
+  // <rtc-template block="public_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="public_operation">
+  
+  // </rtc-template>
+
+  // <rtc-template block="activity">
+  /***
+   *
+   * The initialize action (on CREATED->ALIVE transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+   RTC::ReturnCode_t onInitialize() override;
+
+  /***
+   *
+   * The finalize action (on ALIVE->END transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onFinalize() override;
+
+  /***
+   *
+   * The startup action when ExecutionContext startup
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStartup(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The shutdown action when ExecutionContext stop
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onShutdown(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The activated action (Active state entry action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The deactivated action (Active state exit action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The execution action that is invoked periodically
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The aborting action when main logic error occurred.
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onAborting(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The error action in ERROR state
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onError(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The reset action that is invoked resetting
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onReset(RTC::UniqueId ec_id) override;
+  
+  /***
+   *
+   * The state update action that is invoked after onExecute() action
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStateUpdate(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The action that is invoked when execution context's rate is changed
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id) override;
+  // </rtc-template>
+
+
+ protected:
+  // <rtc-template block="protected_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="protected_operation">
+  
+  // </rtc-template>
+
+  // Configuration variable declaration
+  // <rtc-template block="config_declare">
+
+  // </rtc-template>
+
+  // DataInPort declaration
+  // <rtc-template block="inport_declare">
+  
+  // </rtc-template>
+
+
+  // DataOutPort declaration
+  // <rtc-template block="outport_declare">
+  
+  // </rtc-template>
+
+  // CORBA Port declaration
+  // <rtc-template block="corbaport_declare">
+  
+  // </rtc-template>
+
+  // Service declaration
+  // <rtc-template block="service_declare">
+  
+  // </rtc-template>
+
+  // Consumer declaration
+  // <rtc-template block="consumer_declare">
+  
+  // </rtc-template>
+
+  // State machine declaration
+  // <rtc-template block="fsm_declare">
+  RTC::Machine<ModuleNameFsm::Top> m_fsm;
+  // </rtc-template>
+  
+  // EventPort declaration
+  // <rtc-template block="event_declare">
+  
+  RTC::EventInPort< RTC::Machine<ModuleNameFsm::Top> > m_FSMEventVarIn;
+  // </rtc-template>
+
+ private:
+  // <rtc-template block="private_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="private_operation">
+  
+  // </rtc-template>
+
+};
+
+
+extern "C"
+{
+  DLL_EXPORT void ModuleNameInit(RTC::Manager* manager);
+};
+
+#endif // MODULENAME_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/include/ModuleName/ModuleNameFSM.h
@@ -1,0 +1,75 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameFSM.h
+ * @date  $Date$
+ * $Id$
+ */
+
+#ifndef MODULENAMEFSM_H
+#define MODULENAMEFSM_H
+
+#include <rtm/StaticFSM.h>
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/RTC.h>
+
+class ModuleName;
+
+namespace ModuleNameFsm {
+
+  /*!
+   * @if jp
+   * @class TOP状態
+   *
+   *
+   * @else
+   * @brief TOP state
+   *
+   * @endif
+   */
+  FSM_TOPSTATE(Top) {
+    // Top state variables (visible to all substates)
+  
+    FSM_STATE(Top);
+
+    // Machine's event protocol
+    /*!
+     */
+    virtual void Event01-02(RTC::TimedLong data) {}
+    
+    /*!
+     */
+    virtual void Event02-Final(RTC::TimedString data) {}
+    
+  
+   private:
+     RTC::ReturnCode_t onInit() override;
+     RTC::ReturnCode_t onEntry() override;
+     RTC::ReturnCode_t onExit() override;
+  };
+
+  FSM_SUBSTATE(State01, Top) {
+    FSM_STATE(State01);
+  
+
+    // Event handler
+    void Event01-02(RTC::TimedLong data) override;
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+  };
+
+  FSM_SUBSTATE(State02, Top) {
+    FSM_STATE(State02);
+  
+
+    // Event handler
+    void Event02-Final(RTC::TimedString data) override;
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+  };
+
+
+} //end namespace 'ModuleNameFSM'
+
+#endif // MODULENAMEFSM_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/src/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/src/CMakeLists.txt
@@ -1,0 +1,64 @@
+set(comp_srcs ModuleName.cpp ModuleNameFSM.cpp)
+set(standalone_srcs ModuleNameComp.cpp)
+
+if(${OPENRTM_VERSION_MAJOR} LESS 2)
+  set(OPENRTM_CFLAGS ${OPENRTM_CFLAGS} ${OMNIORB_CFLAGS})
+  set(OPENRTM_INCLUDE_DIRS ${OPENRTM_INCLUDE_DIRS} ${OMNIORB_INCLUDE_DIRS})
+  set(OPENRTM_LIBRARY_DIRS ${OPENRTM_LIBRARY_DIRS} ${OMNIORB_LIBRARY_DIRS})
+endif()
+
+if (DEFINED OPENRTM_INCLUDE_DIRS)
+  string(REGEX REPLACE "-I" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+endif (DEFINED OPENRTM_INCLUDE_DIRS)
+
+if (DEFINED OPENRTM_LIBRARY_DIRS)
+  string(REGEX REPLACE "-L" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+endif (DEFINED OPENRTM_LIBRARY_DIRS)
+
+if (DEFINED OPENRTM_LIBRARIES)
+  string(REGEX REPLACE "-l" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+endif (DEFINED OPENRTM_LIBRARIES)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME})
+include_directories(${PROJECT_BINARY_DIR})
+include_directories(${PROJECT_BINARY_DIR}/idl)
+include_directories(${OPENRTM_INCLUDE_DIRS})
+add_definitions(${OPENRTM_CFLAGS})
+
+MAP_ADD_STR(comp_hdrs "../" comp_headers)
+
+link_directories(${OPENRTM_LIBRARY_DIRS})
+
+add_library(${PROJECT_NAME} ${LIB_TYPE} ${comp_srcs}
+  ${comp_headers} ${ALL_IDL_SRCS})
+set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
+set_source_files_properties(${ALL_IDL_SRCS} PROPERTIES GENERATED 1)
+if(NOT TARGET ALL_IDL_TGT)
+ add_custom_target(ALL_IDL_TGT)
+endif(NOT TARGET ALL_IDL_TGT)
+add_dependencies(${PROJECT_NAME} ALL_IDL_TGT)
+target_link_libraries(${PROJECT_NAME} ${OPENRTM_LIBRARIES})
+
+add_executable(${PROJECT_NAME}Comp ${standalone_srcs}
+  ${comp_srcs} ${comp_headers} ${ALL_IDL_SRCS})
+add_dependencies(${PROJECT_NAME}Comp ALL_IDL_TGT)
+target_link_libraries(${PROJECT_NAME}Comp ${OPENRTM_LIBRARIES})
+
+install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}Comp
+    EXPORT ${PROJECT_NAME}
+    RUNTIME DESTINATION ${INSTALL_PREFIX} COMPONENT component
+    LIBRARY DESTINATION ${INSTALL_PREFIX} COMPONENT component
+    ARCHIVE DESTINATION ${INSTALL_PREFIX} COMPONENT component)
+
+install(FILES ${PROJECT_SOURCE_DIR}/RTC.xml DESTINATION ${INSTALL_PREFIX}
+        COMPONENT component)

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/src/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/src/ModuleName.cpp
@@ -1,0 +1,180 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleName.cpp
+ * @brief ModuleDescription
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include "ModuleName.h"
+
+// Module specification
+// <rtc-template block="module_spec">
+static const char* modulename_spec[] =
+  {
+    "implementation_id", "ModuleName",
+    "type_name",         "ModuleName",
+    "description",       "ModuleDescription",
+    "version",           "1.0.0",
+    "vendor",            "VenderName",
+    "category",          "Category",
+    "activity_type",     "PERIODIC",
+    "kind",              "DataFlowComponent",
+    "max_instance",      "1",
+    "language",          "C++",
+    "lang_type",         "compile",
+    ""
+  };
+// </rtc-template>
+
+/*!
+ * @brief constructor
+ * @param manager Maneger Object
+ */
+ModuleName::ModuleName(RTC::Manager* manager)
+    // <rtc-template block="initializer">
+  : RTC::DataFlowComponentBase(manager),
+    m_fsm(this),
+    m_FSMEventIn("event", m_fsm)
+
+    // </rtc-template>
+{
+}
+
+/*!
+ * @brief destructor
+ */
+ModuleName::~ModuleName()
+{
+}
+
+
+
+RTC::ReturnCode_t ModuleName::onInitialize()
+{
+#ifdef ORB_IS_TAO
+  ::CORBA_Util::toRepositoryIdOfStruct<TimedLong>();
+#endif
+  // Registration: InPort/OutPort/Service
+  // <rtc-template block="registration">
+  // Set InPort buffers
+  
+  // Set OutPort buffer
+
+  // Set EventPort buffer
+  addInPort("event", m_FSMEventVarIn);
+  
+  // Set service provider to Ports
+  
+  // Set service consumers to Ports
+  
+  // Set CORBA Service Ports
+  
+  // </rtc-template>
+
+  // <rtc-template block="bind_config">
+  // </rtc-template>
+  // <rtc-template block="bind_event">
+  m_FSMEventVarIn.bindEvent("Event01-02", &ModuleNameFsm::Top::Event01-02);
+  m_FSMEventVarIn.bindEvent("Event02-Final", &ModuleNameFsm::Top::Event02-Final);
+  // </rtc-template>
+
+  
+  return RTC::RTC_OK;
+}
+
+/*
+RTC::ReturnCode_t ModuleName::onFinalize()
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onStartup(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onShutdown(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onActivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onDeactivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onExecute(RTC::UniqueId ec_id)
+{
+  m_fsm.run_event();
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onAborting(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onError(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onReset(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onStateUpdate(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onRateChanged(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+
+
+extern "C"
+{
+ 
+  void ModuleNameInit(RTC::Manager* manager)
+  {
+    coil::Properties profile(modulename_spec);
+    manager->registerFactory(profile,
+                             RTC::Create<ModuleName>,
+                             RTC::Delete<ModuleName>);
+  }
+  
+};
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/src/ModuleNameComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/src/ModuleNameComp.cpp
@@ -1,0 +1,129 @@
+﻿// -*- C++ -*-
+/*!
+ * @file ModuleNameComp.cpp
+ * @brief Standalone component
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include <rtm/Manager.h>
+#include <iostream>
+#include <string>
+#include <stdlib.h>
+#include "ModuleName.h"
+
+class OverwriteInstanceName
+  : public RTM::RtcLifecycleActionListener
+{
+public:
+  OverwriteInstanceName(int argc, char** argv)
+    : m_name(""), m_count(0)
+  {
+    for (size_t i = 0; i < argc; ++i)
+      {
+        std::string opt = argv[i];
+        if (opt.find("--instance_name=") == std::string::npos) { continue; }
+
+        coil::replaceString(opt, "--instance_name=", "");
+        if (opt.empty()) { continue; }
+
+        m_name = opt;
+      }
+  }
+  virtual ~OverwriteInstanceName() {}
+  virtual void preCreate(std::string& args)
+  {
+    if (m_count != 0 || m_name.empty()) { return; }
+    args = args + "?instance_name=" + m_name;
+    ++m_count;
+  };
+  virtual void postCreate(RTC::RTObject_impl*) {};
+  virtual void preConfigure(coil::Properties&) {};
+  virtual void postConfigure(coil::Properties&) {};
+  virtual void preInitialize() {};
+  virtual void postInitialize() {};
+private:
+  std::string m_name;
+  int32_t m_count;
+};
+
+void MyModuleInit(RTC::Manager* manager)
+{
+  ModuleNameInit(manager);
+  RTC::RtcBase* comp;
+
+  // Create a component
+  comp = manager->createComponent("ModuleName");
+
+  if (comp==NULL)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
+
+  // Example
+  // The following procedure is examples how handle RT-Components.
+  // These should not be in this function.
+
+  // Get the component's object reference
+//  RTC::RTObject_var rtobj;
+//  rtobj = RTC::RTObject::_narrow(manager->getPOA()->servant_to_reference(comp));
+
+  // Get the port list of the component
+//  PortServiceList* portlist;
+//  portlist = rtobj->get_ports();
+
+  // getting port profiles
+//  std::cout << "Number of Ports: ";
+//  std::cout << portlist->length() << std::endl << std::endl; 
+//  for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
+//  {
+//    PortService_ptr port;
+//    port = (*portlist)[i];
+//    std::cout << "Port" << i << " (name): ";
+//    std::cout << port->get_port_profile()->name << std::endl;
+//    
+//    RTC::PortInterfaceProfileList iflist;
+//    iflist = port->get_port_profile()->interfaces;
+//    std::cout << "---interfaces---" << std::endl;
+//    for (CORBA::ULong i(0), n(iflist.length()); i < n; ++i)
+//    {
+//      std::cout << "I/F name: ";
+//      std::cout << iflist[i].instance_name << std::endl;
+//      std::cout << "I/F type: ";
+//      std::cout << iflist[i].type_name << std::endl;
+//      const char* pol;
+//      pol = iflist[i].polarity == 0 ? "PROVIDED" : "REQUIRED";
+//      std::cout << "Polarity: " << pol << std::endl;
+//    }
+//    std::cout << "---properties---" << std::endl;
+//    NVUtil::dump(port->get_port_profile()->properties);
+//    std::cout << "----------------" << std::endl << std::endl;
+//  }
+
+  return;
+}
+
+int main (int argc, char** argv)
+{
+  RTC::Manager* manager;
+  manager = RTC::Manager::init(argc, argv);
+  manager->addRtcLifecycleActionListener(new OverwriteInstanceName(argc, argv), true);
+
+  // Set module initialization proceduer
+  // This procedure will be invoked in activateManager() function.
+  manager->setModuleInitProc(MyModuleInit);
+
+  // Activate manager and register to naming service
+  manager->activateManager();
+
+  // run the manager in blocking mode
+  // runManager(false) is the default.
+  manager->runManager();
+
+  // If you want to run the manager in non-blocking mode, do like this
+  // manager->runManager(true);
+
+  return 0;
+}

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/src/ModuleNameFSM.cpp
@@ -1,0 +1,50 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameFSM.cpp
+ * @date $Date$
+ * $Id$
+ */
+
+#include "ModuleNameFSM.h"
+
+namespace ModuleNameFsm {
+
+// Top state
+RTC::ReturnCode_t Top::onInit() {
+  setState<State01>();
+  return RTC::RTC_OK;
+}
+
+RTC::ReturnCode_t Top::onEntry() {
+  return RTC::RTC_OK;
+}
+
+RTC::ReturnCode_t Top::onExit() {
+  return RTC::RTC_OK;
+}
+
+//============================================================
+// State State01
+// RTC::ReturnCode_t State01::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+
+void State01::Event01-02(RTC::TimedLong data) {
+  setState<State02>();
+}
+
+
+//============================================================
+// State State02
+// RTC::ReturnCode_t State02::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+
+void State02::Event02-Final(RTC::TimedString data) {
+  setState<FinalState>();
+}
+
+
+} //end namespace 'ModuleNameFSM'

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/test/include/ModuleNameTest/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/test/include/ModuleNameTest/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(hdrs
+    ModuleNameTest.h
+    PARENT_SCOPE
+    )

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/test/include/ModuleNameTest/ModuleNameTest.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/test/include/ModuleNameTest/ModuleNameTest.h
@@ -1,0 +1,268 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameTest.h
+ * @brief ModuleDescription
+ * @date  $Date$
+ *
+ * $Id$
+ */
+
+#ifndef MODULENAME_TEST__H
+#define MODULENAME_TEST_H
+
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/idl/ExtendedDataTypesSkel.h>
+#include <rtm/idl/InterfaceDataTypesSkel.h>
+
+// Service implementation headers
+// <rtc-template block="service_impl_h">
+
+// </rtc-template>
+
+// Service Consumer stub headers
+// <rtc-template block="consumer_stub_h">
+
+// </rtc-template>
+
+#include <rtm/Manager.h>
+#include <rtm/DataFlowComponentBase.h>
+#include <rtm/CorbaPort.h>
+#include <rtm/DataInPort.h>
+#include <rtm/DataOutPort.h>
+
+/*!
+ * @class ModuleNameTest
+ * @brief ModuleDescription
+ *
+ */
+class ModuleNameTest
+  : public RTC::DataFlowComponentBase
+{
+ public:
+  /*!
+   * @brief constructor
+   * @param manager Maneger Object
+   */
+  ModuleNameTest(RTC::Manager* manager);
+
+  /*!
+   * @brief destructor
+   */
+  ~ModuleNameTest() override;
+
+  // <rtc-template block="public_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="public_operation">
+  
+  // </rtc-template>
+
+  // <rtc-template block="activity">
+  /***
+   *
+   * The initialize action (on CREATED->ALIVE transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+   RTC::ReturnCode_t onInitialize() override;
+
+  /***
+   *
+   * The finalize action (on ALIVE->END transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onFinalize() override;
+
+  /***
+   *
+   * The startup action when ExecutionContext startup
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStartup(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The shutdown action when ExecutionContext stop
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onShutdown(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The activated action (Active state entry action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The deactivated action (Active state exit action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The execution action that is invoked periodically
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The aborting action when main logic error occurred.
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onAborting(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The error action in ERROR state
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onError(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The reset action that is invoked resetting
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onReset(RTC::UniqueId ec_id) override;
+  
+  /***
+   *
+   * The state update action that is invoked after onExecute() action
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStateUpdate(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The action that is invoked when execution context's rate is changed
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id) override;
+  // </rtc-template>
+
+  bool runTest();
+
+ protected:
+  // <rtc-template block="protected_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="protected_operation">
+  
+  // </rtc-template>
+
+  // Configuration variable declaration
+  // <rtc-template block="config_declare">
+
+  // </rtc-template>
+
+  // DataInPort declaration
+  // <rtc-template block="inport_declare">
+  
+  // </rtc-template>
+
+
+  // DataOutPort declaration
+  // <rtc-template block="outport_declare">
+    RTC::TimedLong m_Event01-02;
+    RTC::OutPort<RTC::TimedLong> m_Event01-02Out;
+    
+    RTC::TimedString m_Event02-Final;
+    RTC::OutPort<RTC::TimedString> m_Event02-FinalOut;
+    
+  
+  // </rtc-template>
+
+  // CORBA Port declaration
+  // <rtc-template block="corbaport_declare">
+  
+  // </rtc-template>
+
+  // Service declaration
+  // <rtc-template block="service_declare">
+  
+  // </rtc-template>
+
+  // Consumer declaration
+  // <rtc-template block="consumer_declare">
+  
+  // </rtc-template>
+
+ private:
+  // <rtc-template block="private_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="private_operation">
+  
+  // </rtc-template>
+
+};
+
+
+extern "C"
+{
+  DLL_EXPORT void ModuleNameTestInit(RTC::Manager* manager);
+};
+
+#endif // MODULENAME_TEST_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/test/src/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/test/src/CMakeLists.txt
@@ -1,0 +1,57 @@
+set(comp_srcs
+   ModuleNameTest.cpp
+   )
+set(standalone_srcs ModuleNameTestComp.cpp)
+
+if(${OPENRTM_VERSION_MAJOR} LESS 2)
+  set(OPENRTM_CFLAGS ${OPENRTM_CFLAGS} ${OMNIORB_CFLAGS})
+  set(OPENRTM_INCLUDE_DIRS ${OPENRTM_INCLUDE_DIRS} ${OMNIORB_INCLUDE_DIRS})
+  set(OPENRTM_LIBRARY_DIRS ${OPENRTM_LIBRARY_DIRS} ${OMNIORB_LIBRARY_DIRS})
+endif()
+
+if (DEFINED OPENRTM_INCLUDE_DIRS)
+  string(REGEX REPLACE "-I" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+endif (DEFINED OPENRTM_INCLUDE_DIRS)
+
+if (DEFINED OPENRTM_LIBRARY_DIRS)
+  string(REGEX REPLACE "-L" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+endif (DEFINED OPENRTM_LIBRARY_DIRS)
+
+if (DEFINED OPENRTM_LIBRARIES)
+  string(REGEX REPLACE "-l" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+endif (DEFINED OPENRTM_LIBRARIES)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME})
+include_directories(${PROJECT_SOURCE_DIR}/test/include)
+include_directories(${PROJECT_SOURCE_DIR}/test/include/${PROJECT_NAME}Test)
+include_directories(${PROJECT_BINARY_DIR})
+include_directories(${PROJECT_BINARY_DIR}/idl)
+include_directories(${OPENRTM_INCLUDE_DIRS})
+add_definitions(${OPENRTM_CFLAGS})
+
+MAP_ADD_STR(comp_test_hdrs "../" comp_headers)
+
+link_directories(${OPENRTM_LIBRARY_DIRS})
+
+if(NOT TARGET ALL_IDL_TGT)
+ add_custom_target(ALL_IDL_TGT)
+endif(NOT TARGET ALL_IDL_TGT)
+
+add_executable(${PROJECT_NAME}Test ${standalone_srcs}
+  ${comp_srcs} ${comp_headers} ${ALL_IDL_SRCS})
+set_source_files_properties(${ALL_IDL_SRCS} PROPERTIES GENERATED 1)
+add_dependencies(${PROJECT_NAME}Test ${PROJECT_NAME})
+target_link_libraries(${PROJECT_NAME}Test ${OPENRTM_LIBRARIES} ${PROJECT_NAME})
+set_property(TARGET ${PROJECT_NAME}Test PROPERTY CXX_STANDARD 11)
+
+add_test(NAME ${PROJECT_NAME}_test COMMAND $<TARGET_FILE:${PROJECT_NAME}Test> -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event01-02&fsm_event_name=Event01-02,${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event02-Final&fsm_event_name=Event02-Final" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/test/src/ModuleNameTest.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/test/src/ModuleNameTest.cpp
@@ -1,0 +1,175 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameTest.cpp
+ * @brief ModuleDescription
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include "ModuleNameTest.h"
+
+// Module specification
+// <rtc-template block="module_spec">
+static const char* modulename_spec[] =
+  {
+    "implementation_id", "ModuleNameTest",
+    "type_name",         "ModuleNameTest",
+    "description",       "ModuleDescription",
+    "version",           "1.0.0",
+    "vendor",            "VenderName",
+    "category",          "Category",
+    "activity_type",     "PERIODIC",
+    "kind",              "DataFlowComponent",
+    "max_instance",      "1",
+    "language",          "C++",
+    "lang_type",         "compile",
+    ""
+  };
+// </rtc-template>
+
+/*!
+ * @brief constructor
+ * @param manager Maneger Object
+ */
+ModuleNameTest::ModuleNameTest(RTC::Manager* manager)
+    // <rtc-template block="initializer">
+  : RTC::DataFlowComponentBase(manager)
+,
+    m_Event01-02Out("Event01-02", m_Event01-02),
+    m_Event02-FinalOut("Event02-Final", m_Event02-Final)
+    // </rtc-template>
+{
+}
+
+/*!
+ * @brief destructor
+ */
+ModuleNameTest::~ModuleNameTest()
+{
+}
+
+
+
+RTC::ReturnCode_t ModuleNameTest::onInitialize()
+{
+  // Registration: InPort/OutPort/Service
+  // <rtc-template block="registration">
+  // Set InPort buffers
+  
+  // Set OutPort buffer
+  addOutPort("Event01-02", m_Event01-02Out);
+  addOutPort("Event02-Final", m_Event02-FinalOut);
+  
+  // Set service provider to Ports
+  
+  // Set service consumers to Ports
+  
+  // Set CORBA Service Ports
+  
+  // </rtc-template>
+
+  // <rtc-template block="bind_config">
+  // </rtc-template>
+  
+  return RTC::RTC_OK;
+}
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onFinalize()
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onStartup(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onShutdown(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onActivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onDeactivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onExecute(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onAborting(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onError(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onReset(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onStateUpdate(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onRateChanged(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+
+bool ModuleNameTest::runTest()
+{
+    return true;
+}
+
+
+extern "C"
+{
+ 
+  void ModuleNameTestInit(RTC::Manager* manager)
+  {
+    coil::Properties profile(modulename_spec);
+    manager->registerFactory(profile,
+                             RTC::Create<ModuleNameTest>,
+                             RTC::Delete<ModuleNameTest>);
+  }
+  
+};
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/test/src/ModuleNameTestComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/test/src/ModuleNameTestComp.cpp
@@ -1,0 +1,135 @@
+﻿// -*- C++ -*-
+/*!
+ * @file ModuleNameTestComp.cpp
+ * @brief Standalone component
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include <rtm/Manager.h>
+#include <iostream>
+#include <string>
+#include <stdlib.h>
+#include <rtm/CORBA_RTCUtil.h>
+#include "ModuleNameTest.h"
+#include "ModuleName.h"
+
+
+void MyModuleInit(RTC::Manager* manager)
+{
+  ModuleNameTestInit(manager);
+  ModuleNameInit(manager);
+  RTC::RtcBase* comp;
+
+  // Create a component
+  comp = manager->createComponent("ModuleNameTest");
+
+  if (comp==nullptr)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
+
+  // Example
+  // The following procedure is examples how handle RT-Components.
+  // These should not be in this function.
+
+  // Get the component's object reference
+//  RTC::RTObject_var rtobj;
+//  rtobj = RTC::RTObject::_narrow(manager->getPOA()->servant_to_reference(comp));
+
+  // Get the port list of the component
+//  PortServiceList* portlist;
+//  portlist = rtobj->get_ports();
+
+  // getting port profiles
+//  std::cout << "Number of Ports: ";
+//  std::cout << portlist->length() << std::endl << std::endl; 
+//  for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
+//  {
+//    PortService_ptr port;
+//    port = (*portlist)[i];
+//    std::cout << "Port" << i << " (name): ";
+//    std::cout << port->get_port_profile()->name << std::endl;
+//    
+//    RTC::PortInterfaceProfileList iflist;
+//    iflist = port->get_port_profile()->interfaces;
+//    std::cout << "---interfaces---" << std::endl;
+//    for (CORBA::ULong i(0), n(iflist.length()); i < n; ++i)
+//    {
+//      std::cout << "I/F name: ";
+//      std::cout << iflist[i].instance_name << std::endl;
+//      std::cout << "I/F type: ";
+//      std::cout << iflist[i].type_name << std::endl;
+//      const char* pol;
+//      pol = iflist[i].polarity == 0 ? "PROVIDED" : "REQUIRED";
+//      std::cout << "Polarity: " << pol << std::endl;
+//    }
+//    std::cout << "---properties---" << std::endl;
+//    NVUtil::dump(port->get_port_profile()->properties);
+//    std::cout << "----------------" << std::endl << std::endl;
+//  }
+
+  return;
+}
+
+bool RunTest()
+{
+  RTC::RtcBase* comp;
+  RTC::Manager &mamager = RTC::Manager::instance();
+  comp = mamager.getComponent("ModuleNameTest0");
+  if (comp == nullptr)
+  {
+    std::cerr << "Component get failed." << std::endl;
+    return false;
+  }
+
+  ModuleNameTest* testcomp = dynamic_cast<ModuleNameTest*>(comp);
+  if (testcomp == nullptr)
+  {
+    std::cerr << "Component get failed." << std::endl;
+    return false;
+  }
+
+  return testcomp->runTest();
+}
+
+int main (int argc, char** argv)
+{
+  RTC::Manager* manager;
+  manager = RTC::Manager::init(argc, argv);
+
+  // Set module initialization proceduer
+  // This procedure will be invoked in activateManager() function.
+  manager->setModuleInitProc(MyModuleInit);
+
+  // Activate manager and register to naming service
+  manager->activateManager();
+
+  // run the manager in blocking mode
+  // runManager(false) is the default.
+  // manager->runManager();
+
+  // If you want to run the manager in non-blocking mode, do like this
+  manager->runManager(true);
+
+  bool ret = RunTest();
+
+#if RTM_MAJOR_VERSION >= 2
+  manager->terminate();
+  manager->join();
+#else
+  manager->shutdown();
+#endif
+
+  
+  if (ret)
+  {
+    return 0;
+  }
+  else
+  {
+    return 1;
+  }
+}

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/ModuleNameFSM.scxml
@@ -1,0 +1,24 @@
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=854 h=400  -->
+
+ <state id="InitialState"><!--   node-size-and-position x=90 y=150 w=75 h=75  -->
+
+  <transition id="21" target="State01"></transition>
+
+ </state>
+
+ <state id="State01"><!--   node-size-and-position x=280 y=150 w=75 h=75  -->
+
+  <transition id="22" target="State02"></transition>
+
+ </state>
+
+ <state id="State02"><!--   node-size-and-position x=470 y=150 w=75 h=75  -->
+
+  <transition id="23" target="FinalState"></transition>
+
+ </state>
+
+ <final id="FinalState"><!--   node-size-and-position x=650 y=160 w=75 h=75  --></final>
+
+</scxml>
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/README.md
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/README.md
@@ -1,0 +1,278 @@
+﻿# ModuleName
+
+## Overview
+
+ModuleDescription
+
+## Description
+
+
+
+### Input and Output
+
+
+
+### Algorithm etc
+
+
+
+### Basic Information
+
+|  |  |
+----|---- 
+| Module Name | ModuleName |
+| Description | ModuleDescription |
+| Version | 1.0.0 |
+| Vendor | VenderName |
+| Category | Category |
+| Comp. Type | STATIC |
+| Act. Type | PERIODIC |
+| Kind | DataFlowComponent |
+| MAX Inst. | 1 |
+
+### Activity definition
+
+<table>
+  <tr>
+    <td rowspan="4">on_initialize</td>
+    <td colspan="2">implemented</td>
+    <tr>
+      <td>Description</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PreCondition</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PostCondition</td>
+      <td></td>
+    </tr>
+  </tr>
+  <tr>
+    <td>on_finalize</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_startup</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_shutdown</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_activated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_deactivated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_execute</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_aborting</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_error</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_reset</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_state_update</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_rate_changed</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+### EventPorts definition
+
+|  |  |
+----|---- 
+| Port Name | FSMEventPort |
+| FSM Type | StaticFSM |
+
+#### Node list
+
+<table>
+  <tr>
+    <td>State Name</td>
+    <td>Event Name</td>
+    <td>Target State</td>
+  </tr>
+  <tr>
+    <td>InitialState</td>
+    <td colspan="2">Initial State</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State01</td>
+    <td></td>
+    <td>State02</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State02</td>
+    <td></td>
+    <td>FinalState</td>
+  </tr>
+  <tr>
+    <td>FinalState</td>
+    <td colspan="2">Final State</td>
+  </tr>
+
+</table>
+
+#### Event list
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">InitialState</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">FinalState</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+
+
+### InPorts definition
+
+
+### OutPorts definition
+
+
+### Service Port definition
+
+
+### Configuration definition
+
+
+## Demo
+
+## Requirement
+
+## Setup
+
+### Windows
+
+### Ubuntu
+
+## Usage
+
+## Running the tests
+
+## LICENCE
+
+
+
+
+## References
+
+
+
+
+## Author
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/RTC.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<rtc:RtcProfile rtc:version="0.3" rtc:id="RTC:VenderName:Category:ModuleName:1.0.0" xmlns:rtc="http://www.openrtp.org/namespaces/rtc" xmlns:rtcExt="http://www.openrtp.org/namespaces/rtc_ext" xmlns:rtcDoc="http://www.openrtp.org/namespaces/rtc_doc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <rtc:BasicInfo xsi:type="rtcExt:basic_info_ext" rtcExt:saveProject="FSMTest" rtc:updateDate="2019-12-19T22:51:23.000+09:00" rtc:creationDate="2019-12-19T22:49:56.000+09:00" rtc:version="1.0.0" rtc:vendor="VenderName" rtc:maxInstances="1" rtc:executionType="PeriodicExecutionContext" rtc:executionRate="1000.0" rtc:description="ModuleDescription" rtc:category="Category" rtc:componentKind="DataFlowComponent" rtc:activityType="PERIODIC" rtc:componentType="STATIC" rtc:name="ModuleName">
+        <rtcExt:Properties rtcExt:value="true" rtcExt:name="FSM"/>
+        <rtcExt:Properties rtcExt:value="StaticFSM" rtcExt:name="FSMType"/>
+    </rtc:BasicInfo>
+    <rtc:Actions>
+        <rtc:OnInitialize xsi:type="rtcDoc:action_status_doc" rtc:implemented="true"/>
+        <rtc:OnFinalize xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStartup xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnShutdown xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnActivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnDeactivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAborting xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnError xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnReset xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnExecute xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStateUpdate xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnRateChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAction xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+    </rtc:Actions>
+    <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="" rtc:name="">
+            <rtcDoc:Doc/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="" rtc:name="">
+            <rtcDoc:Doc/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State01" rtc:source="InitialState" rtc:condition="" rtc:name="">
+            <rtcDoc:Doc/>
+        </rtc:Event>
+    </rtc:DataPorts>
+    <rtc:Language xsi:type="rtcExt:language_ext" rtc:kind="C++"/>
+</rtc:RtcProfile>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/include/ModuleName/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/include/ModuleName/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(hdrs ModuleName.h
+    ModuleNameFSM.h
+    PARENT_SCOPE
+    )

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/include/ModuleName/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/include/ModuleName/ModuleName.h
@@ -1,0 +1,280 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleName.h
+ * @brief ModuleDescription
+ * @date  $Date$
+ *
+ * $Id$
+ */
+
+#ifndef MODULENAME_H
+#define MODULENAME_H
+
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/idl/ExtendedDataTypesSkel.h>
+#include <rtm/idl/InterfaceDataTypesSkel.h>
+
+// Service implementation headers
+// <rtc-template block="service_impl_h">
+
+// </rtc-template>
+
+// Service Consumer stub headers
+// <rtc-template block="consumer_stub_h">
+
+// </rtc-template>
+
+#include <rtm/Manager.h>
+#include <rtm/DataFlowComponentBase.h>
+#include <rtm/CorbaPort.h>
+#include <rtm/DataInPort.h>
+#include <rtm/DataOutPort.h>
+
+// FSM headers
+
+#include <rtm/EventPort.h>
+// <rtc-template block="fsm_h">
+#include "ModuleNameFSM.h"
+// </rtc-template>
+
+
+/*!
+ * @class ModuleName
+ * @brief ModuleDescription
+ *
+ */
+class ModuleName
+  : public RTC::DataFlowComponentBase
+{
+ public:
+  /*!
+   * @brief constructor
+   * @param manager Maneger Object
+   */
+  ModuleName(RTC::Manager* manager);
+
+  /*!
+   * @brief destructor
+   */
+  ~ModuleName() override;
+
+  // <rtc-template block="public_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="public_operation">
+  
+  // </rtc-template>
+
+  // <rtc-template block="activity">
+  /***
+   *
+   * The initialize action (on CREATED->ALIVE transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+   RTC::ReturnCode_t onInitialize() override;
+
+  /***
+   *
+   * The finalize action (on ALIVE->END transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onFinalize() override;
+
+  /***
+   *
+   * The startup action when ExecutionContext startup
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStartup(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The shutdown action when ExecutionContext stop
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onShutdown(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The activated action (Active state entry action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The deactivated action (Active state exit action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The execution action that is invoked periodically
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The aborting action when main logic error occurred.
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onAborting(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The error action in ERROR state
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onError(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The reset action that is invoked resetting
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onReset(RTC::UniqueId ec_id) override;
+  
+  /***
+   *
+   * The state update action that is invoked after onExecute() action
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStateUpdate(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The action that is invoked when execution context's rate is changed
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id) override;
+  // </rtc-template>
+
+
+ protected:
+  // <rtc-template block="protected_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="protected_operation">
+  
+  // </rtc-template>
+
+  // Configuration variable declaration
+  // <rtc-template block="config_declare">
+
+  // </rtc-template>
+
+  // DataInPort declaration
+  // <rtc-template block="inport_declare">
+  
+  // </rtc-template>
+
+
+  // DataOutPort declaration
+  // <rtc-template block="outport_declare">
+  
+  // </rtc-template>
+
+  // CORBA Port declaration
+  // <rtc-template block="corbaport_declare">
+  
+  // </rtc-template>
+
+  // Service declaration
+  // <rtc-template block="service_declare">
+  
+  // </rtc-template>
+
+  // Consumer declaration
+  // <rtc-template block="consumer_declare">
+  
+  // </rtc-template>
+
+  // State machine declaration
+  // <rtc-template block="fsm_declare">
+  RTC::Machine<ModuleNameFsm::Top> m_fsm;
+  // </rtc-template>
+  
+  // EventPort declaration
+  // <rtc-template block="event_declare">
+  
+  RTC::EventInPort< RTC::Machine<ModuleNameFsm::Top> > m_FSMEventVarIn;
+  // </rtc-template>
+
+ private:
+  // <rtc-template block="private_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="private_operation">
+  
+  // </rtc-template>
+
+};
+
+
+extern "C"
+{
+  DLL_EXPORT void ModuleNameInit(RTC::Manager* manager);
+};
+
+#endif // MODULENAME_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/include/ModuleName/ModuleNameFSM.h
@@ -1,0 +1,65 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameFSM.h
+ * @date  $Date$
+ * $Id$
+ */
+
+#ifndef MODULENAMEFSM_H
+#define MODULENAMEFSM_H
+
+#include <rtm/StaticFSM.h>
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/RTC.h>
+
+class ModuleName;
+
+namespace ModuleNameFsm {
+
+  /*!
+   * @if jp
+   * @class TOP状態
+   *
+   *
+   * @else
+   * @brief TOP state
+   *
+   * @endif
+   */
+  FSM_TOPSTATE(Top) {
+    // Top state variables (visible to all substates)
+  
+    FSM_STATE(Top);
+
+    // Machine's event protocol
+  
+   private:
+     RTC::ReturnCode_t onInit() override;
+     RTC::ReturnCode_t onEntry() override;
+     RTC::ReturnCode_t onExit() override;
+  };
+
+  FSM_SUBSTATE(State01, Top) {
+    FSM_STATE(State01);
+  
+
+    // Event handler
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+  };
+
+  FSM_SUBSTATE(State02, Top) {
+    FSM_STATE(State02);
+  
+
+    // Event handler
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+  };
+
+
+} //end namespace 'ModuleNameFSM'
+
+#endif // MODULENAMEFSM_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/src/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/src/CMakeLists.txt
@@ -1,0 +1,64 @@
+set(comp_srcs ModuleName.cpp ModuleNameFSM.cpp)
+set(standalone_srcs ModuleNameComp.cpp)
+
+if(${OPENRTM_VERSION_MAJOR} LESS 2)
+  set(OPENRTM_CFLAGS ${OPENRTM_CFLAGS} ${OMNIORB_CFLAGS})
+  set(OPENRTM_INCLUDE_DIRS ${OPENRTM_INCLUDE_DIRS} ${OMNIORB_INCLUDE_DIRS})
+  set(OPENRTM_LIBRARY_DIRS ${OPENRTM_LIBRARY_DIRS} ${OMNIORB_LIBRARY_DIRS})
+endif()
+
+if (DEFINED OPENRTM_INCLUDE_DIRS)
+  string(REGEX REPLACE "-I" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+endif (DEFINED OPENRTM_INCLUDE_DIRS)
+
+if (DEFINED OPENRTM_LIBRARY_DIRS)
+  string(REGEX REPLACE "-L" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+endif (DEFINED OPENRTM_LIBRARY_DIRS)
+
+if (DEFINED OPENRTM_LIBRARIES)
+  string(REGEX REPLACE "-l" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+endif (DEFINED OPENRTM_LIBRARIES)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME})
+include_directories(${PROJECT_BINARY_DIR})
+include_directories(${PROJECT_BINARY_DIR}/idl)
+include_directories(${OPENRTM_INCLUDE_DIRS})
+add_definitions(${OPENRTM_CFLAGS})
+
+MAP_ADD_STR(comp_hdrs "../" comp_headers)
+
+link_directories(${OPENRTM_LIBRARY_DIRS})
+
+add_library(${PROJECT_NAME} ${LIB_TYPE} ${comp_srcs}
+  ${comp_headers} ${ALL_IDL_SRCS})
+set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
+set_source_files_properties(${ALL_IDL_SRCS} PROPERTIES GENERATED 1)
+if(NOT TARGET ALL_IDL_TGT)
+ add_custom_target(ALL_IDL_TGT)
+endif(NOT TARGET ALL_IDL_TGT)
+add_dependencies(${PROJECT_NAME} ALL_IDL_TGT)
+target_link_libraries(${PROJECT_NAME} ${OPENRTM_LIBRARIES})
+
+add_executable(${PROJECT_NAME}Comp ${standalone_srcs}
+  ${comp_srcs} ${comp_headers} ${ALL_IDL_SRCS})
+add_dependencies(${PROJECT_NAME}Comp ALL_IDL_TGT)
+target_link_libraries(${PROJECT_NAME}Comp ${OPENRTM_LIBRARIES})
+
+install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}Comp
+    EXPORT ${PROJECT_NAME}
+    RUNTIME DESTINATION ${INSTALL_PREFIX} COMPONENT component
+    LIBRARY DESTINATION ${INSTALL_PREFIX} COMPONENT component
+    ARCHIVE DESTINATION ${INSTALL_PREFIX} COMPONENT component)
+
+install(FILES ${PROJECT_SOURCE_DIR}/RTC.xml DESTINATION ${INSTALL_PREFIX}
+        COMPONENT component)

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/src/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/src/ModuleName.cpp
@@ -1,0 +1,178 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleName.cpp
+ * @brief ModuleDescription
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include "ModuleName.h"
+
+// Module specification
+// <rtc-template block="module_spec">
+static const char* modulename_spec[] =
+  {
+    "implementation_id", "ModuleName",
+    "type_name",         "ModuleName",
+    "description",       "ModuleDescription",
+    "version",           "1.0.0",
+    "vendor",            "VenderName",
+    "category",          "Category",
+    "activity_type",     "PERIODIC",
+    "kind",              "DataFlowComponent",
+    "max_instance",      "1",
+    "language",          "C++",
+    "lang_type",         "compile",
+    ""
+  };
+// </rtc-template>
+
+/*!
+ * @brief constructor
+ * @param manager Maneger Object
+ */
+ModuleName::ModuleName(RTC::Manager* manager)
+    // <rtc-template block="initializer">
+  : RTC::DataFlowComponentBase(manager),
+    m_fsm(this),
+    m_FSMEventIn("event", m_fsm)
+
+    // </rtc-template>
+{
+}
+
+/*!
+ * @brief destructor
+ */
+ModuleName::~ModuleName()
+{
+}
+
+
+
+RTC::ReturnCode_t ModuleName::onInitialize()
+{
+#ifdef ORB_IS_TAO
+  ::CORBA_Util::toRepositoryIdOfStruct<TimedLong>();
+#endif
+  // Registration: InPort/OutPort/Service
+  // <rtc-template block="registration">
+  // Set InPort buffers
+  
+  // Set OutPort buffer
+
+  // Set EventPort buffer
+  addInPort("event", m_FSMEventVarIn);
+  
+  // Set service provider to Ports
+  
+  // Set service consumers to Ports
+  
+  // Set CORBA Service Ports
+  
+  // </rtc-template>
+
+  // <rtc-template block="bind_config">
+  // </rtc-template>
+  // <rtc-template block="bind_event">
+  // </rtc-template>
+
+  
+  return RTC::RTC_OK;
+}
+
+/*
+RTC::ReturnCode_t ModuleName::onFinalize()
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onStartup(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onShutdown(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onActivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onDeactivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onExecute(RTC::UniqueId ec_id)
+{
+  m_fsm.run_event();
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onAborting(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onError(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onReset(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onStateUpdate(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onRateChanged(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+
+
+extern "C"
+{
+ 
+  void ModuleNameInit(RTC::Manager* manager)
+  {
+    coil::Properties profile(modulename_spec);
+    manager->registerFactory(profile,
+                             RTC::Create<ModuleName>,
+                             RTC::Delete<ModuleName>);
+  }
+  
+};
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/src/ModuleNameComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/src/ModuleNameComp.cpp
@@ -1,0 +1,129 @@
+﻿// -*- C++ -*-
+/*!
+ * @file ModuleNameComp.cpp
+ * @brief Standalone component
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include <rtm/Manager.h>
+#include <iostream>
+#include <string>
+#include <stdlib.h>
+#include "ModuleName.h"
+
+class OverwriteInstanceName
+  : public RTM::RtcLifecycleActionListener
+{
+public:
+  OverwriteInstanceName(int argc, char** argv)
+    : m_name(""), m_count(0)
+  {
+    for (size_t i = 0; i < argc; ++i)
+      {
+        std::string opt = argv[i];
+        if (opt.find("--instance_name=") == std::string::npos) { continue; }
+
+        coil::replaceString(opt, "--instance_name=", "");
+        if (opt.empty()) { continue; }
+
+        m_name = opt;
+      }
+  }
+  virtual ~OverwriteInstanceName() {}
+  virtual void preCreate(std::string& args)
+  {
+    if (m_count != 0 || m_name.empty()) { return; }
+    args = args + "?instance_name=" + m_name;
+    ++m_count;
+  };
+  virtual void postCreate(RTC::RTObject_impl*) {};
+  virtual void preConfigure(coil::Properties&) {};
+  virtual void postConfigure(coil::Properties&) {};
+  virtual void preInitialize() {};
+  virtual void postInitialize() {};
+private:
+  std::string m_name;
+  int32_t m_count;
+};
+
+void MyModuleInit(RTC::Manager* manager)
+{
+  ModuleNameInit(manager);
+  RTC::RtcBase* comp;
+
+  // Create a component
+  comp = manager->createComponent("ModuleName");
+
+  if (comp==NULL)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
+
+  // Example
+  // The following procedure is examples how handle RT-Components.
+  // These should not be in this function.
+
+  // Get the component's object reference
+//  RTC::RTObject_var rtobj;
+//  rtobj = RTC::RTObject::_narrow(manager->getPOA()->servant_to_reference(comp));
+
+  // Get the port list of the component
+//  PortServiceList* portlist;
+//  portlist = rtobj->get_ports();
+
+  // getting port profiles
+//  std::cout << "Number of Ports: ";
+//  std::cout << portlist->length() << std::endl << std::endl; 
+//  for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
+//  {
+//    PortService_ptr port;
+//    port = (*portlist)[i];
+//    std::cout << "Port" << i << " (name): ";
+//    std::cout << port->get_port_profile()->name << std::endl;
+//    
+//    RTC::PortInterfaceProfileList iflist;
+//    iflist = port->get_port_profile()->interfaces;
+//    std::cout << "---interfaces---" << std::endl;
+//    for (CORBA::ULong i(0), n(iflist.length()); i < n; ++i)
+//    {
+//      std::cout << "I/F name: ";
+//      std::cout << iflist[i].instance_name << std::endl;
+//      std::cout << "I/F type: ";
+//      std::cout << iflist[i].type_name << std::endl;
+//      const char* pol;
+//      pol = iflist[i].polarity == 0 ? "PROVIDED" : "REQUIRED";
+//      std::cout << "Polarity: " << pol << std::endl;
+//    }
+//    std::cout << "---properties---" << std::endl;
+//    NVUtil::dump(port->get_port_profile()->properties);
+//    std::cout << "----------------" << std::endl << std::endl;
+//  }
+
+  return;
+}
+
+int main (int argc, char** argv)
+{
+  RTC::Manager* manager;
+  manager = RTC::Manager::init(argc, argv);
+  manager->addRtcLifecycleActionListener(new OverwriteInstanceName(argc, argv), true);
+
+  // Set module initialization proceduer
+  // This procedure will be invoked in activateManager() function.
+  manager->setModuleInitProc(MyModuleInit);
+
+  // Activate manager and register to naming service
+  manager->activateManager();
+
+  // run the manager in blocking mode
+  // runManager(false) is the default.
+  manager->runManager();
+
+  // If you want to run the manager in non-blocking mode, do like this
+  // manager->runManager(true);
+
+  return 0;
+}

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/src/ModuleNameFSM.cpp
@@ -1,0 +1,42 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameFSM.cpp
+ * @date $Date$
+ * $Id$
+ */
+
+#include "ModuleNameFSM.h"
+
+namespace ModuleNameFsm {
+
+// Top state
+RTC::ReturnCode_t Top::onInit() {
+  setState<State01>();
+  return RTC::RTC_OK;
+}
+
+RTC::ReturnCode_t Top::onEntry() {
+  return RTC::RTC_OK;
+}
+
+RTC::ReturnCode_t Top::onExit() {
+  return RTC::RTC_OK;
+}
+
+//============================================================
+// State State01
+// RTC::ReturnCode_t State01::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+
+
+//============================================================
+// State State02
+// RTC::ReturnCode_t State02::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+
+
+} //end namespace 'ModuleNameFSM'

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/test/include/ModuleNameTest/ModuleNameTest.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/test/include/ModuleNameTest/ModuleNameTest.h
@@ -1,0 +1,262 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameTest.h
+ * @brief ModuleDescription
+ * @date  $Date$
+ *
+ * $Id$
+ */
+
+#ifndef MODULENAME_TEST__H
+#define MODULENAME_TEST_H
+
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/idl/ExtendedDataTypesSkel.h>
+#include <rtm/idl/InterfaceDataTypesSkel.h>
+
+// Service implementation headers
+// <rtc-template block="service_impl_h">
+
+// </rtc-template>
+
+// Service Consumer stub headers
+// <rtc-template block="consumer_stub_h">
+
+// </rtc-template>
+
+#include <rtm/Manager.h>
+#include <rtm/DataFlowComponentBase.h>
+#include <rtm/CorbaPort.h>
+#include <rtm/DataInPort.h>
+#include <rtm/DataOutPort.h>
+
+/*!
+ * @class ModuleNameTest
+ * @brief ModuleDescription
+ *
+ */
+class ModuleNameTest
+  : public RTC::DataFlowComponentBase
+{
+ public:
+  /*!
+   * @brief constructor
+   * @param manager Maneger Object
+   */
+  ModuleNameTest(RTC::Manager* manager);
+
+  /*!
+   * @brief destructor
+   */
+  ~ModuleNameTest() override;
+
+  // <rtc-template block="public_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="public_operation">
+  
+  // </rtc-template>
+
+  // <rtc-template block="activity">
+  /***
+   *
+   * The initialize action (on CREATED->ALIVE transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+   RTC::ReturnCode_t onInitialize() override;
+
+  /***
+   *
+   * The finalize action (on ALIVE->END transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onFinalize() override;
+
+  /***
+   *
+   * The startup action when ExecutionContext startup
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStartup(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The shutdown action when ExecutionContext stop
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onShutdown(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The activated action (Active state entry action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The deactivated action (Active state exit action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The execution action that is invoked periodically
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The aborting action when main logic error occurred.
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onAborting(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The error action in ERROR state
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onError(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The reset action that is invoked resetting
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onReset(RTC::UniqueId ec_id) override;
+  
+  /***
+   *
+   * The state update action that is invoked after onExecute() action
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStateUpdate(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The action that is invoked when execution context's rate is changed
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id) override;
+  // </rtc-template>
+
+  bool runTest();
+
+ protected:
+  // <rtc-template block="protected_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="protected_operation">
+  
+  // </rtc-template>
+
+  // Configuration variable declaration
+  // <rtc-template block="config_declare">
+
+  // </rtc-template>
+
+  // DataInPort declaration
+  // <rtc-template block="inport_declare">
+  
+  // </rtc-template>
+
+
+  // DataOutPort declaration
+  // <rtc-template block="outport_declare">
+  
+  // </rtc-template>
+
+  // CORBA Port declaration
+  // <rtc-template block="corbaport_declare">
+  
+  // </rtc-template>
+
+  // Service declaration
+  // <rtc-template block="service_declare">
+  
+  // </rtc-template>
+
+  // Consumer declaration
+  // <rtc-template block="consumer_declare">
+  
+  // </rtc-template>
+
+ private:
+  // <rtc-template block="private_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="private_operation">
+  
+  // </rtc-template>
+
+};
+
+
+extern "C"
+{
+  DLL_EXPORT void ModuleNameTestInit(RTC::Manager* manager);
+};
+
+#endif // MODULENAME_TEST_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/test/src/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/test/src/CMakeLists.txt
@@ -1,0 +1,57 @@
+set(comp_srcs
+   ModuleNameTest.cpp
+   )
+set(standalone_srcs ModuleNameTestComp.cpp)
+
+if(${OPENRTM_VERSION_MAJOR} LESS 2)
+  set(OPENRTM_CFLAGS ${OPENRTM_CFLAGS} ${OMNIORB_CFLAGS})
+  set(OPENRTM_INCLUDE_DIRS ${OPENRTM_INCLUDE_DIRS} ${OMNIORB_INCLUDE_DIRS})
+  set(OPENRTM_LIBRARY_DIRS ${OPENRTM_LIBRARY_DIRS} ${OMNIORB_LIBRARY_DIRS})
+endif()
+
+if (DEFINED OPENRTM_INCLUDE_DIRS)
+  string(REGEX REPLACE "-I" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+endif (DEFINED OPENRTM_INCLUDE_DIRS)
+
+if (DEFINED OPENRTM_LIBRARY_DIRS)
+  string(REGEX REPLACE "-L" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+endif (DEFINED OPENRTM_LIBRARY_DIRS)
+
+if (DEFINED OPENRTM_LIBRARIES)
+  string(REGEX REPLACE "-l" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+endif (DEFINED OPENRTM_LIBRARIES)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME})
+include_directories(${PROJECT_SOURCE_DIR}/test/include)
+include_directories(${PROJECT_SOURCE_DIR}/test/include/${PROJECT_NAME}Test)
+include_directories(${PROJECT_BINARY_DIR})
+include_directories(${PROJECT_BINARY_DIR}/idl)
+include_directories(${OPENRTM_INCLUDE_DIRS})
+add_definitions(${OPENRTM_CFLAGS})
+
+MAP_ADD_STR(comp_test_hdrs "../" comp_headers)
+
+link_directories(${OPENRTM_LIBRARY_DIRS})
+
+if(NOT TARGET ALL_IDL_TGT)
+ add_custom_target(ALL_IDL_TGT)
+endif(NOT TARGET ALL_IDL_TGT)
+
+add_executable(${PROJECT_NAME}Test ${standalone_srcs}
+  ${comp_srcs} ${comp_headers} ${ALL_IDL_SRCS})
+set_source_files_properties(${ALL_IDL_SRCS} PROPERTIES GENERATED 1)
+add_dependencies(${PROJECT_NAME}Test ${PROJECT_NAME})
+target_link_libraries(${PROJECT_NAME}Test ${OPENRTM_LIBRARIES} ${PROJECT_NAME})
+set_property(TARGET ${PROJECT_NAME}Test PROPERTY CXX_STANDARD 11)
+
+add_test(NAME ${PROJECT_NAME}_test COMMAND $<TARGET_FILE:${PROJECT_NAME}Test> -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/test/src/ModuleNameTest.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/test/src/ModuleNameTest.cpp
@@ -1,0 +1,171 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameTest.cpp
+ * @brief ModuleDescription
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include "ModuleNameTest.h"
+
+// Module specification
+// <rtc-template block="module_spec">
+static const char* modulename_spec[] =
+  {
+    "implementation_id", "ModuleNameTest",
+    "type_name",         "ModuleNameTest",
+    "description",       "ModuleDescription",
+    "version",           "1.0.0",
+    "vendor",            "VenderName",
+    "category",          "Category",
+    "activity_type",     "PERIODIC",
+    "kind",              "DataFlowComponent",
+    "max_instance",      "1",
+    "language",          "C++",
+    "lang_type",         "compile",
+    ""
+  };
+// </rtc-template>
+
+/*!
+ * @brief constructor
+ * @param manager Maneger Object
+ */
+ModuleNameTest::ModuleNameTest(RTC::Manager* manager)
+    // <rtc-template block="initializer">
+  : RTC::DataFlowComponentBase(manager)
+
+    // </rtc-template>
+{
+}
+
+/*!
+ * @brief destructor
+ */
+ModuleNameTest::~ModuleNameTest()
+{
+}
+
+
+
+RTC::ReturnCode_t ModuleNameTest::onInitialize()
+{
+  // Registration: InPort/OutPort/Service
+  // <rtc-template block="registration">
+  // Set InPort buffers
+  
+  // Set OutPort buffer
+  
+  // Set service provider to Ports
+  
+  // Set service consumers to Ports
+  
+  // Set CORBA Service Ports
+  
+  // </rtc-template>
+
+  // <rtc-template block="bind_config">
+  // </rtc-template>
+  
+  return RTC::RTC_OK;
+}
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onFinalize()
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onStartup(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onShutdown(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onActivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onDeactivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onExecute(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onAborting(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onError(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onReset(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onStateUpdate(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onRateChanged(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+
+bool ModuleNameTest::runTest()
+{
+    return true;
+}
+
+
+extern "C"
+{
+ 
+  void ModuleNameTestInit(RTC::Manager* manager)
+  {
+    coil::Properties profile(modulename_spec);
+    manager->registerFactory(profile,
+                             RTC::Create<ModuleNameTest>,
+                             RTC::Delete<ModuleNameTest>);
+  }
+  
+};
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/test/src/ModuleNameTestComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/test/src/ModuleNameTestComp.cpp
@@ -1,0 +1,135 @@
+﻿// -*- C++ -*-
+/*!
+ * @file ModuleNameTestComp.cpp
+ * @brief Standalone component
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include <rtm/Manager.h>
+#include <iostream>
+#include <string>
+#include <stdlib.h>
+#include <rtm/CORBA_RTCUtil.h>
+#include "ModuleNameTest.h"
+#include "ModuleName.h"
+
+
+void MyModuleInit(RTC::Manager* manager)
+{
+  ModuleNameTestInit(manager);
+  ModuleNameInit(manager);
+  RTC::RtcBase* comp;
+
+  // Create a component
+  comp = manager->createComponent("ModuleNameTest");
+
+  if (comp==nullptr)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
+
+  // Example
+  // The following procedure is examples how handle RT-Components.
+  // These should not be in this function.
+
+  // Get the component's object reference
+//  RTC::RTObject_var rtobj;
+//  rtobj = RTC::RTObject::_narrow(manager->getPOA()->servant_to_reference(comp));
+
+  // Get the port list of the component
+//  PortServiceList* portlist;
+//  portlist = rtobj->get_ports();
+
+  // getting port profiles
+//  std::cout << "Number of Ports: ";
+//  std::cout << portlist->length() << std::endl << std::endl; 
+//  for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
+//  {
+//    PortService_ptr port;
+//    port = (*portlist)[i];
+//    std::cout << "Port" << i << " (name): ";
+//    std::cout << port->get_port_profile()->name << std::endl;
+//    
+//    RTC::PortInterfaceProfileList iflist;
+//    iflist = port->get_port_profile()->interfaces;
+//    std::cout << "---interfaces---" << std::endl;
+//    for (CORBA::ULong i(0), n(iflist.length()); i < n; ++i)
+//    {
+//      std::cout << "I/F name: ";
+//      std::cout << iflist[i].instance_name << std::endl;
+//      std::cout << "I/F type: ";
+//      std::cout << iflist[i].type_name << std::endl;
+//      const char* pol;
+//      pol = iflist[i].polarity == 0 ? "PROVIDED" : "REQUIRED";
+//      std::cout << "Polarity: " << pol << std::endl;
+//    }
+//    std::cout << "---properties---" << std::endl;
+//    NVUtil::dump(port->get_port_profile()->properties);
+//    std::cout << "----------------" << std::endl << std::endl;
+//  }
+
+  return;
+}
+
+bool RunTest()
+{
+  RTC::RtcBase* comp;
+  RTC::Manager &mamager = RTC::Manager::instance();
+  comp = mamager.getComponent("ModuleNameTest0");
+  if (comp == nullptr)
+  {
+    std::cerr << "Component get failed." << std::endl;
+    return false;
+  }
+
+  ModuleNameTest* testcomp = dynamic_cast<ModuleNameTest*>(comp);
+  if (testcomp == nullptr)
+  {
+    std::cerr << "Component get failed." << std::endl;
+    return false;
+  }
+
+  return testcomp->runTest();
+}
+
+int main (int argc, char** argv)
+{
+  RTC::Manager* manager;
+  manager = RTC::Manager::init(argc, argv);
+
+  // Set module initialization proceduer
+  // This procedure will be invoked in activateManager() function.
+  manager->setModuleInitProc(MyModuleInit);
+
+  // Activate manager and register to naming service
+  manager->activateManager();
+
+  // run the manager in blocking mode
+  // runManager(false) is the default.
+  // manager->runManager();
+
+  // If you want to run the manager in non-blocking mode, do like this
+  manager->runManager(true);
+
+  bool ret = RunTest();
+
+#if RTM_MAJOR_VERSION >= 2
+  manager->terminate();
+  manager->join();
+#else
+  manager->shutdown();
+#endif
+
+  
+  if (ret)
+  {
+    return 0;
+  }
+  else
+  {
+    return 1;
+  }
+}

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/ModuleNameFSM.scxml
@@ -1,0 +1,24 @@
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=212 h=513  -->
+ <state id="InitialState"><!--   node-size-and-position x=55.86 y=43 w=100 h=75  -->
+  <transition id="13" target="State01"></transition>
+ </state>
+ <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->
+  <onentry>
+   <log label="ON"></log>
+  </onentry>
+  <onexit>
+   <log label="ON"></log>
+  </onexit>
+  <transition cond="Cond01" event="Event01-02" id="15" target="State02"></transition>
+ </state>
+ <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->
+  <onentry>
+   <log label="ON"></log>
+  </onentry>
+  <onexit>
+   <log label="ON"></log>
+  </onexit>
+  <transition cond="Cond02" event="Event02-Final" id="17" target="FinalState"></transition>
+ </state>
+ <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final>
+</scxml>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/README.md
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/README.md
@@ -1,0 +1,278 @@
+﻿# ModuleName
+
+## Overview
+
+ModuleDescription
+
+## Description
+
+
+
+### Input and Output
+
+
+
+### Algorithm etc
+
+
+
+### Basic Information
+
+|  |  |
+----|---- 
+| Module Name | ModuleName |
+| Description | ModuleDescription |
+| Version | 1.0.0 |
+| Vendor | VenderName |
+| Category | Category |
+| Comp. Type | STATIC |
+| Act. Type | PERIODIC |
+| Kind | DataFlowComponent |
+| MAX Inst. | 1 |
+
+### Activity definition
+
+<table>
+  <tr>
+    <td rowspan="4">on_initialize</td>
+    <td colspan="2">implemented</td>
+    <tr>
+      <td>Description</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PreCondition</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PostCondition</td>
+      <td></td>
+    </tr>
+  </tr>
+  <tr>
+    <td>on_finalize</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_startup</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_shutdown</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_activated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_deactivated</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_execute</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_aborting</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_error</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_reset</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_state_update</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>on_rate_changed</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+### EventPorts definition
+
+|  |  |
+----|---- 
+| Port Name | FSMEventPort |
+| FSM Type | StaticFSM |
+
+#### Node list
+
+<table>
+  <tr>
+    <td>State Name</td>
+    <td>Event Name</td>
+    <td>Target State</td>
+  </tr>
+  <tr>
+    <td>InitialState</td>
+    <td colspan="2">Initial State</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State01</td>
+    <td>Event01-02</td>
+    <td>State02</td>
+  </tr>
+  <tr>
+    <td rowspan="1">State02</td>
+    <td>Event02-Final</td>
+    <td>FinalState</td>
+  </tr>
+  <tr>
+    <td>FinalState</td>
+    <td colspan="2">Final State</td>
+  </tr>
+
+</table>
+
+#### Event list
+
+##### 
+
+
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">InitialState</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2"></td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2"></td>
+  </tr>
+</table>
+
+
+
+##### Event01-02
+
+Abst01-02
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State01</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td>RTC::TimedLong</td>
+    <td>Type01-02</td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2">Num01-02</td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2">Unit01-02</td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2">Period01-02</td>
+  </tr>
+</table>
+
+Detail01-02
+
+##### Event02-Final
+
+Abst02-Final
+
+<table>
+  <tr>
+    <td>Source State</td>
+    <td colspan="2">State02</td>
+  </tr>
+  <tr>
+    <td>Target State</td>
+    <td colspan="2">FinalState</td>
+  </tr>
+  <tr>
+    <td>DataType</td>
+    <td>RTC::TimedString</td>
+    <td>Type02-Final</td>
+  </tr>
+  <tr>
+    <td>Number of Data</td>
+    <td colspan="2">Num02-Final</td>
+  </tr>
+  <tr>
+    <td>Unit</td>
+    <td colspan="2">Unit02-Final</td>
+  </tr>
+  <tr>
+    <td>Operational frecency Period</td>
+    <td colspan="2">Period02-Final</td>
+  </tr>
+</table>
+
+Detail02-Final
+
+
+
+### InPorts definition
+
+
+### OutPorts definition
+
+
+### Service Port definition
+
+
+### Configuration definition
+
+
+## Demo
+
+## Requirement
+
+## Setup
+
+### Windows
+
+### Ubuntu
+
+## Usage
+
+## Running the tests
+
+## LICENCE
+
+
+
+
+## References
+
+
+
+
+## Author
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/RTC.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<rtc:RtcProfile rtc:version="0.3" rtc:id="RTC:VenderName:Category:ModuleName:1.0.0" xmlns:rtc="http://www.openrtp.org/namespaces/rtc" xmlns:rtcExt="http://www.openrtp.org/namespaces/rtc_ext" xmlns:rtcDoc="http://www.openrtp.org/namespaces/rtc_doc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <rtc:BasicInfo xsi:type="rtcExt:basic_info_ext" rtcExt:saveProject="FSMTest" rtc:updateDate="2019-12-20T00:07:52.000+09:00" rtc:creationDate="2019-12-19T22:49:56.000+09:00" rtc:version="1.0.0" rtc:vendor="VenderName" rtc:maxInstances="1" rtc:executionType="PeriodicExecutionContext" rtc:executionRate="1000.0" rtc:description="ModuleDescription" rtc:category="Category" rtc:componentKind="DataFlowComponent" rtc:activityType="PERIODIC" rtc:componentType="STATIC" rtc:name="ModuleName">
+        <rtcExt:Properties rtcExt:value="true" rtcExt:name="FSM"/>
+        <rtcExt:Properties rtcExt:value="StaticFSM" rtcExt:name="FSMType"/>
+    </rtc:BasicInfo>
+    <rtc:Actions>
+        <rtc:OnInitialize xsi:type="rtcDoc:action_status_doc" rtc:implemented="true"/>
+        <rtc:OnFinalize xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStartup xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnShutdown xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnActivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnDeactivated xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAborting xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnError xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnReset xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnExecute xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnStateUpdate xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnRateChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnAction xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+        <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
+    </rtc:Actions>
+    <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedLong" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01-02">
+            <rtcDoc:Doc rtcDoc:operation="Period01-02" rtcDoc:unit="Unit01-02" rtcDoc:semantics="Detail01-02" rtcDoc:number="Num01-02" rtcDoc:type="Type01-02" rtcDoc:description="Abst01-02"/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedString" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02-Final">
+            <rtcDoc:Doc rtcDoc:operation="Period02-Final" rtcDoc:unit="Unit02-Final" rtcDoc:semantics="Detail02-Final" rtcDoc:number="Num02-Final" rtcDoc:type="Type02-Final" rtcDoc:description="Abst02-Final"/>
+        </rtc:Event>
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State01" rtc:source="InitialState" rtc:condition="" rtc:name="">
+            <rtcDoc:Doc/>
+        </rtc:Event>
+    </rtc:DataPorts>
+    <rtc:Language xsi:type="rtcExt:language_ext" rtc:kind="C++"/>
+</rtc:RtcProfile>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/include/ModuleName/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/include/ModuleName/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(hdrs ModuleName.h
+    ModuleNameFSM.h
+    PARENT_SCOPE
+    )

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/include/ModuleName/ModuleName.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/include/ModuleName/ModuleName.h
@@ -1,0 +1,280 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleName.h
+ * @brief ModuleDescription
+ * @date  $Date$
+ *
+ * $Id$
+ */
+
+#ifndef MODULENAME_H
+#define MODULENAME_H
+
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/idl/ExtendedDataTypesSkel.h>
+#include <rtm/idl/InterfaceDataTypesSkel.h>
+
+// Service implementation headers
+// <rtc-template block="service_impl_h">
+
+// </rtc-template>
+
+// Service Consumer stub headers
+// <rtc-template block="consumer_stub_h">
+
+// </rtc-template>
+
+#include <rtm/Manager.h>
+#include <rtm/DataFlowComponentBase.h>
+#include <rtm/CorbaPort.h>
+#include <rtm/DataInPort.h>
+#include <rtm/DataOutPort.h>
+
+// FSM headers
+
+#include <rtm/EventPort.h>
+// <rtc-template block="fsm_h">
+#include "ModuleNameFSM.h"
+// </rtc-template>
+
+
+/*!
+ * @class ModuleName
+ * @brief ModuleDescription
+ *
+ */
+class ModuleName
+  : public RTC::DataFlowComponentBase
+{
+ public:
+  /*!
+   * @brief constructor
+   * @param manager Maneger Object
+   */
+  ModuleName(RTC::Manager* manager);
+
+  /*!
+   * @brief destructor
+   */
+  ~ModuleName() override;
+
+  // <rtc-template block="public_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="public_operation">
+  
+  // </rtc-template>
+
+  // <rtc-template block="activity">
+  /***
+   *
+   * The initialize action (on CREATED->ALIVE transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+   RTC::ReturnCode_t onInitialize() override;
+
+  /***
+   *
+   * The finalize action (on ALIVE->END transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onFinalize() override;
+
+  /***
+   *
+   * The startup action when ExecutionContext startup
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStartup(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The shutdown action when ExecutionContext stop
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onShutdown(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The activated action (Active state entry action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The deactivated action (Active state exit action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The execution action that is invoked periodically
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The aborting action when main logic error occurred.
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onAborting(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The error action in ERROR state
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onError(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The reset action that is invoked resetting
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onReset(RTC::UniqueId ec_id) override;
+  
+  /***
+   *
+   * The state update action that is invoked after onExecute() action
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStateUpdate(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The action that is invoked when execution context's rate is changed
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id) override;
+  // </rtc-template>
+
+
+ protected:
+  // <rtc-template block="protected_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="protected_operation">
+  
+  // </rtc-template>
+
+  // Configuration variable declaration
+  // <rtc-template block="config_declare">
+
+  // </rtc-template>
+
+  // DataInPort declaration
+  // <rtc-template block="inport_declare">
+  
+  // </rtc-template>
+
+
+  // DataOutPort declaration
+  // <rtc-template block="outport_declare">
+  
+  // </rtc-template>
+
+  // CORBA Port declaration
+  // <rtc-template block="corbaport_declare">
+  
+  // </rtc-template>
+
+  // Service declaration
+  // <rtc-template block="service_declare">
+  
+  // </rtc-template>
+
+  // Consumer declaration
+  // <rtc-template block="consumer_declare">
+  
+  // </rtc-template>
+
+  // State machine declaration
+  // <rtc-template block="fsm_declare">
+  RTC::Machine<ModuleNameFsm::Top> m_fsm;
+  // </rtc-template>
+  
+  // EventPort declaration
+  // <rtc-template block="event_declare">
+  
+  RTC::EventInPort< RTC::Machine<ModuleNameFsm::Top> > m_FSMEventVarIn;
+  // </rtc-template>
+
+ private:
+  // <rtc-template block="private_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="private_operation">
+  
+  // </rtc-template>
+
+};
+
+
+extern "C"
+{
+  DLL_EXPORT void ModuleNameInit(RTC::Manager* manager);
+};
+
+#endif // MODULENAME_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/include/ModuleName/ModuleNameFSM.h
@@ -1,0 +1,91 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameFSM.h
+ * @date  $Date$
+ * $Id$
+ */
+
+#ifndef MODULENAMEFSM_H
+#define MODULENAMEFSM_H
+
+#include <rtm/StaticFSM.h>
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/RTC.h>
+
+class ModuleName;
+
+namespace ModuleNameFsm {
+
+  /*!
+   * @if jp
+   * @class TOP状態
+   *
+   *
+   * @else
+   * @brief TOP state
+   *
+   * @endif
+   */
+  FSM_TOPSTATE(Top) {
+    // Top state variables (visible to all substates)
+  
+    FSM_STATE(Top);
+
+    // Machine's event protocol
+    /*!
+     * Abst01-02
+     * - Type: Type01-02
+     * - Number: Num01-02
+     * - Semantics: Detail01-02
+     * - Unit: Unit01-02
+     * - Operation Cycle: Period01-02
+     */
+    virtual void Event01-02(RTC::TimedLong data) {}
+    
+    /*!
+     * Abst02-Final
+     * - Type: Type02-Final
+     * - Number: Num02-Final
+     * - Semantics: Detail02-Final
+     * - Unit: Unit02-Final
+     * - Operation Cycle: Period02-Final
+     */
+    virtual void Event02-Final(RTC::TimedString data) {}
+    
+  
+   private:
+     RTC::ReturnCode_t onInit() override;
+     RTC::ReturnCode_t onEntry() override;
+     RTC::ReturnCode_t onExit() override;
+  };
+
+  FSM_SUBSTATE(State01, Top) {
+    FSM_STATE(State01);
+  
+
+    // Event handler
+    void Event01-02(RTC::TimedLong data) override;
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+       RTC::ReturnCode_t onEntry() override;
+       RTC::ReturnCode_t onExit() override;
+  };
+
+  FSM_SUBSTATE(State02, Top) {
+    FSM_STATE(State02);
+  
+
+    // Event handler
+    void Event02-Final(RTC::TimedString data) override;
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+       RTC::ReturnCode_t onEntry() override;
+       RTC::ReturnCode_t onExit() override;
+  };
+
+
+} //end namespace 'ModuleNameFSM'
+
+#endif // MODULENAMEFSM_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/src/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/src/CMakeLists.txt
@@ -1,0 +1,64 @@
+set(comp_srcs ModuleName.cpp ModuleNameFSM.cpp)
+set(standalone_srcs ModuleNameComp.cpp)
+
+if(${OPENRTM_VERSION_MAJOR} LESS 2)
+  set(OPENRTM_CFLAGS ${OPENRTM_CFLAGS} ${OMNIORB_CFLAGS})
+  set(OPENRTM_INCLUDE_DIRS ${OPENRTM_INCLUDE_DIRS} ${OMNIORB_INCLUDE_DIRS})
+  set(OPENRTM_LIBRARY_DIRS ${OPENRTM_LIBRARY_DIRS} ${OMNIORB_LIBRARY_DIRS})
+endif()
+
+if (DEFINED OPENRTM_INCLUDE_DIRS)
+  string(REGEX REPLACE "-I" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+endif (DEFINED OPENRTM_INCLUDE_DIRS)
+
+if (DEFINED OPENRTM_LIBRARY_DIRS)
+  string(REGEX REPLACE "-L" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+endif (DEFINED OPENRTM_LIBRARY_DIRS)
+
+if (DEFINED OPENRTM_LIBRARIES)
+  string(REGEX REPLACE "-l" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+endif (DEFINED OPENRTM_LIBRARIES)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME})
+include_directories(${PROJECT_BINARY_DIR})
+include_directories(${PROJECT_BINARY_DIR}/idl)
+include_directories(${OPENRTM_INCLUDE_DIRS})
+add_definitions(${OPENRTM_CFLAGS})
+
+MAP_ADD_STR(comp_hdrs "../" comp_headers)
+
+link_directories(${OPENRTM_LIBRARY_DIRS})
+
+add_library(${PROJECT_NAME} ${LIB_TYPE} ${comp_srcs}
+  ${comp_headers} ${ALL_IDL_SRCS})
+set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
+set_source_files_properties(${ALL_IDL_SRCS} PROPERTIES GENERATED 1)
+if(NOT TARGET ALL_IDL_TGT)
+ add_custom_target(ALL_IDL_TGT)
+endif(NOT TARGET ALL_IDL_TGT)
+add_dependencies(${PROJECT_NAME} ALL_IDL_TGT)
+target_link_libraries(${PROJECT_NAME} ${OPENRTM_LIBRARIES})
+
+add_executable(${PROJECT_NAME}Comp ${standalone_srcs}
+  ${comp_srcs} ${comp_headers} ${ALL_IDL_SRCS})
+add_dependencies(${PROJECT_NAME}Comp ALL_IDL_TGT)
+target_link_libraries(${PROJECT_NAME}Comp ${OPENRTM_LIBRARIES})
+
+install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}Comp
+    EXPORT ${PROJECT_NAME}
+    RUNTIME DESTINATION ${INSTALL_PREFIX} COMPONENT component
+    LIBRARY DESTINATION ${INSTALL_PREFIX} COMPONENT component
+    ARCHIVE DESTINATION ${INSTALL_PREFIX} COMPONENT component)
+
+install(FILES ${PROJECT_SOURCE_DIR}/RTC.xml DESTINATION ${INSTALL_PREFIX}
+        COMPONENT component)

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/src/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/src/ModuleName.cpp
@@ -1,0 +1,180 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleName.cpp
+ * @brief ModuleDescription
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include "ModuleName.h"
+
+// Module specification
+// <rtc-template block="module_spec">
+static const char* modulename_spec[] =
+  {
+    "implementation_id", "ModuleName",
+    "type_name",         "ModuleName",
+    "description",       "ModuleDescription",
+    "version",           "1.0.0",
+    "vendor",            "VenderName",
+    "category",          "Category",
+    "activity_type",     "PERIODIC",
+    "kind",              "DataFlowComponent",
+    "max_instance",      "1",
+    "language",          "C++",
+    "lang_type",         "compile",
+    ""
+  };
+// </rtc-template>
+
+/*!
+ * @brief constructor
+ * @param manager Maneger Object
+ */
+ModuleName::ModuleName(RTC::Manager* manager)
+    // <rtc-template block="initializer">
+  : RTC::DataFlowComponentBase(manager),
+    m_fsm(this),
+    m_FSMEventIn("event", m_fsm)
+
+    // </rtc-template>
+{
+}
+
+/*!
+ * @brief destructor
+ */
+ModuleName::~ModuleName()
+{
+}
+
+
+
+RTC::ReturnCode_t ModuleName::onInitialize()
+{
+#ifdef ORB_IS_TAO
+  ::CORBA_Util::toRepositoryIdOfStruct<TimedLong>();
+#endif
+  // Registration: InPort/OutPort/Service
+  // <rtc-template block="registration">
+  // Set InPort buffers
+  
+  // Set OutPort buffer
+
+  // Set EventPort buffer
+  addInPort("event", m_FSMEventVarIn);
+  
+  // Set service provider to Ports
+  
+  // Set service consumers to Ports
+  
+  // Set CORBA Service Ports
+  
+  // </rtc-template>
+
+  // <rtc-template block="bind_config">
+  // </rtc-template>
+  // <rtc-template block="bind_event">
+  m_FSMEventVarIn.bindEvent("Event01-02", &ModuleNameFsm::Top::Event01-02);
+  m_FSMEventVarIn.bindEvent("Event02-Final", &ModuleNameFsm::Top::Event02-Final);
+  // </rtc-template>
+
+  
+  return RTC::RTC_OK;
+}
+
+/*
+RTC::ReturnCode_t ModuleName::onFinalize()
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onStartup(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onShutdown(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onActivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onDeactivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onExecute(RTC::UniqueId ec_id)
+{
+  m_fsm.run_event();
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onAborting(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onError(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onReset(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onStateUpdate(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleName::onRateChanged(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+
+
+extern "C"
+{
+ 
+  void ModuleNameInit(RTC::Manager* manager)
+  {
+    coil::Properties profile(modulename_spec);
+    manager->registerFactory(profile,
+                             RTC::Create<ModuleName>,
+                             RTC::Delete<ModuleName>);
+  }
+  
+};
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/src/ModuleNameComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/src/ModuleNameComp.cpp
@@ -1,0 +1,129 @@
+﻿// -*- C++ -*-
+/*!
+ * @file ModuleNameComp.cpp
+ * @brief Standalone component
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include <rtm/Manager.h>
+#include <iostream>
+#include <string>
+#include <stdlib.h>
+#include "ModuleName.h"
+
+class OverwriteInstanceName
+  : public RTM::RtcLifecycleActionListener
+{
+public:
+  OverwriteInstanceName(int argc, char** argv)
+    : m_name(""), m_count(0)
+  {
+    for (size_t i = 0; i < argc; ++i)
+      {
+        std::string opt = argv[i];
+        if (opt.find("--instance_name=") == std::string::npos) { continue; }
+
+        coil::replaceString(opt, "--instance_name=", "");
+        if (opt.empty()) { continue; }
+
+        m_name = opt;
+      }
+  }
+  virtual ~OverwriteInstanceName() {}
+  virtual void preCreate(std::string& args)
+  {
+    if (m_count != 0 || m_name.empty()) { return; }
+    args = args + "?instance_name=" + m_name;
+    ++m_count;
+  };
+  virtual void postCreate(RTC::RTObject_impl*) {};
+  virtual void preConfigure(coil::Properties&) {};
+  virtual void postConfigure(coil::Properties&) {};
+  virtual void preInitialize() {};
+  virtual void postInitialize() {};
+private:
+  std::string m_name;
+  int32_t m_count;
+};
+
+void MyModuleInit(RTC::Manager* manager)
+{
+  ModuleNameInit(manager);
+  RTC::RtcBase* comp;
+
+  // Create a component
+  comp = manager->createComponent("ModuleName");
+
+  if (comp==NULL)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
+
+  // Example
+  // The following procedure is examples how handle RT-Components.
+  // These should not be in this function.
+
+  // Get the component's object reference
+//  RTC::RTObject_var rtobj;
+//  rtobj = RTC::RTObject::_narrow(manager->getPOA()->servant_to_reference(comp));
+
+  // Get the port list of the component
+//  PortServiceList* portlist;
+//  portlist = rtobj->get_ports();
+
+  // getting port profiles
+//  std::cout << "Number of Ports: ";
+//  std::cout << portlist->length() << std::endl << std::endl; 
+//  for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
+//  {
+//    PortService_ptr port;
+//    port = (*portlist)[i];
+//    std::cout << "Port" << i << " (name): ";
+//    std::cout << port->get_port_profile()->name << std::endl;
+//    
+//    RTC::PortInterfaceProfileList iflist;
+//    iflist = port->get_port_profile()->interfaces;
+//    std::cout << "---interfaces---" << std::endl;
+//    for (CORBA::ULong i(0), n(iflist.length()); i < n; ++i)
+//    {
+//      std::cout << "I/F name: ";
+//      std::cout << iflist[i].instance_name << std::endl;
+//      std::cout << "I/F type: ";
+//      std::cout << iflist[i].type_name << std::endl;
+//      const char* pol;
+//      pol = iflist[i].polarity == 0 ? "PROVIDED" : "REQUIRED";
+//      std::cout << "Polarity: " << pol << std::endl;
+//    }
+//    std::cout << "---properties---" << std::endl;
+//    NVUtil::dump(port->get_port_profile()->properties);
+//    std::cout << "----------------" << std::endl << std::endl;
+//  }
+
+  return;
+}
+
+int main (int argc, char** argv)
+{
+  RTC::Manager* manager;
+  manager = RTC::Manager::init(argc, argv);
+  manager->addRtcLifecycleActionListener(new OverwriteInstanceName(argc, argv), true);
+
+  // Set module initialization proceduer
+  // This procedure will be invoked in activateManager() function.
+  manager->setModuleInitProc(MyModuleInit);
+
+  // Activate manager and register to naming service
+  manager->activateManager();
+
+  // run the manager in blocking mode
+  // runManager(false) is the default.
+  manager->runManager();
+
+  // If you want to run the manager in non-blocking mode, do like this
+  // manager->runManager(true);
+
+  return 0;
+}

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/src/ModuleNameFSM.cpp
@@ -1,0 +1,62 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameFSM.cpp
+ * @date $Date$
+ * $Id$
+ */
+
+#include "ModuleNameFSM.h"
+
+namespace ModuleNameFsm {
+
+// Top state
+RTC::ReturnCode_t Top::onInit() {
+  setState<State01>();
+  return RTC::RTC_OK;
+}
+
+RTC::ReturnCode_t Top::onEntry() {
+  return RTC::RTC_OK;
+}
+
+RTC::ReturnCode_t Top::onExit() {
+  return RTC::RTC_OK;
+}
+
+//============================================================
+// State State01
+// RTC::ReturnCode_t State01::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+RTC::ReturnCode_t State01::onEntry() {
+  return RTC::RTC_OK;
+}
+RTC::ReturnCode_t State01::onExit() {
+  return RTC::RTC_OK;
+}
+
+void State01::Event01-02(RTC::TimedLong data) {
+  setState<State02>();
+}
+
+
+//============================================================
+// State State02
+// RTC::ReturnCode_t State02::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+RTC::ReturnCode_t State02::onEntry() {
+  return RTC::RTC_OK;
+}
+RTC::ReturnCode_t State02::onExit() {
+  return RTC::RTC_OK;
+}
+
+void State02::Event02-Final(RTC::TimedString data) {
+  setState<FinalState>();
+}
+
+
+} //end namespace 'ModuleNameFSM'

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/test/include/ModuleNameTest/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/test/include/ModuleNameTest/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(hdrs
+    ModuleNameTest.h
+    PARENT_SCOPE
+    )

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/test/include/ModuleNameTest/ModuleNameTest.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/test/include/ModuleNameTest/ModuleNameTest.h
@@ -1,0 +1,268 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameTest.h
+ * @brief ModuleDescription
+ * @date  $Date$
+ *
+ * $Id$
+ */
+
+#ifndef MODULENAME_TEST__H
+#define MODULENAME_TEST_H
+
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/idl/ExtendedDataTypesSkel.h>
+#include <rtm/idl/InterfaceDataTypesSkel.h>
+
+// Service implementation headers
+// <rtc-template block="service_impl_h">
+
+// </rtc-template>
+
+// Service Consumer stub headers
+// <rtc-template block="consumer_stub_h">
+
+// </rtc-template>
+
+#include <rtm/Manager.h>
+#include <rtm/DataFlowComponentBase.h>
+#include <rtm/CorbaPort.h>
+#include <rtm/DataInPort.h>
+#include <rtm/DataOutPort.h>
+
+/*!
+ * @class ModuleNameTest
+ * @brief ModuleDescription
+ *
+ */
+class ModuleNameTest
+  : public RTC::DataFlowComponentBase
+{
+ public:
+  /*!
+   * @brief constructor
+   * @param manager Maneger Object
+   */
+  ModuleNameTest(RTC::Manager* manager);
+
+  /*!
+   * @brief destructor
+   */
+  ~ModuleNameTest() override;
+
+  // <rtc-template block="public_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="public_operation">
+  
+  // </rtc-template>
+
+  // <rtc-template block="activity">
+  /***
+   *
+   * The initialize action (on CREATED->ALIVE transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+   RTC::ReturnCode_t onInitialize() override;
+
+  /***
+   *
+   * The finalize action (on ALIVE->END transition)
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onFinalize() override;
+
+  /***
+   *
+   * The startup action when ExecutionContext startup
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStartup(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The shutdown action when ExecutionContext stop
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onShutdown(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The activated action (Active state entry action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The deactivated action (Active state exit action)
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The execution action that is invoked periodically
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The aborting action when main logic error occurred.
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onAborting(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The error action in ERROR state
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onError(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The reset action that is invoked resetting
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onReset(RTC::UniqueId ec_id) override;
+  
+  /***
+   *
+   * The state update action that is invoked after onExecute() action
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onStateUpdate(RTC::UniqueId ec_id) override;
+
+  /***
+   *
+   * The action that is invoked when execution context's rate is changed
+   *
+   * @param ec_id target ExecutionContext Id
+   *
+   * @return RTC::ReturnCode_t
+   * 
+   * 
+   */
+  // RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id) override;
+  // </rtc-template>
+
+  bool runTest();
+
+ protected:
+  // <rtc-template block="protected_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="protected_operation">
+  
+  // </rtc-template>
+
+  // Configuration variable declaration
+  // <rtc-template block="config_declare">
+
+  // </rtc-template>
+
+  // DataInPort declaration
+  // <rtc-template block="inport_declare">
+  
+  // </rtc-template>
+
+
+  // DataOutPort declaration
+  // <rtc-template block="outport_declare">
+    RTC::TimedLong m_Event01-02;
+    RTC::OutPort<RTC::TimedLong> m_Event01-02Out;
+    
+    RTC::TimedString m_Event02-Final;
+    RTC::OutPort<RTC::TimedString> m_Event02-FinalOut;
+    
+  
+  // </rtc-template>
+
+  // CORBA Port declaration
+  // <rtc-template block="corbaport_declare">
+  
+  // </rtc-template>
+
+  // Service declaration
+  // <rtc-template block="service_declare">
+  
+  // </rtc-template>
+
+  // Consumer declaration
+  // <rtc-template block="consumer_declare">
+  
+  // </rtc-template>
+
+ private:
+  // <rtc-template block="private_attribute">
+  
+  // </rtc-template>
+
+  // <rtc-template block="private_operation">
+  
+  // </rtc-template>
+
+};
+
+
+extern "C"
+{
+  DLL_EXPORT void ModuleNameTestInit(RTC::Manager* manager);
+};
+
+#endif // MODULENAME_TEST_H

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/test/src/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/test/src/CMakeLists.txt
@@ -1,0 +1,57 @@
+set(comp_srcs
+   ModuleNameTest.cpp
+   )
+set(standalone_srcs ModuleNameTestComp.cpp)
+
+if(${OPENRTM_VERSION_MAJOR} LESS 2)
+  set(OPENRTM_CFLAGS ${OPENRTM_CFLAGS} ${OMNIORB_CFLAGS})
+  set(OPENRTM_INCLUDE_DIRS ${OPENRTM_INCLUDE_DIRS} ${OMNIORB_INCLUDE_DIRS})
+  set(OPENRTM_LIBRARY_DIRS ${OPENRTM_LIBRARY_DIRS} ${OMNIORB_LIBRARY_DIRS})
+endif()
+
+if (DEFINED OPENRTM_INCLUDE_DIRS)
+  string(REGEX REPLACE "-I" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_INCLUDE_DIRS "${OPENRTM_INCLUDE_DIRS}")
+endif (DEFINED OPENRTM_INCLUDE_DIRS)
+
+if (DEFINED OPENRTM_LIBRARY_DIRS)
+  string(REGEX REPLACE "-L" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARY_DIRS "${OPENRTM_LIBRARY_DIRS}")
+endif (DEFINED OPENRTM_LIBRARY_DIRS)
+
+if (DEFINED OPENRTM_LIBRARIES)
+  string(REGEX REPLACE "-l" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+  string(REGEX REPLACE " ;" ";"
+    OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
+endif (DEFINED OPENRTM_LIBRARIES)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME})
+include_directories(${PROJECT_SOURCE_DIR}/test/include)
+include_directories(${PROJECT_SOURCE_DIR}/test/include/${PROJECT_NAME}Test)
+include_directories(${PROJECT_BINARY_DIR})
+include_directories(${PROJECT_BINARY_DIR}/idl)
+include_directories(${OPENRTM_INCLUDE_DIRS})
+add_definitions(${OPENRTM_CFLAGS})
+
+MAP_ADD_STR(comp_test_hdrs "../" comp_headers)
+
+link_directories(${OPENRTM_LIBRARY_DIRS})
+
+if(NOT TARGET ALL_IDL_TGT)
+ add_custom_target(ALL_IDL_TGT)
+endif(NOT TARGET ALL_IDL_TGT)
+
+add_executable(${PROJECT_NAME}Test ${standalone_srcs}
+  ${comp_srcs} ${comp_headers} ${ALL_IDL_SRCS})
+set_source_files_properties(${ALL_IDL_SRCS} PROPERTIES GENERATED 1)
+add_dependencies(${PROJECT_NAME}Test ${PROJECT_NAME})
+target_link_libraries(${PROJECT_NAME}Test ${OPENRTM_LIBRARIES} ${PROJECT_NAME})
+set_property(TARGET ${PROJECT_NAME}Test PROPERTY CXX_STANDARD 11)
+
+add_test(NAME ${PROJECT_NAME}_test COMMAND $<TARGET_FILE:${PROJECT_NAME}Test> -o "manager.components.precreate:${PROJECT_NAME}" -o "manager.components.preconnect:${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event01-02&fsm_event_name=Event01-02,${PROJECT_NAME}0.event?port=${PROJECT_NAME}Test0.Event02-Final&fsm_event_name=Event02-Final" -o "manager.components.preactivation:${PROJECT_NAME}0,${PROJECT_NAME}Test0" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/test/src/ModuleNameTest.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/test/src/ModuleNameTest.cpp
@@ -1,0 +1,175 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ModuleNameTest.cpp
+ * @brief ModuleDescription
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include "ModuleNameTest.h"
+
+// Module specification
+// <rtc-template block="module_spec">
+static const char* modulename_spec[] =
+  {
+    "implementation_id", "ModuleNameTest",
+    "type_name",         "ModuleNameTest",
+    "description",       "ModuleDescription",
+    "version",           "1.0.0",
+    "vendor",            "VenderName",
+    "category",          "Category",
+    "activity_type",     "PERIODIC",
+    "kind",              "DataFlowComponent",
+    "max_instance",      "1",
+    "language",          "C++",
+    "lang_type",         "compile",
+    ""
+  };
+// </rtc-template>
+
+/*!
+ * @brief constructor
+ * @param manager Maneger Object
+ */
+ModuleNameTest::ModuleNameTest(RTC::Manager* manager)
+    // <rtc-template block="initializer">
+  : RTC::DataFlowComponentBase(manager)
+,
+    m_Event01-02Out("Event01-02", m_Event01-02),
+    m_Event02-FinalOut("Event02-Final", m_Event02-Final)
+    // </rtc-template>
+{
+}
+
+/*!
+ * @brief destructor
+ */
+ModuleNameTest::~ModuleNameTest()
+{
+}
+
+
+
+RTC::ReturnCode_t ModuleNameTest::onInitialize()
+{
+  // Registration: InPort/OutPort/Service
+  // <rtc-template block="registration">
+  // Set InPort buffers
+  
+  // Set OutPort buffer
+  addOutPort("Event01-02", m_Event01-02Out);
+  addOutPort("Event02-Final", m_Event02-FinalOut);
+  
+  // Set service provider to Ports
+  
+  // Set service consumers to Ports
+  
+  // Set CORBA Service Ports
+  
+  // </rtc-template>
+
+  // <rtc-template block="bind_config">
+  // </rtc-template>
+  
+  return RTC::RTC_OK;
+}
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onFinalize()
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onStartup(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onShutdown(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onActivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onDeactivated(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onExecute(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onAborting(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onError(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onReset(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onStateUpdate(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t ModuleNameTest::onRateChanged(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+
+bool ModuleNameTest::runTest()
+{
+    return true;
+}
+
+
+extern "C"
+{
+ 
+  void ModuleNameTestInit(RTC::Manager* manager)
+  {
+    coil::Properties profile(modulename_spec);
+    manager->registerFactory(profile,
+                             RTC::Create<ModuleNameTest>,
+                             RTC::Delete<ModuleNameTest>);
+  }
+  
+};
+
+

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/test/src/ModuleNameTestComp.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/test/src/ModuleNameTestComp.cpp
@@ -1,0 +1,135 @@
+﻿// -*- C++ -*-
+/*!
+ * @file ModuleNameTestComp.cpp
+ * @brief Standalone component
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include <rtm/Manager.h>
+#include <iostream>
+#include <string>
+#include <stdlib.h>
+#include <rtm/CORBA_RTCUtil.h>
+#include "ModuleNameTest.h"
+#include "ModuleName.h"
+
+
+void MyModuleInit(RTC::Manager* manager)
+{
+  ModuleNameTestInit(manager);
+  ModuleNameInit(manager);
+  RTC::RtcBase* comp;
+
+  // Create a component
+  comp = manager->createComponent("ModuleNameTest");
+
+  if (comp==nullptr)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
+
+  // Example
+  // The following procedure is examples how handle RT-Components.
+  // These should not be in this function.
+
+  // Get the component's object reference
+//  RTC::RTObject_var rtobj;
+//  rtobj = RTC::RTObject::_narrow(manager->getPOA()->servant_to_reference(comp));
+
+  // Get the port list of the component
+//  PortServiceList* portlist;
+//  portlist = rtobj->get_ports();
+
+  // getting port profiles
+//  std::cout << "Number of Ports: ";
+//  std::cout << portlist->length() << std::endl << std::endl; 
+//  for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
+//  {
+//    PortService_ptr port;
+//    port = (*portlist)[i];
+//    std::cout << "Port" << i << " (name): ";
+//    std::cout << port->get_port_profile()->name << std::endl;
+//    
+//    RTC::PortInterfaceProfileList iflist;
+//    iflist = port->get_port_profile()->interfaces;
+//    std::cout << "---interfaces---" << std::endl;
+//    for (CORBA::ULong i(0), n(iflist.length()); i < n; ++i)
+//    {
+//      std::cout << "I/F name: ";
+//      std::cout << iflist[i].instance_name << std::endl;
+//      std::cout << "I/F type: ";
+//      std::cout << iflist[i].type_name << std::endl;
+//      const char* pol;
+//      pol = iflist[i].polarity == 0 ? "PROVIDED" : "REQUIRED";
+//      std::cout << "Polarity: " << pol << std::endl;
+//    }
+//    std::cout << "---properties---" << std::endl;
+//    NVUtil::dump(port->get_port_profile()->properties);
+//    std::cout << "----------------" << std::endl << std::endl;
+//  }
+
+  return;
+}
+
+bool RunTest()
+{
+  RTC::RtcBase* comp;
+  RTC::Manager &mamager = RTC::Manager::instance();
+  comp = mamager.getComponent("ModuleNameTest0");
+  if (comp == nullptr)
+  {
+    std::cerr << "Component get failed." << std::endl;
+    return false;
+  }
+
+  ModuleNameTest* testcomp = dynamic_cast<ModuleNameTest*>(comp);
+  if (testcomp == nullptr)
+  {
+    std::cerr << "Component get failed." << std::endl;
+    return false;
+  }
+
+  return testcomp->runTest();
+}
+
+int main (int argc, char** argv)
+{
+  RTC::Manager* manager;
+  manager = RTC::Manager::init(argc, argv);
+
+  // Set module initialization proceduer
+  // This procedure will be invoked in activateManager() function.
+  manager->setModuleInitProc(MyModuleInit);
+
+  // Activate manager and register to naming service
+  manager->activateManager();
+
+  // run the manager in blocking mode
+  // runManager(false) is the default.
+  // manager->runManager();
+
+  // If you want to run the manager in non-blocking mode, do like this
+  manager->runManager(true);
+
+  bool ret = RunTest();
+
+#if RTM_MAJOR_VERSION >= 2
+  manager->terminate();
+  manager->join();
+#else
+  manager->shutdown();
+#endif
+
+  
+  if (ret)
+  {
+    return 0;
+  }
+  else
+  {
+    return 1;
+  }
+}

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/EventParam.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/EventParam.java
@@ -19,6 +19,13 @@ public class EventParam {
 		this.condition = "";
 		this.source = "";
 		this.target = "";
+		//
+		doc_description = "";
+		doc_type = "";
+		doc_num = "";
+		doc_semantics = "";
+		doc_unit = "";
+		doc_operation = "";
 	}
 	
 	public String getName() {
@@ -70,66 +77,48 @@ public class EventParam {
 		return doc_description;
 	}
 	public void setDoc_description(String doc_description) {
+		if(doc_description==null) doc_description = "";
 		this.doc_description = doc_description;
-	}
-	public String getDoc_descriptionStr() {
-		if(doc_description==null) return "";
-		return doc_description;
 	}
 	
 	public String getDoc_type() {
 		return doc_type;
 	}
 	public void setDoc_type(String doc_type) {
+		if(doc_type==null) doc_type = "";
 		this.doc_type = doc_type;
-	}
-	public String getDoc_typeStr() {
-		if(doc_type==null) return "";
-		return doc_type;
 	}
 	
 	public String getDoc_num() {
 		return doc_num;
 	}
 	public void setDoc_num(String doc_num) {
+		if(doc_num==null) doc_num = "";
 		this.doc_num = doc_num;
-	}
-	public String getDoc_numStr() {
-		if(doc_num==null) return "";
-		return doc_num;
 	}
 	
 	public String getDoc_semantics() {
 		return doc_semantics;
 	}
 	public void setDoc_semantics(String doc_semantics) {
+		if(doc_semantics==null) doc_semantics = "";
 		this.doc_semantics = doc_semantics;
-	}
-	public String getDoc_semanticsStr() {
-		if(doc_semantics==null) return "";
-		return doc_semantics;
 	}
 	
 	public String getDoc_unit() {
 		return doc_unit;
 	}
 	public void setDoc_unit(String doc_unit) {
+		if(doc_unit==null) doc_unit = "";
 		this.doc_unit = doc_unit;
-	}
-	public String getDoc_unitStr() {
-		if(doc_unit==null) return "";
-		return doc_unit;
 	}
 	
 	public String getDoc_operation() {
 		return doc_operation;
 	}
 	public void setDoc_operation(String doc_operation) {
+		if(doc_operation==null) doc_operation = "";
 		this.doc_operation = doc_operation;
-	}
-	public String getDoc_operationStr() {
-		if(doc_operation==null) return "";
-		return doc_operation;
 	}
 	
 	public boolean checkSame(EventParam source) {

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/TransitionParam.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/TransitionParam.java
@@ -21,17 +21,15 @@ public class TransitionParam {
 		return event;
 	}
 	public void setEvent(String event) {
+		if(event==null) event = "";
 		this.event = event;
-	}
-	public String getEventStr() {
-		if(event==null) return "";
-		return event;
 	}
 	
 	public String getCondition() {
 		return condition;
 	}
 	public void setCondition(String condition) {
+		if(condition==null) condition = "";
 		this.condition = condition;
 	}
 	
@@ -39,6 +37,7 @@ public class TransitionParam {
 		return source;
 	}
 	public void setSource(String source) {
+		if(source==null) source = "";
 		this.source = source;
 	}
 	
@@ -46,11 +45,8 @@ public class TransitionParam {
 		return target;
 	}
 	public void setTarget(String target) {
+		if(target==null) target = "";
 		this.target = target;
-	}
-	public String getTargetStr() {
-		if(target==null) return "";
-		return target;
 	}
 
 	public EventParam getEventParam() {

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/manager/CommonGenerateManager.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/manager/CommonGenerateManager.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import jp.go.aist.rtm.rtcbuilder.fsm.StateParam;
 import jp.go.aist.rtm.rtcbuilder.generator.GeneratedResult;
 import jp.go.aist.rtm.rtcbuilder.generator.param.RtcParam;
 import jp.go.aist.rtm.rtcbuilder.template.TemplateHelper;
@@ -51,6 +52,12 @@ public class CommonGenerateManager extends GenerateManager {
 	public List<GeneratedResult> generateTemplateCode10(
 			Map<String, Object> contextMap) {
 		List<GeneratedResult> result = new ArrayList<GeneratedResult>();
+		RtcParam rtcParam = (RtcParam) contextMap.get("rtcParam");
+		if(rtcParam.isStaticFSM()) {
+			StateParam stateParam = rtcParam.getFsmParam();
+			stateParam.setEventParam(rtcParam);
+			contextMap.put("fsmParam", stateParam);
+		}
 
 		result.add(generateREADME(contextMap));
 		result.add(generateRTCConf10(contextMap));

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/TemplateHelper.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/TemplateHelper.java
@@ -413,6 +413,7 @@ public class TemplateHelper {
 		EventPortParam evPort = param.getEventport();
 		if(evPort!=null) {
 			for(EventParam event : evPort.getEvents() ) {
+				if(event.getName()==null || event.getName().length()==0) continue;
 				if(0<builder.length()) builder.append(",");
 				
 				builder.append("${PROJECT_NAME}0.event");
@@ -450,14 +451,14 @@ public class TemplateHelper {
 				} else {
 					builder.append("  <tr>").append(br);
 					builder.append("    <td rowspan=\"").append(transList.size()).append("\">").append(state.getName()).append("</td>").append(br);
-					builder.append("    <td>").append(transList.get(0).getEventStr()).append("</td>").append(br);
-					builder.append("    <td>").append(transList.get(0).getTargetStr()).append("</td>").append(br);
+					builder.append("    <td>").append(transList.get(0).getEvent()).append("</td>").append(br);
+					builder.append("    <td>").append(transList.get(0).getTarget()).append("</td>").append(br);
 					builder.append("  </tr>").append(br);
 					if( 1<state.getTransList().size() ) {
 						for(int index=1; index<state.getTransList().size(); index++) {
 							builder.append("  <tr>").append(br);
-							builder.append("    <td>").append(transList.get(index).getEventStr()).append("</td>").append(br);
-							builder.append("    <td>").append(transList.get(index).getTargetStr()).append("</td>").append(br);
+							builder.append("    <td>").append(transList.get(index).getEvent()).append("</td>").append(br);
+							builder.append("    <td>").append(transList.get(index).getTarget()).append("</td>").append(br);
 							builder.append("  </tr>").append(br);
 						}
 					}
@@ -475,7 +476,7 @@ public class TemplateHelper {
 			if(tranParam.getEventParam()==null) continue;
 			builder.append("##### ").append(tranParam.getEventParam().getName()).append(br);
 			builder.append(br);
-			builder.append(tranParam.getEventParam().getDoc_descriptionStr()).append(br);
+			builder.append(tranParam.getEventParam().getDoc_description()).append(br);
 			builder.append(br);
 			builder.append("<table>").append(br);
 			builder.append("  <tr>").append(br);
@@ -491,27 +492,27 @@ public class TemplateHelper {
 			builder.append("  <tr>").append(br);
 			builder.append("    <td>DataType</td>").append(br);
 			builder.append("    <td>").append(tranParam.getEventParam().getDataType()).append("</td>").append(br);
-			builder.append("    <td>").append(tranParam.getEventParam().getDoc_typeStr()).append("</td>").append(br);
+			builder.append("    <td>").append(tranParam.getEventParam().getDoc_type()).append("</td>").append(br);
 			builder.append("  </tr>").append(br);
 			
 			builder.append("  <tr>").append(br);
 			builder.append("    <td>Number of Data</td>").append(br);
-			builder.append("    <td colspan=\"2\">").append(tranParam.getEventParam().getDoc_numStr()).append("</td>").append(br);
+			builder.append("    <td colspan=\"2\">").append(tranParam.getEventParam().getDoc_num()).append("</td>").append(br);
 			builder.append("  </tr>").append(br);
 			
 			builder.append("  <tr>").append(br);
 			builder.append("    <td>Unit</td>").append(br);
-			builder.append("    <td colspan=\"2\">").append(tranParam.getEventParam().getDoc_unitStr()).append("</td>").append(br);
+			builder.append("    <td colspan=\"2\">").append(tranParam.getEventParam().getDoc_unit()).append("</td>").append(br);
 			builder.append("  </tr>").append(br);
 			
 			builder.append("  <tr>").append(br);
 			builder.append("    <td>Operational frecency Period</td>").append(br);
-			builder.append("    <td colspan=\"2\">").append(tranParam.getEventParam().getDoc_operationStr()).append("</td>").append(br);
+			builder.append("    <td colspan=\"2\">").append(tranParam.getEventParam().getDoc_operation()).append("</td>").append(br);
 			builder.append("  </tr>").append(br);
 			
 			builder.append("</table>").append(br);
 			builder.append(br);
-			builder.append(tranParam.getEventParam().getDoc_semanticsStr()).append(br);
+			builder.append(tranParam.getEventParam().getDoc_semantics()).append(br);
 			builder.append(br);
 		}
 		

--- a/jp.go.aist.rtm.rtcbuilder/test/jp/go/aist/rtm/rtcbuilder/_test/AllTests.java
+++ b/jp.go.aist.rtm.rtcbuilder/test/jp/go/aist/rtm/rtcbuilder/_test/AllTests.java
@@ -14,6 +14,7 @@ import jp.go.aist.rtm.rtcbuilder._test.generateCode.ContentTest;
 import jp.go.aist.rtm.rtcbuilder._test.generateCode.DataPortIDLTest;
 import jp.go.aist.rtm.rtcbuilder._test.generateCode.DocLongTest;
 import jp.go.aist.rtm.rtcbuilder._test.generateCode.ExCxtTest;
+import jp.go.aist.rtm.rtcbuilder._test.generateCode.FSMTest;
 import jp.go.aist.rtm.rtcbuilder._test.generateCode.IDLInheritTest;
 import jp.go.aist.rtm.rtcbuilder._test.generateCode.IDLModuleTest;
 import jp.go.aist.rtm.rtcbuilder._test.generateCode.IDLPathTest;
@@ -94,6 +95,8 @@ public class AllTests {
 		suite.addTestSuite(IDLStructTest.class);
 		suite.addTestSuite(ManipTest.class);
 		suite.addTestSuite(ContentTest.class);
+		//
+		suite.addTestSuite(FSMTest.class);
 		//
 		suite.addTestSuite(TemplateHelperTest.class);
 		//

--- a/jp.go.aist.rtm.rtcbuilder/test/jp/go/aist/rtm/rtcbuilder/_test/generateCode/FSMTest.java
+++ b/jp.go.aist.rtm.rtcbuilder/test/jp/go/aist/rtm/rtcbuilder/_test/generateCode/FSMTest.java
@@ -1,0 +1,117 @@
+package jp.go.aist.rtm.rtcbuilder._test.generateCode;
+
+import java.util.List;
+
+import jp.go.aist.rtm.rtcbuilder.Generator;
+import jp.go.aist.rtm.rtcbuilder._test.TestBase;
+import jp.go.aist.rtm.rtcbuilder.fsm.ScXMLHandler;
+import jp.go.aist.rtm.rtcbuilder.fsm.StateParam;
+import jp.go.aist.rtm.rtcbuilder.generator.GeneratedResult;
+import jp.go.aist.rtm.rtcbuilder.generator.ProfileHandler;
+import jp.go.aist.rtm.rtcbuilder.generator.param.GeneratorParam;
+
+public class FSMTest extends TestBase {
+
+	protected void setUp() throws Exception {
+	}
+
+	private List<GeneratedResult> generateCode(String rtcProfile, String fsmProfile) throws Exception {
+		ProfileHandler handler = new ProfileHandler(true);
+		GeneratorParam genParam = handler.restorefromXMLFile(rtcProfile, true);
+		
+		ScXMLHandler scHandler = new ScXMLHandler();
+		StringBuffer buffer = new StringBuffer();
+		StateParam rootState = scHandler.parseSCXML(fsmProfile, buffer);
+		if(rootState!=null) {
+			genParam.getRtcParam().setFsmParam(rootState);
+			genParam.getRtcParam().setFsmContents(buffer.toString());
+			genParam.getRtcParam().parseEvent();
+			
+		}
+		
+		Generator generator = new Generator();
+		List<GeneratedResult> result = generator.generateTemplateCode(genParam);
+		return result;
+	}
+
+	private void checkGeneratedCode(List<GeneratedResult> result, String resourceDir) {
+		checkCode(result, resourceDir, "README.md");
+		
+		checkCode(result, resourceDir, "include/ModuleName/CMakeLists.txt");
+		checkCode(result, resourceDir, "include/ModuleName/ModuleName.h");
+		checkCode(result, resourceDir, "include/ModuleName/ModuleNameFSM.h");
+		
+		checkCode(result, resourceDir, "src/CMakeLists.txt");
+		checkCode(result, resourceDir, "src/ModuleName.cpp");
+		checkCode(result, resourceDir, "src/ModuleNameComp.cpp");
+		checkCode(result, resourceDir, "src/ModuleNameFSM.cpp");
+		
+		checkCode(result, resourceDir, "test/include/ModuleNameTest/ModuleNameTest.h");
+		checkCode(result, resourceDir, "test/src/CMakeLists.txt");
+		checkCode(result, resourceDir, "test/src/ModuleNameTest.cpp");
+		checkCode(result, resourceDir, "test/src/ModuleNameTestComp.cpp");
+	}
+
+	public void testBasic() throws Exception {
+		String rtcProfile = rootPath + "resource/FSM/basic/RTC.xml";
+		String fsmProfile = rootPath + "resource/FSM/basic/ModuleNameFSM.scxml";
+		String resourceDir = rootPath + "/resource/FSM/basic/";
+		
+		List<GeneratedResult> result = generateCode(rtcProfile, fsmProfile);
+		checkGeneratedCode(result, resourceDir);
+	}
+
+	public void testPortName() throws Exception {
+		String rtcProfile = rootPath + "resource/FSM/portName/RTC.xml";
+		String fsmProfile = rootPath + "resource/FSM/portName/ModuleNameFSM.scxml";
+		String resourceDir = rootPath + "/resource/FSM/portName/";
+		
+		List<GeneratedResult> result = generateCode(rtcProfile, fsmProfile);
+		checkGeneratedCode(result, resourceDir);
+	}
+	
+	public void testEventName() throws Exception {
+		String rtcProfile = rootPath + "resource/FSM/eventName/RTC.xml";
+		String fsmProfile = rootPath + "resource/FSM/eventName/ModuleNameFSM.scxml";
+		String resourceDir = rootPath + "/resource/FSM/eventName/";
+		
+		List<GeneratedResult> result = generateCode(rtcProfile, fsmProfile);
+		checkGeneratedCode(result, resourceDir);
+	}
+	
+	public void testEventCond() throws Exception {
+		String rtcProfile = rootPath + "resource/FSM/eventCond/RTC.xml";
+		String fsmProfile = rootPath + "resource/FSM/eventCond/ModuleNameFSM.scxml";
+		String resourceDir = rootPath + "/resource/FSM/eventCond/";
+		
+		List<GeneratedResult> result = generateCode(rtcProfile, fsmProfile);
+		checkGeneratedCode(result, resourceDir);
+	}
+	
+	public void testEventType() throws Exception {
+		String rtcProfile = rootPath + "resource/FSM/eventType/RTC.xml";
+		String fsmProfile = rootPath + "resource/FSM/eventType/ModuleNameFSM.scxml";
+		String resourceDir = rootPath + "/resource/FSM/eventType/";
+		
+		List<GeneratedResult> result = generateCode(rtcProfile, fsmProfile);
+		checkGeneratedCode(result, resourceDir);
+	}
+	
+	public void testEventDoc() throws Exception {
+		String rtcProfile = rootPath + "resource/FSM/eventDoc/RTC.xml";
+		String fsmProfile = rootPath + "resource/FSM/eventDoc/ModuleNameFSM.scxml";
+		String resourceDir = rootPath + "/resource/FSM/eventDoc/";
+		
+		List<GeneratedResult> result = generateCode(rtcProfile, fsmProfile);
+		checkGeneratedCode(result, resourceDir);
+	}
+	
+	public void testStateEntry() throws Exception {
+		String rtcProfile = rootPath + "resource/FSM/stateEntry/RTC.xml";
+		String fsmProfile = rootPath + "resource/FSM/stateEntry/ModuleNameFSM.scxml";
+		String resourceDir = rootPath + "/resource/FSM/stateEntry/";
+		
+		List<GeneratedResult> result = generateCode(rtcProfile, fsmProfile);
+		checkGeneratedCode(result, resourceDir);
+	}
+}


### PR DESCRIPTION
## Identify the Bug

Link to #256

## Description of the Change

C++版FSM RTCおよびPython版FSM RTCについて，コード生成に関するユニットテストを追加させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [x] Have you passed the unit tests? ユニットテストを追加し，指定した内容でコードが生成されることを確認