### PR TITLE
FSMコンポーネントのonInit関数をコメントアウトしないように修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/basic/src/FinalState.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/basic/src/FinalState.java
@@ -6,9 +6,12 @@ import jp.go.aist.rtm.RTC.jfsm.State;
  */
   
 public class FinalState extends Top {
-//    @Override
-//    public void onInit() {
-//    }
+    // The onInit method provides a special kind of entry action.
+    // On state transition, onEntry functions are called at the target state and its superstate.
+    // But an onInit function is called only at the target state.
+    @Override
+    public void onInit() {
+    }
 //    @Override
 //    public void onEntry() {
 //    }

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/basic/src/State01.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/basic/src/State01.java
@@ -8,9 +8,12 @@ import jp.go.aist.rtm.RTC.jfsm.State;
  */
   
 public class State01 extends Top {
-//    @Override
-//    public void onInit() {
-//    }
+    // The onInit method provides a special kind of entry action.
+    // On state transition, onEntry functions are called at the target state and its superstate.
+    // But an onInit function is called only at the target state.
+    @Override
+    public void onInit() {
+    }
 
 //    @Override
 //    public void onEntry() {

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/basic/src/State02.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/basic/src/State02.java
@@ -8,9 +8,12 @@ import jp.go.aist.rtm.RTC.jfsm.State;
  */
   
 public class State02 extends Top {
-//    @Override
-//    public void onInit() {
-//    }
+    // The onInit method provides a special kind of entry action.
+    // On state transition, onEntry functions are called at the target state and its superstate.
+    // But an onInit function is called only at the target state.
+    @Override
+    public void onInit() {
+    }
 
 //    @Override
 //    public void onEntry() {

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventCond/src/FinalState.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventCond/src/FinalState.java
@@ -6,9 +6,12 @@ import jp.go.aist.rtm.RTC.jfsm.State;
  */
   
 public class FinalState extends Top {
-//    @Override
-//    public void onInit() {
-//    }
+    // The onInit method provides a special kind of entry action.
+    // On state transition, onEntry functions are called at the target state and its superstate.
+    // But an onInit function is called only at the target state.
+    @Override
+    public void onInit() {
+    }
 //    @Override
 //    public void onEntry() {
 //    }

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventCond/src/State01.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventCond/src/State01.java
@@ -13,9 +13,12 @@ public class State01 extends Top {
         setState(new State(State02.class));
     }
 
-//    @Override
-//    public void onInit() {
-//    }
+    // The onInit method provides a special kind of entry action.
+    // On state transition, onEntry functions are called at the target state and its superstate.
+    // But an onInit function is called only at the target state.
+    @Override
+    public void onInit() {
+    }
 
 //    @Override
 //    public void onEntry() {

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventCond/src/State02.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventCond/src/State02.java
@@ -13,9 +13,12 @@ public class State02 extends Top {
         setState(new State(FinalState.class));
     }
 
-//    @Override
-//    public void onInit() {
-//    }
+    // The onInit method provides a special kind of entry action.
+    // On state transition, onEntry functions are called at the target state and its superstate.
+    // But an onInit function is called only at the target state.
+    @Override
+    public void onInit() {
+    }
 
 //    @Override
 //    public void onEntry() {

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventName/src/FinalState.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventName/src/FinalState.java
@@ -6,9 +6,12 @@ import jp.go.aist.rtm.RTC.jfsm.State;
  */
   
 public class FinalState extends Top {
-//    @Override
-//    public void onInit() {
-//    }
+    // The onInit method provides a special kind of entry action.
+    // On state transition, onEntry functions are called at the target state and its superstate.
+    // But an onInit function is called only at the target state.
+    @Override
+    public void onInit() {
+    }
 //    @Override
 //    public void onEntry() {
 //    }

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventName/src/State01.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventName/src/State01.java
@@ -13,9 +13,12 @@ public class State01 extends Top {
         setState(new State(State02.class));
     }
 
-//    @Override
-//    public void onInit() {
-//    }
+    // The onInit method provides a special kind of entry action.
+    // On state transition, onEntry functions are called at the target state and its superstate.
+    // But an onInit function is called only at the target state.
+    @Override
+    public void onInit() {
+    }
 
 //    @Override
 //    public void onEntry() {

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventName/src/State02.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventName/src/State02.java
@@ -13,9 +13,12 @@ public class State02 extends Top {
         setState(new State(FinalState.class));
     }
 
-//    @Override
-//    public void onInit() {
-//    }
+    // The onInit method provides a special kind of entry action.
+    // On state transition, onEntry functions are called at the target state and its superstate.
+    // But an onInit function is called only at the target state.
+    @Override
+    public void onInit() {
+    }
 
 //    @Override
 //    public void onEntry() {

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateEntry/src/FinalState.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateEntry/src/FinalState.java
@@ -6,9 +6,12 @@ import jp.go.aist.rtm.RTC.jfsm.State;
  */
   
 public class FinalState extends Top {
-//    @Override
-//    public void onInit() {
-//    }
+    // The onInit method provides a special kind of entry action.
+    // On state transition, onEntry functions are called at the target state and its superstate.
+    // But an onInit function is called only at the target state.
+    @Override
+    public void onInit() {
+    }
 //    @Override
 //    public void onEntry() {
 //    }

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateEntry/src/State01.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateEntry/src/State01.java
@@ -14,16 +14,19 @@ public class State01 extends Top {
         setState(new State(State02.class));
     }
 
-//    @Override
-//    public void onInit() {
-//    }
+    // The onInit method provides a special kind of entry action.
+    // On state transition, onEntry functions are called at the target state and its superstate.
+    // But an onInit function is called only at the target state.
+    @Override
+    public void onInit() {
+    }
 
-      @Override
-      public void onEntry() {
-      }
+    @Override
+    public void onEntry() {
+    }
 
-      @Override
-      public void onExit() {
-      }
+    @Override
+    public void onExit() {
+    }
 
 }

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateEntry/src/State02.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateEntry/src/State02.java
@@ -14,17 +14,20 @@ public class State02 extends Top {
         setState(new State(FinalState.class));
     }
 
-//    @Override
-//    public void onInit() {
-//    }
+    // The onInit method provides a special kind of entry action.
+    // On state transition, onEntry functions are called at the target state and its superstate.
+    // But an onInit function is called only at the target state.
+    @Override
+    public void onInit() {
+    }
 
-      @Override
-      public void onEntry() {
-      }
+    @Override
+    public void onEntry() {
+    }
 
-      @Override
-      public void onExit() {
-      }
+    @Override
+    public void onExit() {
+    }
 
 //    @Override
 //    public void Event01_02() {

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateName/src/FinalState.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateName/src/FinalState.java
@@ -6,9 +6,12 @@ import jp.go.aist.rtm.RTC.jfsm.State;
  */
   
 public class FinalState extends Top {
-//    @Override
-//    public void onInit() {
-//    }
+    // The onInit method provides a special kind of entry action.
+    // On state transition, onEntry functions are called at the target state and its superstate.
+    // But an onInit function is called only at the target state.
+    @Override
+    public void onInit() {
+    }
 //    @Override
 //    public void onEntry() {
 //    }

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateName/src/State_01.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateName/src/State_01.java
@@ -8,9 +8,12 @@ import jp.go.aist.rtm.RTC.jfsm.State;
  */
   
 public class State_01 extends Top {
-//    @Override
-//    public void onInit() {
-//    }
+    // The onInit method provides a special kind of entry action.
+    // On state transition, onEntry functions are called at the target state and its superstate.
+    // But an onInit function is called only at the target state.
+    @Override
+    public void onInit() {
+    }
 
 //    @Override
 //    public void onEntry() {

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateName/src/State_02.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateName/src/State_02.java
@@ -8,9 +8,12 @@ import jp.go.aist.rtm.RTC.jfsm.State;
  */
   
 public class State_02 extends Top {
-//    @Override
-//    public void onInit() {
-//    }
+    // The onInit method provides a special kind of entry action.
+    // On state transition, onEntry functions are called at the target state and its superstate.
+    // But an onInit function is called only at the target state.
+    @Override
+    public void onInit() {
+    }
 
 //    @Override
 //    public void onEntry() {

--- a/jp.go.aist.rtm.rtcbuilder.java/src/jp/go/aist/rtm/rtcbuilder/java/template/java/fsm/Java_FSM.java.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.java/src/jp/go/aist/rtm/rtcbuilder/java/template/java/fsm/Java_FSM.java.vsl
@@ -26,17 +26,20 @@ public class ${targetFsm.name} extends ${targetFsm.parentName} {
 #end
 #end
 #end
-//    @Override
-//    public void onInit() {
-//    }
+    // The onInit method provides a special kind of entry action.
+    // On state transition, onEntry functions are called at the target state and its superstate.
+    // But an onInit function is called only at the target state.
+    @Override
+    public void onInit() {
+    }
 
-#if( !${targetFsm.hasEntry} )//#else  #end    @Override
-#if( !${targetFsm.hasEntry} )//#else  #end    public void onEntry() {
-#if( !${targetFsm.hasEntry} )//#else  #end    }
+#if( !${targetFsm.hasEntry} )//#else#end    @Override
+#if( !${targetFsm.hasEntry} )//#else#end    public void onEntry() {
+#if( !${targetFsm.hasEntry} )//#else#end    }
 
-#if( !${targetFsm.hasExit} )//#else  #end    @Override
-#if( !${targetFsm.hasExit} )//#else  #end    public void onExit() {
-#if( !${targetFsm.hasExit} )//#else  #end    }
+#if( !${targetFsm.hasExit} )//#else#end    @Override
+#if( !${targetFsm.hasExit} )//#else#end    public void onExit() {
+#if( !${targetFsm.hasExit} )//#else#end    }
 
 #foreach($eachEvent in ${tmpltHelperJava.getInEventList(${fsmParam}, ${targetFsm})})
 //    @Override

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/ModuleNameFSM.py
@@ -23,10 +23,25 @@ class Top(StaticFSM.Link):
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class State01(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class State02(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class FinalState(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/ModuleNameFSM.py
@@ -27,7 +27,7 @@ class State01(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class State02(StaticFSM.Link):
@@ -35,7 +35,7 @@ class State02(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class FinalState(StaticFSM.Link):
@@ -43,5 +43,5 @@ class FinalState(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/ModuleNameFSM.py
@@ -37,7 +37,7 @@ class State01(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
 
     def Event01_02(self):
         self.set_state(StaticFSM.State(State02))
@@ -48,7 +48,7 @@ class State02(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
 
     def Event02_Final(self):
         self.set_state(StaticFSM.State(FinalState))
@@ -59,5 +59,5 @@ class FinalState(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/ModuleNameFSM.py
@@ -33,14 +33,31 @@ class Top(StaticFSM.Link):
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class State01(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
+
     def Event01_02(self):
         self.set_state(StaticFSM.State(State02))
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class State02(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
+
     def Event02_Final(self):
         self.set_state(StaticFSM.State(FinalState))
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class FinalState(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/ModuleNameFSM.py
@@ -49,7 +49,7 @@ class State01(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
 
     def Event01_02(self, data):
         self.set_state(StaticFSM.State(State02))
@@ -60,7 +60,7 @@ class State02(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
 
     def Event02_Final(self, data):
         self.set_state(StaticFSM.State(FinalState))
@@ -71,5 +71,5 @@ class FinalState(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/ModuleNameFSM.py
@@ -45,14 +45,31 @@ class Top(StaticFSM.Link):
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class State01(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
+
     def Event01_02(self, data):
         self.set_state(StaticFSM.State(State02))
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class State02(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
+
     def Event02_Final(self, data):
         self.set_state(StaticFSM.State(FinalState))
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class FinalState(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/ModuleNameFSM.py
@@ -37,7 +37,7 @@ class State01(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
 
     def Event01_02(self):
         self.set_state(StaticFSM.State(State02))
@@ -48,7 +48,7 @@ class State02(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
 
     def Event02_Final(self):
         self.set_state(StaticFSM.State(FinalState))
@@ -59,5 +59,5 @@ class FinalState(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/ModuleNameFSM.py
@@ -33,14 +33,31 @@ class Top(StaticFSM.Link):
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class State01(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
+
     def Event01_02(self):
         self.set_state(StaticFSM.State(State02))
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class State02(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
+
     def Event02_Final(self):
         self.set_state(StaticFSM.State(FinalState))
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class FinalState(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/ModuleNameFSM.py
@@ -33,14 +33,31 @@ class Top(StaticFSM.Link):
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class State01(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
+
     def Event01_02(self, data):
         self.set_state(StaticFSM.State(State02))
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class State02(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
+
     def Event02_Final(self, data):
         self.set_state(StaticFSM.State(FinalState))
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class FinalState(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/ModuleNameFSM.py
@@ -37,7 +37,7 @@ class State01(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
 
     def Event01_02(self, data):
         self.set_state(StaticFSM.State(State02))
@@ -48,7 +48,7 @@ class State02(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
 
     def Event02_Final(self, data):
         self.set_state(StaticFSM.State(FinalState))
@@ -59,5 +59,5 @@ class FinalState(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/ModuleNameFSM.py
@@ -23,10 +23,25 @@ class Top(StaticFSM.Link):
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class State01(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class State02(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class FinalState(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/ModuleNameFSM.py
@@ -27,7 +27,7 @@ class State01(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class State02(StaticFSM.Link):
@@ -35,7 +35,7 @@ class State02(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class FinalState(StaticFSM.Link):
@@ -43,5 +43,5 @@ class FinalState(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/ModuleNameFSM.py
@@ -45,6 +45,12 @@ class Top(StaticFSM.Link):
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class State01(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
+
     def onEntry(self):
         return RTC.RTC_OK
 
@@ -56,6 +62,12 @@ class State01(StaticFSM.Link):
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class State02(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
+
     def onEntry(self):
         return RTC.RTC_OK
 
@@ -67,4 +79,9 @@ class State02(StaticFSM.Link):
   
 @StaticFSM.FSM_SUBSTATE(Top)
 class FinalState(StaticFSM.Link):
+    # The onInit method provides a special kind of entry action.
+    # On state transition, onEntry functions are called at the target state and its superstate.
+    # But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/ModuleNameFSM.py
@@ -49,7 +49,7 @@ class State01(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
 
     def onEntry(self):
         return RTC.RTC_OK
@@ -66,7 +66,7 @@ class State02(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
 
     def onEntry(self):
         return RTC.RTC_OK
@@ -83,5 +83,5 @@ class FinalState(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
 

--- a/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/fsm/Py_FSM.py.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/fsm/Py_FSM.py.vsl
@@ -63,7 +63,7 @@ class ${eachState.name}(StaticFSM.Link):
     ${sharp} On state transition, onEntry functions are called at the target state and its superstate.
     ${sharp} But an onInit function is called only at the target state.
     def onInit(self):
-        pass
+        return RTC.RTC_OK
 
 #if( ${eachState.hasEntry} )
     def onEntry(self):

--- a/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/fsm/Py_FSM.py.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/fsm/Py_FSM.py.vsl
@@ -59,6 +59,12 @@ class ${fsmParam.name}(StaticFSM.Link):
 ${tmpltHelperPy.getHistory(${eachState})}
 @StaticFSM.FSM_SUBSTATE(${eachState.parentName})
 class ${eachState.name}(StaticFSM.Link):
+    ${sharp} The onInit method provides a special kind of entry action.
+    ${sharp} On state transition, onEntry functions are called at the target state and its superstate.
+    ${sharp} But an onInit function is called only at the target state.
+    def onInit(self):
+        pass
+
 #if( ${eachState.hasEntry} )
     def onEntry(self):
         return RTC.RTC_OK

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/include/ModuleName/ModuleNameFSM.h
@@ -46,7 +46,10 @@ namespace ModuleNameFsm {
     // Event handler
 
     private:
-      // RTC::ReturnCode_t onInit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
   };
 
   FSM_SUBSTATE(State02, Top) {
@@ -56,7 +59,10 @@ namespace ModuleNameFsm {
     // Event handler
 
     private:
-      // RTC::ReturnCode_t onInit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
   };
 
   FSM_SUBSTATE(FinalState, Top) {
@@ -66,7 +72,10 @@ namespace ModuleNameFsm {
     // Event handler
 
     private:
-      // RTC::ReturnCode_t onInit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
   };
 
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/src/ModuleNameFSM.cpp
@@ -25,25 +25,25 @@ RTC::ReturnCode_t Top::onExit() {
 
 //============================================================
 // State State01
-// RTC::ReturnCode_t State01::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t State01::onInit() {
+  return RTC::RTC_OK;
+}
 
 
 
 //============================================================
 // State State02
-// RTC::ReturnCode_t State02::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t State02::onInit() {
+  return RTC::RTC_OK;
+}
 
 
 
 //============================================================
 // State FinalState
-// RTC::ReturnCode_t FinalState::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t FinalState::onInit() {
+  return RTC::RTC_OK;
+}
 
 
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/include/ModuleName/ModuleNameFSM.h
@@ -55,7 +55,10 @@ namespace ModuleNameFsm {
     void Event01_02() override;
 
     private:
-      // RTC::ReturnCode_t onInit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
   };
 
   FSM_SUBSTATE(State02, Top) {
@@ -66,7 +69,10 @@ namespace ModuleNameFsm {
     void Event02_Final() override;
 
     private:
-      // RTC::ReturnCode_t onInit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
   };
 
   FSM_SUBSTATE(FinalState, Top) {
@@ -76,7 +82,10 @@ namespace ModuleNameFsm {
     // Event handler
 
     private:
-      // RTC::ReturnCode_t onInit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
   };
 
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/src/ModuleNameFSM.cpp
@@ -25,9 +25,9 @@ RTC::ReturnCode_t Top::onExit() {
 
 //============================================================
 // State State01
-// RTC::ReturnCode_t State01::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t State01::onInit() {
+  return RTC::RTC_OK;
+}
 
 
 void State01::Event01_02() {
@@ -37,9 +37,9 @@ void State01::Event01_02() {
 
 //============================================================
 // State State02
-// RTC::ReturnCode_t State02::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t State02::onInit() {
+  return RTC::RTC_OK;
+}
 
 
 void State02::Event02_Final() {
@@ -49,9 +49,9 @@ void State02::Event02_Final() {
 
 //============================================================
 // State FinalState
-// RTC::ReturnCode_t FinalState::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t FinalState::onInit() {
+  return RTC::RTC_OK;
+}
 
 
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/include/ModuleName/ModuleNameFSM.h
@@ -67,7 +67,10 @@ namespace ModuleNameFsm {
     void Event01_02(RTC::TimedLong data) override;
 
     private:
-      // RTC::ReturnCode_t onInit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
   };
 
   FSM_SUBSTATE(State02, Top) {
@@ -78,7 +81,10 @@ namespace ModuleNameFsm {
     void Event02_Final(RTC::TimedString data) override;
 
     private:
-      // RTC::ReturnCode_t onInit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
   };
 
   FSM_SUBSTATE(FinalState, Top) {
@@ -88,7 +94,10 @@ namespace ModuleNameFsm {
     // Event handler
 
     private:
-      // RTC::ReturnCode_t onInit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
   };
 
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/src/ModuleNameFSM.cpp
@@ -25,9 +25,9 @@ RTC::ReturnCode_t Top::onExit() {
 
 //============================================================
 // State State01
-// RTC::ReturnCode_t State01::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t State01::onInit() {
+  return RTC::RTC_OK;
+}
 
 
 void State01::Event01_02(RTC::TimedLong data) {
@@ -37,9 +37,9 @@ void State01::Event01_02(RTC::TimedLong data) {
 
 //============================================================
 // State State02
-// RTC::ReturnCode_t State02::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t State02::onInit() {
+  return RTC::RTC_OK;
+}
 
 
 void State02::Event02_Final(RTC::TimedString data) {
@@ -49,9 +49,9 @@ void State02::Event02_Final(RTC::TimedString data) {
 
 //============================================================
 // State FinalState
-// RTC::ReturnCode_t FinalState::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t FinalState::onInit() {
+  return RTC::RTC_OK;
+}
 
 
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/include/ModuleName/ModuleNameFSM.h
@@ -55,7 +55,10 @@ namespace ModuleNameFsm {
     void Event01_02() override;
 
     private:
-      // RTC::ReturnCode_t onInit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
   };
 
   FSM_SUBSTATE(State02, Top) {
@@ -66,7 +69,10 @@ namespace ModuleNameFsm {
     void Event02_Final() override;
 
     private:
-      // RTC::ReturnCode_t onInit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
   };
 
   FSM_SUBSTATE(FinalState, Top) {
@@ -76,7 +82,10 @@ namespace ModuleNameFsm {
     // Event handler
 
     private:
-      // RTC::ReturnCode_t onInit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
   };
 
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/src/ModuleNameFSM.cpp
@@ -25,9 +25,9 @@ RTC::ReturnCode_t Top::onExit() {
 
 //============================================================
 // State State01
-// RTC::ReturnCode_t State01::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t State01::onInit() {
+  return RTC::RTC_OK;
+}
 
 
 void State01::Event01_02() {
@@ -37,9 +37,9 @@ void State01::Event01_02() {
 
 //============================================================
 // State State02
-// RTC::ReturnCode_t State02::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t State02::onInit() {
+  return RTC::RTC_OK;
+}
 
 
 void State02::Event02_Final() {
@@ -49,9 +49,9 @@ void State02::Event02_Final() {
 
 //============================================================
 // State FinalState
-// RTC::ReturnCode_t FinalState::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t FinalState::onInit() {
+  return RTC::RTC_OK;
+}
 
 
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/include/ModuleName/ModuleNameFSM.h
@@ -55,7 +55,10 @@ namespace ModuleNameFsm {
     void Event01_02(RTC::TimedLong data) override;
 
     private:
-      // RTC::ReturnCode_t onInit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
   };
 
   FSM_SUBSTATE(State02, Top) {
@@ -66,7 +69,10 @@ namespace ModuleNameFsm {
     void Event02_Final(RTC::TimedString data) override;
 
     private:
-      // RTC::ReturnCode_t onInit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
   };
 
   FSM_SUBSTATE(FinalState, Top) {
@@ -76,7 +82,10 @@ namespace ModuleNameFsm {
     // Event handler
 
     private:
-      // RTC::ReturnCode_t onInit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
   };
 
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/src/ModuleNameFSM.cpp
@@ -25,9 +25,9 @@ RTC::ReturnCode_t Top::onExit() {
 
 //============================================================
 // State State01
-// RTC::ReturnCode_t State01::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t State01::onInit() {
+  return RTC::RTC_OK;
+}
 
 
 void State01::Event01_02(RTC::TimedLong data) {
@@ -37,9 +37,9 @@ void State01::Event01_02(RTC::TimedLong data) {
 
 //============================================================
 // State State02
-// RTC::ReturnCode_t State02::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t State02::onInit() {
+  return RTC::RTC_OK;
+}
 
 
 void State02::Event02_Final(RTC::TimedString data) {
@@ -49,9 +49,9 @@ void State02::Event02_Final(RTC::TimedString data) {
 
 //============================================================
 // State FinalState
-// RTC::ReturnCode_t FinalState::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t FinalState::onInit() {
+  return RTC::RTC_OK;
+}
 
 
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/include/ModuleName/ModuleNameFSM.h
@@ -46,7 +46,10 @@ namespace ModuleNameFsm {
     // Event handler
 
     private:
-      // RTC::ReturnCode_t onInit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
   };
 
   FSM_SUBSTATE(State02, Top) {
@@ -56,7 +59,10 @@ namespace ModuleNameFsm {
     // Event handler
 
     private:
-      // RTC::ReturnCode_t onInit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
   };
 
   FSM_SUBSTATE(FinalState, Top) {
@@ -66,7 +72,10 @@ namespace ModuleNameFsm {
     // Event handler
 
     private:
-      // RTC::ReturnCode_t onInit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
   };
 
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/src/ModuleNameFSM.cpp
@@ -25,25 +25,25 @@ RTC::ReturnCode_t Top::onExit() {
 
 //============================================================
 // State State01
-// RTC::ReturnCode_t State01::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t State01::onInit() {
+  return RTC::RTC_OK;
+}
 
 
 
 //============================================================
 // State State02
-// RTC::ReturnCode_t State02::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t State02::onInit() {
+  return RTC::RTC_OK;
+}
 
 
 
 //============================================================
 // State FinalState
-// RTC::ReturnCode_t FinalState::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t FinalState::onInit() {
+  return RTC::RTC_OK;
+}
 
 
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/include/ModuleName/ModuleNameFSM.h
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/include/ModuleName/ModuleNameFSM.h
@@ -67,9 +67,12 @@ namespace ModuleNameFsm {
     void Event01_02(RTC::TimedLong data) override;
 
     private:
-      // RTC::ReturnCode_t onInit() override;
-       RTC::ReturnCode_t onEntry() override;
-       RTC::ReturnCode_t onExit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
+      RTC::ReturnCode_t onEntry() override;
+      RTC::ReturnCode_t onExit() override;
   };
 
   FSM_SUBSTATE(State02, Top) {
@@ -80,9 +83,12 @@ namespace ModuleNameFsm {
     void Event02_Final(RTC::TimedString data) override;
 
     private:
-      // RTC::ReturnCode_t onInit() override;
-       RTC::ReturnCode_t onEntry() override;
-       RTC::ReturnCode_t onExit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
+      RTC::ReturnCode_t onEntry() override;
+      RTC::ReturnCode_t onExit() override;
   };
 
   FSM_SUBSTATE(FinalState, Top) {
@@ -92,7 +98,10 @@ namespace ModuleNameFsm {
     // Event handler
 
     private:
-      // RTC::ReturnCode_t onInit() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
   };
 
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/src/ModuleNameFSM.cpp
@@ -25,9 +25,9 @@ RTC::ReturnCode_t Top::onExit() {
 
 //============================================================
 // State State01
-// RTC::ReturnCode_t State01::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t State01::onInit() {
+  return RTC::RTC_OK;
+}
 
 RTC::ReturnCode_t State01::onEntry() {
   return RTC::RTC_OK;
@@ -43,9 +43,9 @@ void State01::Event01_02(RTC::TimedLong data) {
 
 //============================================================
 // State State02
-// RTC::ReturnCode_t State02::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t State02::onInit() {
+  return RTC::RTC_OK;
+}
 
 RTC::ReturnCode_t State02::onEntry() {
   return RTC::RTC_OK;
@@ -61,9 +61,9 @@ void State02::Event02_Final(RTC::TimedString data) {
 
 //============================================================
 // State FinalState
-// RTC::ReturnCode_t FinalState::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t FinalState::onInit() {
+  return RTC::RTC_OK;
+}
 
 
 

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/fsm/CXX_FSM.cpp.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/fsm/CXX_FSM.cpp.vsl
@@ -26,9 +26,9 @@ RTC::ReturnCode_t ${fsmParam.name}::onExit() {
 #foreach($eachState in ${fsmParam.getAllValidStateList()})
 //============================================================
 // State ${eachState.name}
-// RTC::ReturnCode_t ${eachState.name}::onInit() {
-//   return RTC::RTC_OK;
-// }
+RTC::ReturnCode_t ${eachState.name}::onInit() {
+  return RTC::RTC_OK;
+}
 
 #if( ${eachState.hasEntry} )
 RTC::ReturnCode_t ${eachState.name}::onEntry() {

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/fsm/CXX_FSM.h.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/fsm/CXX_FSM.h.vsl
@@ -76,10 +76,13 @@ ${tmpltHelper.getHistory(${eachState})}
 #end
 
     private:
-      // RTC::ReturnCode_t onInit() override;
-#if( ${eachState.hasEntry} )       RTC::ReturnCode_t onEntry() override;
+      // The onInit method provides a special kind of entry action.
+      // On state transition, onEntry functions are called at the target state and its superstate.
+      // But an onInit function is called only at the target state.
+      RTC::ReturnCode_t onInit() override;
+#if( ${eachState.hasEntry} )      RTC::ReturnCode_t onEntry() override;
 #end
-#if( ${eachState.hasExit} )       RTC::ReturnCode_t onExit() override;
+#if( ${eachState.hasExit} )      RTC::ReturnCode_t onExit() override;
 #end
   };
 


### PR DESCRIPTION
## Identify the Bug

Link to #277

## Description of the Change

FSMコンポーネントのonInit()関数をコメントアウトせずに出力するように修正しました．
また，ご連絡を頂きましたコメントも出力するように修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [x] Have you passed the unit tests? 既存のユニットテストを修正し，正常に実行されることを確認