### PR TITLE
IDLファイルのパースに失敗した場合に，詳細情報を表示するように修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/generator/IDLParamConverter.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/generator/IDLParamConverter.java
@@ -239,7 +239,7 @@ public class IDLParamConverter {
 		return builder.toString();
 	}
 
-	public static boolean extractTypeDef(List<DataTypeParam> sources, List<String> result) {
+	public static boolean extractTypeDef(List<DataTypeParam> sources, List<String> result, StringBuilder builder) {
 		boolean ret = true;
 		for( Iterator<DataTypeParam> iter = sources.iterator(); iter.hasNext(); ) {
 			DataTypeParam targetParam = iter.next();
@@ -250,6 +250,8 @@ public class IDLParamConverter {
 			try {
 				spec = parser.specification();
 			} catch (ParseException e) {
+				builder.append("Target File : ").append(targetParam.getDispPath()).append(System.lineSeparator());
+				builder.append(e.getMessage()).append(System.lineSeparator());
 				ret = false;
 				continue;
 			}

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/AbstractEditorFormPage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/AbstractEditorFormPage.java
@@ -480,8 +480,10 @@ public abstract class AbstractEditorFormPage extends FormPage {
 		}
 		String[] defaultTypeList = new String[0];
 		List<String> dataTypes = new ArrayList<String>();
-		if( IDLParamConverter.extractTypeDef(sourceContents, dataTypes)==false ) {
-			MessageDialog.openWarning(RtcBuilderPlugin.getDefault().getWorkbench().getActiveWorkbenchWindow().getShell(), "IDL Parse", IMessageConstants.IDL_PARSE_EROOR);
+		StringBuilder builder = new StringBuilder();
+		if( IDLParamConverter.extractTypeDef(sourceContents, dataTypes, builder)==false ) {
+			MessageDialog.openWarning(RtcBuilderPlugin.getDefault().getWorkbench().getActiveWorkbenchWindow().getShell(),
+					"IDL Parse", IMessageConstants.IDL_PARSE_EROOR + System.lineSeparator() + builder.toString());
 		}
 		defaultTypeList = new String[dataTypes.size()];
 		defaultTypeList = dataTypes.toArray(defaultTypeList);

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/DataPortEditorFormPage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/DataPortEditorFormPage.java
@@ -90,6 +90,9 @@ public class DataPortEditorFormPage extends AbstractEditorFormPage {
 	private List<DataParam> typeList = new ArrayList<DataParam>();
 	private List<DataParam> currentList = new ArrayList<DataParam>();
 
+	public void setDefaultTypeList(String[] defaultTypeList) {
+		this.defaultTypeList = defaultTypeList;
+	}
 	/**
 	 * コンストラクタ
 	 *
@@ -100,7 +103,11 @@ public class DataPortEditorFormPage extends AbstractEditorFormPage {
 		super(editor, "id", Messages.getString("IMC.DATAPORT_SECTION"));
 		//
 		preSelection = null;
-		updateDefaultValue();
+		
+		IPreferenceStore store = RtcBuilderPlugin.getDefault().getPreferenceStore();
+		defaultPortName = ComponentPreferenceManager.getInstance().getDataPort_Name();
+		defaultPortType = store.getString(ComponentPreferenceManager.Generate_DataPort_Type);
+		defaultPortVarName = store.getString(ComponentPreferenceManager.Generate_DataPort_VarName);
 	}
 
 	public void updateDefaultValue() {

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/FSMEditorFormPage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/FSMEditorFormPage.java
@@ -91,6 +91,10 @@ public class FSMEditorFormPage extends AbstractEditorFormPage {
 	
 	private EventParam selectParam;
 	private String[] defaultTypeList;
+	
+	public String[] getDefaultTypeList() {
+		return defaultTypeList;
+	}
 	//
 	/**
 	 * コンストラクタ

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/RtcBuilderEditor.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/RtcBuilderEditor.java
@@ -266,6 +266,7 @@ public class RtcBuilderEditor extends FormEditor implements IActionFilter {
 			fsmFormPage = new FSMEditorFormPage(this);
 			defaultPages[2] = fsmFormPage;
 			dataPortFormPage = new DataPortEditorFormPage(this);
+			dataPortFormPage.setDefaultTypeList(fsmFormPage.getDefaultTypeList());
 			defaultPages[3] = dataPortFormPage;
 			servicePortFormPage = new ServicePortEditorFormPage(this);
 			defaultPages[4] = servicePortFormPage;

--- a/jp.go.aist.rtm.rtcbuilder/test/jp/go/aist/rtm/rtcbuilder/_test/parse/CORBAParseTest.java
+++ b/jp.go.aist.rtm.rtcbuilder/test/jp/go/aist/rtm/rtcbuilder/_test/parse/CORBAParseTest.java
@@ -22,7 +22,8 @@ public class CORBAParseTest extends TestBase {
 		}
 			
 		try {
-			IDLParamConverter.extractTypeDef(sourceContents, dataTypes);
+			StringBuilder builder = new StringBuilder();
+			IDLParamConverter.extractTypeDef(sourceContents, dataTypes, builder);
 		} catch (Exception e) {
 			fail();
 		}
@@ -39,7 +40,8 @@ public class CORBAParseTest extends TestBase {
 			sourceContents.get(intidx).setContent(idlContent);
 		}
 			
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 		
 		assertEquals(7, results.size());
 		assertTrue(results.contains("RTC::MyData"));
@@ -61,7 +63,8 @@ public class CORBAParseTest extends TestBase {
 			sourceContents.get(intidx).setContent(idlContent);
 		}
 			
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(2, results.size());
 		assertTrue(results.contains("RTC::MyData"));
@@ -78,7 +81,8 @@ public class CORBAParseTest extends TestBase {
 			sourceContents.get(intidx).setContent(idlContent);
 		}
 		
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(2, results.size());
 		assertTrue(results.contains("Time"));
@@ -94,7 +98,8 @@ public class CORBAParseTest extends TestBase {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(5, results.size());
 		assertTrue(results.contains("Time"));
@@ -113,7 +118,8 @@ public class CORBAParseTest extends TestBase {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 		assertEquals(0, results.size());
 	}
 	
@@ -126,7 +132,8 @@ public class CORBAParseTest extends TestBase {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(5, results.size());
 		assertTrue(results.contains("RTC::Time"));
@@ -145,7 +152,8 @@ public class CORBAParseTest extends TestBase {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(22, results.size());
 		assertTrue(results.contains("RTC::Time"));
@@ -181,7 +189,8 @@ public class CORBAParseTest extends TestBase {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(22, results.size());
 		assertTrue(results.contains("RTC::Time"));
@@ -217,7 +226,8 @@ public class CORBAParseTest extends TestBase {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(1, results.size());
 		assertTrue(results.contains("RTC::Time"));
@@ -233,7 +243,8 @@ public class CORBAParseTest extends TestBase {
 			sourceContents.get(intidx).setContent(idlContent);
 		}
 		try {
-			IDLParamConverter.extractTypeDef(sourceContents, results);
+			StringBuilder builder = new StringBuilder();
+			IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 		} catch (Exception ex) {
 			System.out.println("Error");
 			fail();

--- a/jp.go.aist.rtm.rtcbuilder/test/jp/go/aist/rtm/rtcbuilder/_test/parse/CORBAParseTypeTest.java
+++ b/jp.go.aist.rtm.rtcbuilder/test/jp/go/aist/rtm/rtcbuilder/_test/parse/CORBAParseTypeTest.java
@@ -19,7 +19,8 @@ public class CORBAParseTypeTest extends TestBase {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(1, results.size());
 		assertTrue(results.contains("AAA::BBB::CCC::TimeBBB"));
@@ -34,7 +35,8 @@ public class CORBAParseTypeTest extends TestBase {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 		
 		assertEquals(9, results.size());
 		assertTrue(results.contains("SDOPackage::NameValue"));
@@ -58,7 +60,8 @@ public class CORBAParseTypeTest extends TestBase {
 			sourceContents.get(intidx).setContent(idlContent);
 		}
 			
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 		
 		assertEquals(2, results.size());
 		assertTrue(results.contains("RTM::ModuleProfile"));
@@ -75,7 +78,8 @@ public class CORBAParseTypeTest extends TestBase {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 		
 		assertEquals(2, results.size());
 		assertTrue(results.contains("RTC::Time"));
@@ -94,7 +98,8 @@ public class CORBAParseTypeTest extends TestBase {
 		}
 			
 		try {
-			IDLParamConverter.extractTypeDef(sourceContents, results);
+			StringBuilder builder = new StringBuilder();
+			IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 		} catch (Exception e) {
 			fail();
 		}
@@ -110,7 +115,8 @@ public class CORBAParseTypeTest extends TestBase {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 		
 		assertEquals(7, results.size());
 		assertTrue(results.contains("RTC::MyData"));
@@ -131,7 +137,8 @@ public class CORBAParseTypeTest extends TestBase {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(2, results.size());
 		assertTrue(results.contains("RTC::MyData"));
@@ -147,7 +154,8 @@ public class CORBAParseTypeTest extends TestBase {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(2, results.size());
 		assertTrue(results.contains("Time"));
@@ -163,7 +171,8 @@ public class CORBAParseTypeTest extends TestBase {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(5, results.size());
 		assertTrue(results.contains("Time"));
@@ -182,7 +191,8 @@ public class CORBAParseTypeTest extends TestBase {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 		assertEquals(0, results.size());
 	}
 	
@@ -195,7 +205,8 @@ public class CORBAParseTypeTest extends TestBase {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(5, results.size());
 		assertTrue(results.contains("RTC::Time"));
@@ -214,7 +225,8 @@ public class CORBAParseTypeTest extends TestBase {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(22, results.size());
 		assertTrue(results.contains("RTC::Time"));
@@ -250,7 +262,8 @@ public class CORBAParseTypeTest extends TestBase {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(22, results.size());
 		assertTrue(results.contains("RTC::Time"));
@@ -286,7 +299,8 @@ public class CORBAParseTypeTest extends TestBase {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(1, results.size());
 		assertTrue(results.contains("RTC::Time"));
@@ -302,7 +316,8 @@ public class CORBAParseTypeTest extends TestBase {
 			sourceContents.get(intidx).setContent(idlContent);
 		}
 		try {
-			IDLParamConverter.extractTypeDef(sourceContents, results);
+			StringBuilder builder = new StringBuilder();
+			IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 		} catch (Exception ex) {
 			fail();
 			System.out.println("Error");


### PR DESCRIPTION
## Identify the Bug

Link to #253

## Description of the Change

IDLファイルの不備などで，パースに失敗した場合に，以下の詳細情報を表示するように修正しました．
- 対象ファイル名
- パースに失敗した箇所

また，RTCBuilder起動時にIDLファイルのパースに失敗すると，メッセージが複数回表示されていたので，１回だけ表示するように修正しました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [x] Have you passed the unit tests? 既存のユニットテストが正常に実行されることを確認