### PR TITLE
FSM RTCのコード生成時，終了状態についてもコードを生成するように修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventCond/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventCond/ModuleNameFSM.scxml
@@ -1,12 +1,1 @@
-<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=212 h=513  -->
- <state id="InitialState"><!--   node-size-and-position x=55.86 y=43 w=100 h=75  -->
-  <transition id="13" target="State01"></transition>
- </state>
- <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->
-  <transition cond="Cond01" event="Event01-02" id="15" target="State02"></transition>
- </state>
- <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->
-  <transition cond="Cond02" event="Event02-Final" id="17" target="FinalState"></transition>
- </state>
- <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final>
-</scxml>
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=212 h=513  --> <state id="InitialState"><!--   node-size-and-position x=55.86 y=43 w=100 h=75  -->  <transition id="13" target="State01"></transition> </state> <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->  <transition cond="Cond01" event="Event01_02" id="15" target="State02"></transition> </state> <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->  <transition cond="Cond02" event="Event02_Final" id="17" target="FinalState"></transition> </state> <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final></scxml>

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventCond/README.md
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventCond/README.md
@@ -1,23 +1,10 @@
 # ModuleName
-
 ## Overview
-
 ModuleDescription
-
 ## Description
-
-
-
 ### Input and Output
-
-
-
 ### Algorithm etc
-
-
-
 ### Basic Information
-
 |  |  |
 ----|---- 
 | Module Name | ModuleName |
@@ -29,9 +16,7 @@ ModuleDescription
 | Act. Type | PERIODIC |
 | Kind | DataFlowComponent |
 | MAX Inst. | 1 |
-
 ### Activity definition
-
 <table>
   <tr>
     <td rowspan="4">on_initialize</td>
@@ -94,16 +79,12 @@ ModuleDescription
     <td colspan="2"></td>
   </tr>
 </table>
-
 ### EventPorts definition
-
 |  |  |
 ----|---- 
 | Port Name | FSMEventPort |
 | FSM Type | StaticFSM |
-
 #### Node list
-
 <table>
   <tr>
     <td>State Name</td>
@@ -128,15 +109,9 @@ ModuleDescription
     <td>FinalState</td>
     <td colspan="2">Final State</td>
   </tr>
-
 </table>
-
 #### Event list
-
 ##### 
-
-
-
 <table>
   <tr>
     <td>Source State</td>
@@ -164,13 +139,7 @@ ModuleDescription
     <td colspan="2"></td>
   </tr>
 </table>
-
-
-
 ##### Event01_02
-
-
-
 <table>
   <tr>
     <td>Source State</td>
@@ -198,13 +167,7 @@ ModuleDescription
     <td colspan="2"></td>
   </tr>
 </table>
-
-
-
 ##### Event02_Final
-
-
-
 <table>
   <tr>
     <td>Source State</td>
@@ -232,47 +195,17 @@ ModuleDescription
     <td colspan="2"></td>
   </tr>
 </table>
-
-
-
-
-
 ### InPorts definition
-
-
 ### OutPorts definition
-
-
 ### Service Port definition
-
-
 ### Configuration definition
-
-
 ## Demo
-
 ## Requirement
-
 ## Setup
-
 ### Windows
-
 ### Ubuntu
-
 ## Usage
-
 ## Running the tests
-
 ## LICENCE
-
-
-
-
 ## References
-
-
-
-
 ## Author
-
-

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventCond/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventCond/RTC.xml
@@ -24,10 +24,10 @@
         <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State01" rtc:source="InitialState" rtc:condition="" rtc:name="">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01-02">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01_02">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02-Final">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02_Final">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
     </rtc:DataPorts>

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventName/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventName/ModuleNameFSM.scxml
@@ -1,12 +1,1 @@
-<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=140 h=513  -->
- <state id="InitialState"><!--   node-size-and-position x=20 y=43 w=100 h=75  -->
-  <transition id="13" target="State01"></transition>
- </state>
- <state id="State01"><!--   node-size-and-position x=32.5 y=168 w=75 h=75  -->
-  <transition event="Event01-02" id="15" target="State02"></transition>
- </state>
- <state id="State02"><!--   node-size-and-position x=32.5 y=293 w=75 h=75  -->
-  <transition event="Event02-Final" id="17" target="FinalState"></transition>
- </state>
- <final id="FinalState"><!--   node-size-and-position x=30 y=418 w=80 h=75  --></final>
-</scxml>
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=140 h=513  --> <state id="InitialState"><!--   node-size-and-position x=20 y=43 w=100 h=75  -->  <transition id="13" target="State01"></transition> </state> <state id="State01"><!--   node-size-and-position x=32.5 y=168 w=75 h=75  -->  <transition event="Event01_02" id="15" target="State02"></transition> </state> <state id="State02"><!--   node-size-and-position x=32.5 y=293 w=75 h=75  -->  <transition event="Event02_Final" id="17" target="FinalState"></transition> </state> <final id="FinalState"><!--   node-size-and-position x=30 y=418 w=80 h=75  --></final></scxml>

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventName/README.md
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventName/README.md
@@ -1,23 +1,10 @@
 # ModuleName
-
 ## Overview
-
 ModuleDescription
-
 ## Description
-
-
-
 ### Input and Output
-
-
-
 ### Algorithm etc
-
-
-
 ### Basic Information
-
 |  |  |
 ----|---- 
 | Module Name | ModuleName |
@@ -29,9 +16,7 @@ ModuleDescription
 | Act. Type | PERIODIC |
 | Kind | DataFlowComponent |
 | MAX Inst. | 1 |
-
 ### Activity definition
-
 <table>
   <tr>
     <td rowspan="4">on_initialize</td>
@@ -94,16 +79,12 @@ ModuleDescription
     <td colspan="2"></td>
   </tr>
 </table>
-
 ### EventPorts definition
-
 |  |  |
 ----|---- 
 | Port Name | FSMEventPort |
 | FSM Type | StaticFSM |
-
 #### Node list
-
 <table>
   <tr>
     <td>State Name</td>
@@ -128,15 +109,9 @@ ModuleDescription
     <td>FinalState</td>
     <td colspan="2">Final State</td>
   </tr>
-
 </table>
-
 #### Event list
-
 ##### 
-
-
-
 <table>
   <tr>
     <td>Source State</td>
@@ -164,13 +139,7 @@ ModuleDescription
     <td colspan="2"></td>
   </tr>
 </table>
-
-
-
 ##### Event01_02
-
-
-
 <table>
   <tr>
     <td>Source State</td>
@@ -198,13 +167,7 @@ ModuleDescription
     <td colspan="2"></td>
   </tr>
 </table>
-
-
-
 ##### Event02_Final
-
-
-
 <table>
   <tr>
     <td>Source State</td>
@@ -232,47 +195,17 @@ ModuleDescription
     <td colspan="2"></td>
   </tr>
 </table>
-
-
-
-
-
 ### InPorts definition
-
-
 ### OutPorts definition
-
-
 ### Service Port definition
-
-
 ### Configuration definition
-
-
 ## Demo
-
 ## Requirement
-
 ## Setup
-
 ### Windows
-
 ### Ubuntu
-
 ## Usage
-
 ## Running the tests
-
 ## LICENCE
-
-
-
-
 ## References
-
-
-
-
 ## Author
-
-

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventName/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventName/RTC.xml
@@ -21,10 +21,10 @@
         <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
     </rtc:Actions>
     <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="" rtc:name="Event01-02">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="" rtc:name="Event01_02">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="" rtc:name="Event02-Final">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="" rtc:name="Event02_Final">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
         <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State01" rtc:source="InitialState" rtc:condition="" rtc:name="">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateEntry/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateEntry/ModuleNameFSM.scxml
@@ -1,48 +1,1 @@
-<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=212 h=513  -->
-
- <state id="InitialState"><!--   node-size-and-position x=55.86 y=43 w=100 h=75  -->
-
-  <transition id="13" target="State01"></transition>
-
- </state>
-
- <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->
-
-  <onentry>
-
-   <log label="ON"></log>
-
-  </onentry>
-
-  <onexit>
-
-   <log label="ON"></log>
-
-  </onexit>
-
-  <transition cond="Cond01" event="Event01-02" id="15" target="State02"></transition>
-
- </state>
-
- <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->
-
-  <onentry>
-
-   <log label="ON"></log>
-
-  </onentry>
-
-  <onexit>
-
-   <log label="ON"></log>
-
-  </onexit>
-
-  <transition cond="Cond02" event="Event02-Final" id="17" target="FinalState"></transition>
-
- </state>
-
- <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final>
-
-</scxml>
-
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=212 h=513  --> <state id="InitialState"><!--   node-size-and-position x=55.86 y=43 w=100 h=75  -->  <transition id="13" target="State01"></transition> </state> <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->  <onentry>   <log label="ON"></log>  </onentry>  <onexit>   <log label="ON"></log>  </onexit>  <transition cond="Cond01" event="Event01_02" id="15" target="State02"></transition> </state> <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->  <onentry>   <log label="ON"></log>  </onentry>  <onexit>   <log label="ON"></log>  </onexit>  <transition cond="Cond02" event="Event02_Final" id="17" target="FinalState"></transition> </state> <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final></scxml>

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateEntry/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateEntry/RTC.xml
@@ -21,10 +21,10 @@
         <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
     </rtc:Actions>
     <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedLong" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01-02">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedLong" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01_02">
             <rtcDoc:Doc rtcDoc:operation="Period01-02" rtcDoc:unit="Unit01-02" rtcDoc:semantics="Detail01-02" rtcDoc:number="Num01-02" rtcDoc:type="Type01-02" rtcDoc:description="Abst01-02"/>
         </rtc:Event>
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedString" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02-Final">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedString" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02_Final">
             <rtcDoc:Doc rtcDoc:operation="Period02-Final" rtcDoc:unit="Unit02-Final" rtcDoc:semantics="Detail02-Final" rtcDoc:number="Num02-Final" rtcDoc:type="Type02-Final" rtcDoc:description="Abst02-Final"/>
         </rtc:Event>
         <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State01" rtc:source="InitialState" rtc:condition="" rtc:name="">

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateName/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateName/ModuleNameFSM.scxml
@@ -1,24 +1,1 @@
-<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=854 h=400  -->
-
- <state id="InitialState"><!--   node-size-and-position x=90 y=150 w=75 h=75  -->
-
-  <transition id="21" target="State-01"></transition>
-
- </state>
-
- <state id="State-01"><!--   node-size-and-position x=280 y=150 w=75 h=75  -->
-
-  <transition id="22" target="State-02"></transition>
-
- </state>
-
- <state id="State-02"><!--   node-size-and-position x=470 y=150 w=75 h=75  -->
-
-  <transition id="23" target="FinalState"></transition>
-
- </state>
-
- <final id="FinalState"><!--   node-size-and-position x=650 y=160 w=75 h=75  --></final>
-
-</scxml>
-
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=854 h=400  --> <state id="InitialState"><!--   node-size-and-position x=90 y=150 w=75 h=75  -->  <transition id="21" target="State_01"></transition> </state> <state id="State_01"><!--   node-size-and-position x=280 y=150 w=75 h=75  -->  <transition id="22" target="State_02"></transition> </state> <state id="State_02"><!--   node-size-and-position x=470 y=150 w=75 h=75  -->  <transition id="23" target="FinalState"></transition> </state> <final id="FinalState"><!--   node-size-and-position x=650 y=160 w=75 h=75  --></final></scxml>

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateName/README.md
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateName/README.md
@@ -1,23 +1,10 @@
 # ModuleName
-
 ## Overview
-
 ModuleDescription
-
 ## Description
-
-
-
 ### Input and Output
-
-
-
 ### Algorithm etc
-
-
-
 ### Basic Information
-
 |  |  |
 ----|---- 
 | Module Name | ModuleName |
@@ -29,9 +16,7 @@ ModuleDescription
 | Act. Type | PERIODIC |
 | Kind | DataFlowComponent |
 | MAX Inst. | 1 |
-
 ### Activity definition
-
 <table>
   <tr>
     <td rowspan="4">on_initialize</td>
@@ -94,16 +79,12 @@ ModuleDescription
     <td colspan="2"></td>
   </tr>
 </table>
-
 ### EventPorts definition
-
 |  |  |
 ----|---- 
 | Port Name | FSMEvent |
 | FSM Type | StaticFSM |
-
 #### Node list
-
 <table>
   <tr>
     <td>State Name</td>
@@ -128,15 +109,9 @@ ModuleDescription
     <td>FinalState</td>
     <td colspan="2">Final State</td>
   </tr>
-
 </table>
-
 #### Event list
-
 ##### 
-
-
-
 <table>
   <tr>
     <td>Source State</td>
@@ -164,13 +139,7 @@ ModuleDescription
     <td colspan="2"></td>
   </tr>
 </table>
-
-
-
 ##### 
-
-
-
 <table>
   <tr>
     <td>Source State</td>
@@ -198,13 +167,7 @@ ModuleDescription
     <td colspan="2"></td>
   </tr>
 </table>
-
-
-
 ##### 
-
-
-
 <table>
   <tr>
     <td>Source State</td>
@@ -232,47 +195,17 @@ ModuleDescription
     <td colspan="2"></td>
   </tr>
 </table>
-
-
-
-
-
 ### InPorts definition
-
-
 ### OutPorts definition
-
-
 ### Service Port definition
-
-
 ### Configuration definition
-
-
 ## Demo
-
 ## Requirement
-
 ## Setup
-
 ### Windows
-
 ### Ubuntu
-
 ## Usage
-
 ## Running the tests
-
 ## LICENCE
-
-
-
-
 ## References
-
-
-
-
 ## Author
-
-

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateName/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateName/RTC.xml
@@ -21,13 +21,13 @@
         <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
     </rtc:Actions>
     <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEvent" rtc:type="Any" rtc:name="FSMEvent" rtc:portType="EventPort">
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State-02" rtc:source="State-01" rtc:condition="" rtc:name="">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State_02" rtc:source="State_01" rtc:condition="" rtc:name="">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State-02" rtc:condition="" rtc:name="">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State_02" rtc:condition="" rtc:name="">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State-01" rtc:source="InitialState" rtc:condition="" rtc:name="">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State_01" rtc:source="InitialState" rtc:condition="" rtc:name="">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
     </rtc:DataPorts>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/ModuleNameFSM.py
@@ -26,4 +26,7 @@ class State01(StaticFSM.Link):
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class State02(StaticFSM.Link):
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class FinalState(StaticFSM.Link):
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/ModuleNameFSM.scxml
@@ -1,12 +1,1 @@
-<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=854 h=400  -->
- <state id="InitialState"><!--   node-size-and-position x=90 y=150 w=75 h=75  -->
-  <transition id="21" target="State01"></transition>
- </state>
- <state id="State01"><!--   node-size-and-position x=280 y=150 w=75 h=75  -->
-  <transition id="22" target="State02"></transition>
- </state>
- <state id="State02"><!--   node-size-and-position x=470 y=150 w=75 h=75  -->
-  <transition id="23" target="FinalState"></transition>
- </state>
- <final id="FinalState"><!--   node-size-and-position x=650 y=160 w=75 h=75  --></final>
-</scxml>
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=854 h=400  --> <state id="InitialState"><!--   node-size-and-position x=90 y=150 w=75 h=75  -->  <transition id="21" target="State01"></transition> </state> <state id="State01"><!--   node-size-and-position x=280 y=150 w=75 h=75  -->  <transition id="22" target="State02"></transition> </state> <state id="State02"><!--   node-size-and-position x=470 y=150 w=75 h=75  -->  <transition id="23" target="FinalState"></transition> </state> <final id="FinalState"><!--   node-size-and-position x=650 y=160 w=75 h=75  --></final></scxml>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/ModuleNameFSM.py
@@ -40,4 +40,7 @@ class State01(StaticFSM.Link):
 class State02(StaticFSM.Link):
     def Event02_Final(self):
         self.set_state(StaticFSM.State(FinalState))
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class FinalState(StaticFSM.Link):
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/ModuleNameFSM.scxml
@@ -1,12 +1,1 @@
-<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=212 h=513  -->
- <state id="InitialState"><!--   node-size-and-position x=55.86 y=43 w=100 h=75  -->
-  <transition id="13" target="State01"></transition>
- </state>
- <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->
-  <transition cond="Cond01" event="Event01-02" id="15" target="State02"></transition>
- </state>
- <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->
-  <transition cond="Cond02" event="Event02-Final" id="17" target="FinalState"></transition>
- </state>
- <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final>
-</scxml>
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=212 h=513  --> <state id="InitialState"><!--   node-size-and-position x=55.86 y=43 w=100 h=75  -->  <transition id="13" target="State01"></transition> </state> <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->  <transition cond="Cond01" event="Event01_02" id="15" target="State02"></transition> </state> <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->  <transition cond="Cond02" event="Event02_Final" id="17" target="FinalState"></transition> </state> <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final></scxml>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/RTC.xml
@@ -24,10 +24,10 @@
         <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State01" rtc:source="InitialState" rtc:condition="" rtc:name="">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01-02">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01_02">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02-Final">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02_Final">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
     </rtc:DataPorts>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/ModuleNameFSM.py
@@ -52,4 +52,7 @@ class State01(StaticFSM.Link):
 class State02(StaticFSM.Link):
     def Event02_Final(self, data):
         self.set_state(StaticFSM.State(FinalState))
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class FinalState(StaticFSM.Link):
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/ModuleNameFSM.scxml
@@ -1,12 +1,1 @@
-<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=212 h=513  -->
- <state id="InitialState"><!--   node-size-and-position x=55.86 y=43 w=100 h=75  -->
-  <transition id="13" target="State01"></transition>
- </state>
- <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->
-  <transition cond="Cond01" event="Event01-02" id="15" target="State02"></transition>
- </state>
- <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->
-  <transition cond="Cond02" event="Event02-Final" id="17" target="FinalState"></transition>
- </state>
- <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final>
-</scxml>
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=212 h=513  --> <state id="InitialState"><!--   node-size-and-position x=55.86 y=43 w=100 h=75  -->  <transition id="13" target="State01"></transition> </state> <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->  <transition cond="Cond01" event="Event01_02" id="15" target="State02"></transition> </state> <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->  <transition cond="Cond02" event="Event02_Final" id="17" target="FinalState"></transition> </state> <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final></scxml>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/RTC.xml
@@ -21,10 +21,10 @@
         <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
     </rtc:Actions>
     <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedLong" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01-02">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedLong" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01_02">
             <rtcDoc:Doc rtcDoc:operation="Period01-02" rtcDoc:unit="Unit01-02" rtcDoc:semantics="Detail01-02" rtcDoc:number="Num01-02" rtcDoc:type="Type01-02" rtcDoc:description="Abst01-02"/>
         </rtc:Event>
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedString" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02-Final">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedString" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02_Final">
             <rtcDoc:Doc rtcDoc:operation="Period02-Final" rtcDoc:unit="Unit02-Final" rtcDoc:semantics="Detail02-Final" rtcDoc:number="Num02-Final" rtcDoc:type="Type02-Final" rtcDoc:description="Abst02-Final"/>
         </rtc:Event>
         <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State01" rtc:source="InitialState" rtc:condition="" rtc:name="">

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/ModuleNameFSM.py
@@ -40,4 +40,7 @@ class State01(StaticFSM.Link):
 class State02(StaticFSM.Link):
     def Event02_Final(self):
         self.set_state(StaticFSM.State(FinalState))
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class FinalState(StaticFSM.Link):
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/ModuleNameFSM.scxml
@@ -1,12 +1,1 @@
-<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=140 h=513  -->
- <state id="InitialState"><!--   node-size-and-position x=20 y=43 w=100 h=75  -->
-  <transition id="13" target="State01"></transition>
- </state>
- <state id="State01"><!--   node-size-and-position x=32.5 y=168 w=75 h=75  -->
-  <transition event="Event01-02" id="15" target="State02"></transition>
- </state>
- <state id="State02"><!--   node-size-and-position x=32.5 y=293 w=75 h=75  -->
-  <transition event="Event02-Final" id="17" target="FinalState"></transition>
- </state>
- <final id="FinalState"><!--   node-size-and-position x=30 y=418 w=80 h=75  --></final>
-</scxml>
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=140 h=513  --> <state id="InitialState"><!--   node-size-and-position x=20 y=43 w=100 h=75  -->  <transition id="13" target="State01"></transition> </state> <state id="State01"><!--   node-size-and-position x=32.5 y=168 w=75 h=75  -->  <transition event="Event01_02" id="15" target="State02"></transition> </state> <state id="State02"><!--   node-size-and-position x=32.5 y=293 w=75 h=75  -->  <transition event="Event02_Final" id="17" target="FinalState"></transition> </state> <final id="FinalState"><!--   node-size-and-position x=30 y=418 w=80 h=75  --></final></scxml>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/RTC.xml
@@ -21,10 +21,10 @@
         <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
     </rtc:Actions>
     <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="" rtc:name="Event01-02">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="" rtc:name="Event01_02">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="" rtc:name="Event02-Final">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="" rtc:name="Event02_Final">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
         <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State01" rtc:source="InitialState" rtc:condition="" rtc:name="">

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/ModuleNameFSM.py
@@ -40,4 +40,7 @@ class State01(StaticFSM.Link):
 class State02(StaticFSM.Link):
     def Event02_Final(self, data):
         self.set_state(StaticFSM.State(FinalState))
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class FinalState(StaticFSM.Link):
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/ModuleNameFSM.scxml
@@ -1,12 +1,1 @@
-<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=212 h=513  -->
- <state id="InitialState"><!--   node-size-and-position x=55.86 y=43 w=100 h=75  -->
-  <transition id="13" target="State01"></transition>
- </state>
- <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->
-  <transition cond="Cond01" event="Event01-02" id="15" target="State02"></transition>
- </state>
- <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->
-  <transition cond="Cond02" event="Event02-Final" id="17" target="FinalState"></transition>
- </state>
- <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final>
-</scxml>
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=212 h=513  --> <state id="InitialState"><!--   node-size-and-position x=55.86 y=43 w=100 h=75  -->  <transition id="13" target="State01"></transition> </state> <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->  <transition cond="Cond01" event="Event01_02" id="15" target="State02"></transition> </state> <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->  <transition cond="Cond02" event="Event02_Final" id="17" target="FinalState"></transition> </state> <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final></scxml>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/RTC.xml
@@ -21,10 +21,10 @@
         <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
     </rtc:Actions>
     <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedLong" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01-02">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedLong" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01_02">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedString" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02-Final">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedString" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02_Final">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
         <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State01" rtc:source="InitialState" rtc:condition="" rtc:name="">

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/ModuleNameFSM.py
@@ -26,4 +26,7 @@ class State01(StaticFSM.Link):
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class State02(StaticFSM.Link):
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class FinalState(StaticFSM.Link):
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/ModuleNameFSM.scxml
@@ -1,48 +1,1 @@
-<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=854 h=400  -->
-
-
-
- <state id="InitialState"><!--   node-size-and-position x=90 y=150 w=75 h=75  -->
-
-
-
-  <transition id="21" target="State01"></transition>
-
-
-
- </state>
-
-
-
- <state id="State01"><!--   node-size-and-position x=280 y=150 w=75 h=75  -->
-
-
-
-  <transition id="22" target="State02"></transition>
-
-
-
- </state>
-
-
-
- <state id="State02"><!--   node-size-and-position x=470 y=150 w=75 h=75  -->
-
-
-
-  <transition id="23" target="FinalState"></transition>
-
-
-
- </state>
-
-
-
- <final id="FinalState"><!--   node-size-and-position x=650 y=160 w=75 h=75  --></final>
-
-
-
-</scxml>
-
-
-
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=854 h=400  --> <state id="InitialState"><!--   node-size-and-position x=90 y=150 w=75 h=75  -->  <transition id="21" target="State01"></transition> </state> <state id="State01"><!--   node-size-and-position x=280 y=150 w=75 h=75  -->  <transition id="22" target="State02"></transition> </state> <state id="State02"><!--   node-size-and-position x=470 y=150 w=75 h=75  -->  <transition id="23" target="FinalState"></transition> </state> <final id="FinalState"><!--   node-size-and-position x=650 y=160 w=75 h=75  --></final></scxml>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/ModuleNameFSM.py
@@ -64,4 +64,7 @@ class State02(StaticFSM.Link):
 
     def Event02_Final(self, data):
         self.set_state(StaticFSM.State(FinalState))
+  
+@StaticFSM.FSM_SUBSTATE(Top)
+class FinalState(StaticFSM.Link):
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/ModuleNameFSM.scxml
@@ -1,48 +1,1 @@
-<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=212 h=513  -->
-
- <state id="InitialState"><!--   node-size-and-position x=55.86 y=43 w=100 h=75  -->
-
-  <transition id="13" target="State01"></transition>
-
- </state>
-
- <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->
-
-  <onentry>
-
-   <log label="ON"></log>
-
-  </onentry>
-
-  <onexit>
-
-   <log label="ON"></log>
-
-  </onexit>
-
-  <transition cond="Cond01" event="Event01-02" id="15" target="State02"></transition>
-
- </state>
-
- <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->
-
-  <onentry>
-
-   <log label="ON"></log>
-
-  </onentry>
-
-  <onexit>
-
-   <log label="ON"></log>
-
-  </onexit>
-
-  <transition cond="Cond02" event="Event02-Final" id="17" target="FinalState"></transition>
-
- </state>
-
- <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final>
-
-</scxml>
-
+<scxml initial="InitialState" name="Top" version="1.0" xmlns="http://www.w3.org/2005/07/scxml"><!--   node-size-and-position x=0 y=0 w=212 h=513  --> <state id="InitialState"><!--   node-size-and-position x=55.86 y=43 w=100 h=75  -->  <transition id="13" target="State01"></transition> </state> <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->  <onentry>   <log label="ON"></log>  </onentry>  <onexit>   <log label="ON"></log>  </onexit>  <transition cond="Cond01" event="Event01_02" id="15" target="State02"></transition> </state> <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->  <onentry>   <log label="ON"></log>  </onentry>  <onexit>   <log label="ON"></log>  </onexit>  <transition cond="Cond02" event="Event02_Final" id="17" target="FinalState"></transition> </state> <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final></scxml>

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/RTC.xml
@@ -21,10 +21,10 @@
         <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
     </rtc:Actions>
     <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedLong" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01-02">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedLong" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01_02">
             <rtcDoc:Doc rtcDoc:operation="Period01-02" rtcDoc:unit="Unit01-02" rtcDoc:semantics="Detail01-02" rtcDoc:number="Num01-02" rtcDoc:type="Type01-02" rtcDoc:description="Abst01-02"/>
         </rtc:Event>
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedString" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02-Final">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedString" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02_Final">
             <rtcDoc:Doc rtcDoc:operation="Period02-Final" rtcDoc:unit="Unit02-Final" rtcDoc:semantics="Detail02-Final" rtcDoc:number="Num02-Final" rtcDoc:type="Type02-Final" rtcDoc:description="Abst02-Final"/>
         </rtc:Event>
         <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State01" rtc:source="InitialState" rtc:condition="" rtc:name="">

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/include/ModuleName/ModuleNameFSM.h
@@ -59,6 +59,16 @@ namespace ModuleNameFsm {
       // RTC::ReturnCode_t onInit() override;
   };
 
+  FSM_SUBSTATE(FinalState, Top) {
+    FSM_STATE(FinalState);
+  
+
+    // Event handler
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+  };
+
 
 } //end namespace 'ModuleNameFSM'
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/src/ModuleNameFSM.cpp
@@ -39,4 +39,12 @@ RTC::ReturnCode_t Top::onExit() {
 
 
 
+//============================================================
+// State FinalState
+// RTC::ReturnCode_t FinalState::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+
+
 } //end namespace 'ModuleNameFSM'

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/ModuleNameFSM.scxml
@@ -3,10 +3,10 @@
   <transition id="13" target="State01"></transition>
  </state>
  <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->
-  <transition cond="Cond01" event="Event01-02" id="15" target="State02"></transition>
+  <transition cond="Cond01" event="Event01_02" id="15" target="State02"></transition>
  </state>
  <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->
-  <transition cond="Cond02" event="Event02-Final" id="17" target="FinalState"></transition>
+  <transition cond="Cond02" event="Event02_Final" id="17" target="FinalState"></transition>
  </state>
  <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final>
 </scxml>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/RTC.xml
@@ -21,10 +21,10 @@
         <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
     </rtc:Actions>
     <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01-02">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01_02">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02-Final">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02_Final">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
     </rtc:DataPorts>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/include/ModuleName/ModuleNameFSM.h
@@ -69,6 +69,16 @@ namespace ModuleNameFsm {
       // RTC::ReturnCode_t onInit() override;
   };
 
+  FSM_SUBSTATE(FinalState, Top) {
+    FSM_STATE(FinalState);
+  
+
+    // Event handler
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+  };
+
 
 } //end namespace 'ModuleNameFSM'
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/src/ModuleNameFSM.cpp
@@ -47,4 +47,12 @@ void State02::Event02_Final() {
 }
 
 
+//============================================================
+// State FinalState
+// RTC::ReturnCode_t FinalState::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+
+
 } //end namespace 'ModuleNameFSM'

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/ModuleNameFSM.scxml
@@ -3,10 +3,10 @@
   <transition id="13" target="State01"></transition>
  </state>
  <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->
-  <transition cond="Cond01" event="Event01-02" id="15" target="State02"></transition>
+  <transition cond="Cond01" event="Event01_02" id="15" target="State02"></transition>
  </state>
  <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->
-  <transition cond="Cond02" event="Event02-Final" id="17" target="FinalState"></transition>
+  <transition cond="Cond02" event="Event02_Final" id="17" target="FinalState"></transition>
  </state>
  <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final>
 </scxml>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/RTC.xml
@@ -21,10 +21,10 @@
         <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
     </rtc:Actions>
     <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedLong" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01-02">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedLong" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01_02">
             <rtcDoc:Doc rtcDoc:operation="Period01-02" rtcDoc:unit="Unit01-02" rtcDoc:semantics="Detail01-02" rtcDoc:number="Num01-02" rtcDoc:type="Type01-02" rtcDoc:description="Abst01-02"/>
         </rtc:Event>
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedString" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02-Final">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedString" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02_Final">
             <rtcDoc:Doc rtcDoc:operation="Period02-Final" rtcDoc:unit="Unit02-Final" rtcDoc:semantics="Detail02-Final" rtcDoc:number="Num02-Final" rtcDoc:type="Type02-Final" rtcDoc:description="Abst02-Final"/>
         </rtc:Event>
     </rtc:DataPorts>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/include/ModuleName/ModuleNameFSM.h
@@ -81,6 +81,16 @@ namespace ModuleNameFsm {
       // RTC::ReturnCode_t onInit() override;
   };
 
+  FSM_SUBSTATE(FinalState, Top) {
+    FSM_STATE(FinalState);
+  
+
+    // Event handler
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+  };
+
 
 } //end namespace 'ModuleNameFSM'
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/src/ModuleNameFSM.cpp
@@ -47,4 +47,12 @@ void State02::Event02_Final(RTC::TimedString data) {
 }
 
 
+//============================================================
+// State FinalState
+// RTC::ReturnCode_t FinalState::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+
+
 } //end namespace 'ModuleNameFSM'

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/ModuleNameFSM.scxml
@@ -3,10 +3,10 @@
   <transition id="13" target="State01"></transition>
  </state>
  <state id="State01"><!--   node-size-and-position x=32.5 y=168 w=75 h=75  -->
-  <transition event="Event01-02" id="15" target="State02"></transition>
+  <transition event="Event01_02" id="15" target="State02"></transition>
  </state>
  <state id="State02"><!--   node-size-and-position x=32.5 y=293 w=75 h=75  -->
-  <transition event="Event02-Final" id="17" target="FinalState"></transition>
+  <transition event="Event02_Final" id="17" target="FinalState"></transition>
  </state>
  <final id="FinalState"><!--   node-size-and-position x=30 y=418 w=80 h=75  --></final>
 </scxml>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/RTC.xml
@@ -21,10 +21,10 @@
         <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
     </rtc:Actions>
     <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="" rtc:name="Event01-02">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State02" rtc:source="State01" rtc:condition="" rtc:name="Event01_02">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="" rtc:name="Event02-Final">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="FinalState" rtc:source="State02" rtc:condition="" rtc:name="Event02_Final">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
     </rtc:DataPorts>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/include/ModuleName/ModuleNameFSM.h
@@ -69,6 +69,16 @@ namespace ModuleNameFsm {
       // RTC::ReturnCode_t onInit() override;
   };
 
+  FSM_SUBSTATE(FinalState, Top) {
+    FSM_STATE(FinalState);
+  
+
+    // Event handler
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+  };
+
 
 } //end namespace 'ModuleNameFSM'
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/src/ModuleNameFSM.cpp
@@ -47,4 +47,12 @@ void State02::Event02_Final() {
 }
 
 
+//============================================================
+// State FinalState
+// RTC::ReturnCode_t FinalState::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+
+
 } //end namespace 'ModuleNameFSM'

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/ModuleNameFSM.scxml
@@ -3,10 +3,10 @@
   <transition id="13" target="State01"></transition>
  </state>
  <state id="State01"><!--   node-size-and-position x=68.36 y=168 w=75 h=75  -->
-  <transition cond="Cond01" event="Event01-02" id="15" target="State02"></transition>
+  <transition cond="Cond01" event="Event01_02" id="15" target="State02"></transition>
  </state>
  <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->
-  <transition cond="Cond02" event="Event02-Final" id="17" target="FinalState"></transition>
+  <transition cond="Cond02" event="Event02_Final" id="17" target="FinalState"></transition>
  </state>
  <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final>
 </scxml>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/RTC.xml
@@ -21,10 +21,10 @@
         <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
     </rtc:Actions>
     <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedLong" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01-02">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedLong" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01_02">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedString" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02-Final">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedString" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02_Final">
             <rtcDoc:Doc rtcDoc:operation="" rtcDoc:unit="" rtcDoc:semantics="" rtcDoc:number="" rtcDoc:type="" rtcDoc:description=""/>
         </rtc:Event>
     </rtc:DataPorts>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/include/ModuleName/ModuleNameFSM.h
@@ -69,6 +69,16 @@ namespace ModuleNameFsm {
       // RTC::ReturnCode_t onInit() override;
   };
 
+  FSM_SUBSTATE(FinalState, Top) {
+    FSM_STATE(FinalState);
+  
+
+    // Event handler
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+  };
+
 
 } //end namespace 'ModuleNameFSM'
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/src/ModuleNameFSM.cpp
@@ -47,4 +47,12 @@ void State02::Event02_Final(RTC::TimedString data) {
 }
 
 
+//============================================================
+// State FinalState
+// RTC::ReturnCode_t FinalState::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+
+
 } //end namespace 'ModuleNameFSM'

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/include/ModuleName/ModuleNameFSM.h
@@ -59,6 +59,16 @@ namespace ModuleNameFsm {
       // RTC::ReturnCode_t onInit() override;
   };
 
+  FSM_SUBSTATE(FinalState, Top) {
+    FSM_STATE(FinalState);
+  
+
+    // Event handler
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+  };
+
 
 } //end namespace 'ModuleNameFSM'
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/src/ModuleNameFSM.cpp
@@ -39,4 +39,12 @@ RTC::ReturnCode_t Top::onExit() {
 
 
 
+//============================================================
+// State FinalState
+// RTC::ReturnCode_t FinalState::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+
+
 } //end namespace 'ModuleNameFSM'

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/ModuleNameFSM.scxml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/ModuleNameFSM.scxml
@@ -9,7 +9,7 @@
   <onexit>
    <log label="ON"></log>
   </onexit>
-  <transition cond="Cond01" event="Event01-02" id="15" target="State02"></transition>
+  <transition cond="Cond01" event="Event01_02" id="15" target="State02"></transition>
  </state>
  <state id="State02"><!--   node-size-and-position x=68.36 y=293 w=75 h=75  -->
   <onentry>
@@ -18,7 +18,7 @@
   <onexit>
    <log label="ON"></log>
   </onexit>
-  <transition cond="Cond02" event="Event02-Final" id="17" target="FinalState"></transition>
+  <transition cond="Cond02" event="Event02_Final" id="17" target="FinalState"></transition>
  </state>
  <final id="FinalState"><!--   node-size-and-position x=65.86 y=418 w=80 h=75  --></final>
 </scxml>

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/RTC.xml
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/RTC.xml
@@ -21,10 +21,10 @@
         <rtc:OnModeChanged xsi:type="rtcDoc:action_status_doc" rtc:implemented="false"/>
     </rtc:Actions>
     <rtc:DataPorts xsi:type="rtcExt:dataport_ext" rtcExt:position="LEFT" rtcExt:variableName="FSMEventVar" rtc:type="Any" rtc:name="FSMEventPort" rtc:portType="EventPort">
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedLong" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01-02">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedLong" rtc:target="State02" rtc:source="State01" rtc:condition="Cond01" rtc:name="Event01_02">
             <rtcDoc:Doc rtcDoc:operation="Period01-02" rtcDoc:unit="Unit01-02" rtcDoc:semantics="Detail01-02" rtcDoc:number="Num01-02" rtcDoc:type="Type01-02" rtcDoc:description="Abst01-02"/>
         </rtc:Event>
-        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedString" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02-Final">
+        <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="RTC::TimedString" rtc:target="FinalState" rtc:source="State02" rtc:condition="Cond02" rtc:name="Event02_Final">
             <rtcDoc:Doc rtcDoc:operation="Period02-Final" rtcDoc:unit="Unit02-Final" rtcDoc:semantics="Detail02-Final" rtcDoc:number="Num02-Final" rtcDoc:type="Type02-Final" rtcDoc:description="Abst02-Final"/>
         </rtc:Event>
         <rtc:Event xsi:type="rtcDoc:event_doc" rtc:type="" rtc:target="State01" rtc:source="InitialState" rtc:condition="" rtc:name="">

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/include/ModuleName/ModuleNameFSM.h
@@ -85,6 +85,16 @@ namespace ModuleNameFsm {
        RTC::ReturnCode_t onExit() override;
   };
 
+  FSM_SUBSTATE(FinalState, Top) {
+    FSM_STATE(FinalState);
+  
+
+    // Event handler
+
+    private:
+      // RTC::ReturnCode_t onInit() override;
+  };
+
 
 } //end namespace 'ModuleNameFSM'
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/src/ModuleNameFSM.cpp
@@ -59,4 +59,12 @@ void State02::Event02_Final(RTC::TimedString data) {
 }
 
 
+//============================================================
+// State FinalState
+// RTC::ReturnCode_t FinalState::onInit() {
+//   return RTC::RTC_OK;
+// }
+
+
+
 } //end namespace 'ModuleNameFSM'

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/EventParam.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/EventParam.java
@@ -33,7 +33,7 @@ public class EventParam {
 	}
 	public void setName(String name) {
 		if(name==null) this.name = "";
-		else this.name = name.replace("-", "_");
+		else this.name = name;
 	}
 	
 	public String getDataType() {
@@ -58,7 +58,7 @@ public class EventParam {
 	}
 
 	public String getSource() {
-		return source.replace("-", "_");
+		return source;
 	}
 	public void setSource(String source) {
 		if(source==null) this.source = "";
@@ -66,7 +66,7 @@ public class EventParam {
 	}
 
 	public String getTarget() {
-		return target.replace("-", "_");
+		return target;
 	}
 	public void setTarget(String target) {
 		if(target==null) this.target = "";
@@ -124,8 +124,8 @@ public class EventParam {
 	public boolean checkSame(EventParam source) {
 		if(this.name.equals(source.name)
 				&& this.condition.equals(source.condition)
-				&& this.source.replace("-", "_").equals(source.source)
-				&& this.target.replace("-", "_").equals(source.target) ) {
+				&& this.source.equals(source.source)
+				&& this.target.equals(source.target) ) {
 			return true;
 		}
 		return false;

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/StateParam.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/StateParam.java
@@ -44,7 +44,7 @@ public class StateParam {
 	}
 	
 	public String getName() {
-		return name.replace("-", "_");
+		return name;
 	}
 	public void setName(String name) {
 		this.name = name;
@@ -99,7 +99,7 @@ public class StateParam {
 	public List<StateParam> getAllValidStateList() {
 		List<StateParam> result = new ArrayList<StateParam>();
 		for(StateParam each : allStateList) {
-			if(each.isInitial() || each.isFinal()) continue;
+			if(each.isInitial()) continue;
 			result.add(each);
 		}
 		return result;

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/TransitionParam.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/TransitionParam.java
@@ -22,7 +22,7 @@ public class TransitionParam {
 	}
 	public void setEvent(String event) {
 		if(event==null) event = "";
-		this.event = event.replace("-", "_");
+		this.event = event;
 	}
 	
 	public String getCondition() {
@@ -34,7 +34,7 @@ public class TransitionParam {
 	}
 	
 	public String getSource() {
-		return source.replace("-", "_");
+		return source;
 	}
 	public void setSource(String source) {
 		if(source==null) source = "";
@@ -42,7 +42,7 @@ public class TransitionParam {
 	}
 	
 	public String getTarget() {
-		return target.replace("-", "_");
+		return target;
 	}
 	public void setTarget(String target) {
 		if(target==null) target = "";
@@ -79,10 +79,10 @@ public class TransitionParam {
 		if(transCondition == null) transCondition = "";
 		String transSource = this.source;
 		if(transSource == null) transSource = "";
-		else transSource = transSource.replace("-", "_");
+		else transSource = transSource;
 		String transTarget = this.target;
 		if(transTarget == null) transTarget = "";
-		else transTarget = transTarget.replace("-", "_");
+		else transTarget = transTarget;
 
 		EventPortParam eventPort = rtcParam.getEventport();
 		if(eventPort==null) return;


### PR DESCRIPTION
## Identify the Bug

Link to #268

## Description of the Change

FSM RTCのコード生成を行う際に，終了状態についても他の状態と同様な内容のコードを生成するように修正させて頂きました．
なお，Java版については修正済みだったため，C++版およびPython版について修正を行っております．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [x] Have you passed the unit tests? 既存のユニットテストを修正し，正常に実行されることを確認