### PR TITLE
FSMエディタを閉じた際の処理を修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/FSMEditorFormPage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/FSMEditorFormPage.java
@@ -664,44 +664,51 @@ public class FSMEditorFormPage extends AbstractEditorFormPage {
 		public void notifyContents(String contents, List<EventParam> eventList) {
     		editor.updateDirty();
 			ScXMLHandler handler = new ScXMLHandler();
-			StateParam rootState = handler.parseSCXMLStr(contents);
-			if(rootState!=null) {
-				rtcParam.setFsmParam(rootState);
-				rtcParam.setFsmContents(contents);
-				
-				List<EventParam> newEventList = new ArrayList<EventParam>();
-				List<TransitionParam> transList = rootState.getAllTransList();
-				for(TransitionParam trans : transList) {
-					StateParam source = rootState.getStateParam(trans.getSource());
-					StateParam target = rootState.getStateParam(trans.getTarget());
-					if(source.isInitial() || target.isInitial()) continue;
-					
-					EventParam newParam = new EventParam();
-					newParam.setName(trans.getEvent());
-					newParam.setCondition(trans.getCondition());
-					newParam.setSource(trans.getSource());
-					newParam.setTarget(trans.getTarget());
-					for(EventParam event : eventList) {
-						if(newParam.checkSame(event)) {
-							newParam.replaceContents(event);
-							break;
-						}
-					}
-					newEventList.add(newParam);
-				}
-				rtcParam.getEventports().get(0).getEvents().clear();
-				rtcParam.getEventports().get(0).getEvents().addAll(newEventList);
-				editor.updateDirty();
-				PlatformUI.getWorkbench().getDisplay().asyncExec(new Runnable() {
-					public void run() {
-						editBtn.setEnabled(true);
-						if(eventTableViewer.getInput()==null) {
-							eventTableViewer.setInput(rtcParam.getEventports().get(0).getEvents());
-						}
-						eventTableViewer.refresh();
-					}
-				});
+			if(contents==null || contents.length()==0) {
+				scxmlEditor = null;
+				return;
 			}
+			StateParam rootState = handler.parseSCXMLStr(contents);
+			if(rootState==null) {
+				scxmlEditor = null;
+				return;
+			}
+			
+			rtcParam.setFsmParam(rootState);
+			rtcParam.setFsmContents(contents);
+			
+			List<EventParam> newEventList = new ArrayList<EventParam>();
+			List<TransitionParam> transList = rootState.getAllTransList();
+			for(TransitionParam trans : transList) {
+				StateParam source = rootState.getStateParam(trans.getSource());
+				StateParam target = rootState.getStateParam(trans.getTarget());
+				if(source.isInitial() || target.isInitial()) continue;
+				
+				EventParam newParam = new EventParam();
+				newParam.setName(trans.getEvent());
+				newParam.setCondition(trans.getCondition());
+				newParam.setSource(trans.getSource());
+				newParam.setTarget(trans.getTarget());
+				for(EventParam event : eventList) {
+					if(newParam.checkSame(event)) {
+						newParam.replaceContents(event);
+						break;
+					}
+				}
+				newEventList.add(newParam);
+			}
+			rtcParam.getEventports().get(0).getEvents().clear();
+			rtcParam.getEventports().get(0).getEvents().addAll(newEventList);
+			editor.updateDirty();
+			PlatformUI.getWorkbench().getDisplay().asyncExec(new Runnable() {
+				public void run() {
+					editBtn.setEnabled(true);
+					if(eventTableViewer.getInput()==null) {
+						eventTableViewer.setInput(rtcParam.getEventports().get(0).getEvents());
+					}
+					eventTableViewer.refresh();
+				}
+			});
 			scxmlEditor = null;
 		}
 	}


### PR DESCRIPTION
## Identify the Bug

Link to #261

## Description of the Change

FSMタブの｢新規作成｣ボタンを押した後，何もせずにFSMエディタを閉じた場合，再度｢新規作成｣ボタンを押してもFSMエディタが表示されない現象を修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests? ユニットテストなし