### PR TITLE
名称から余計な空白を削除

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder.nl1/META-INF/MANIFEST.MF
+++ b/jp.go.aist.rtm.rtcbuilder.nl1/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Ant-Version: Apache Ant 1.7.1
 Created-By: 20.0-b12 (Sun Microsystems Inc.)
 Bundle-ManifestVersion: 2
-Bundle-Name: RTC Builder Nl1 Fragment
+Bundle-Name: RTCBuilder Nl1 Fragment
 Bundle-SymbolicName: jp.go.aist.rtm.rtcbuilder.nl1
 Bundle-Version: 2.0.0
 Fragment-Host: jp.go.aist.rtm.rtcbuilder;bundle-version="2.0.0"

--- a/jp.go.aist.rtm.rtcbuilder.nl1/plugin_ja.properties
+++ b/jp.go.aist.rtm.rtcbuilder.nl1/plugin_ja.properties
@@ -34,7 +34,7 @@ wizardName = RTC\u30d3\u30eb\u30c0
 
 perspectiveName = RTCBuilder
 
-preferecePagesName = RtcBuilder
+preferecePagesName = RTCBuilder
 preferecePagesCodeGenerateName = \u30b3\u30fc\u30c9\u751f\u6210
 preferecePagesPortsName = \u30dd\u30fc\u30c8
 preferecePagesDocumentName = \u30a2\u30af\u30c6\u30a3\u30d3\u30c6\u30a3, \u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u751f\u6210

--- a/jp.go.aist.rtm.rtcbuilder.nl1/plugin_ja.properties
+++ b/jp.go.aist.rtm.rtcbuilder.nl1/plugin_ja.properties
@@ -15,10 +15,10 @@
 # %%% END OF TRANSLATED PROPERTIES %%%
 # ====================================================================
 
-pluginName = RTC Builder
+pluginName = RTCBuilder
 providerName = AIST
 
-RtcBuilderEditorName = RTC Builder Editor
+RtcBuilderEditorName = RTCBuilder Editor
 SaveAsActionLabel = Save As...
 SaveActionLabel = Save
 OpenActionLabel = Open...
@@ -29,10 +29,10 @@ NewRtcBuilderEditorActionToolTip = Open New RtcBuilder Editor
 viewCategoryName = OpenRTP Tools
 buildeviewName = BuildView
 
-wizardCategoryName = RTC Builder Wizard
+wizardCategoryName = RTCBuilder Wizard
 wizardName = RTC\u30d3\u30eb\u30c0
 
-perspectiveName = RTC Builder
+perspectiveName = RTCBuilder
 
 preferecePagesName = RtcBuilder
 preferecePagesCodeGenerateName = \u30b3\u30fc\u30c9\u751f\u6210

--- a/jp.go.aist.rtm.rtcbuilder/plugin.properties
+++ b/jp.go.aist.rtm.rtcbuilder/plugin.properties
@@ -15,10 +15,10 @@
 # %%% END OF TRANSLATED PROPERTIES %%%
 # ====================================================================
 
-pluginName = RTC Builder
+pluginName = RTCBuilder
 providerName = AIST
 
-RtcBuilderEditorName = RTC Builder Editor
+RtcBuilderEditorName = RTCBuilder Editor
 SaveAsActionLabel = Save As...
 SaveActionLabel = Save
 OpenActionLabel = Open...
@@ -29,10 +29,10 @@ NewRtcBuilderEditorActionToolTip = Open New RtcBuilder Editor
 viewCategoryName = OpenRTP Tools
 buildeviewName = BuildView
 
-wizardCategoryName = RTC Builder Wizard
-wizardName = RTC Builder
+wizardCategoryName = RTCBuilder Wizard
+wizardName = RTCBuilder
 
-perspectiveName = RTC Builder
+perspectiveName = RTCBuilder
 
 preferecePagesName = RtcBuilder
 preferecePagesCodeGenerateName = Code Generate

--- a/jp.go.aist.rtm.rtcbuilder/plugin.properties
+++ b/jp.go.aist.rtm.rtcbuilder/plugin.properties
@@ -34,7 +34,7 @@ wizardName = RTCBuilder
 
 perspectiveName = RTCBuilder
 
-preferecePagesName = RtcBuilder
+preferecePagesName = RTCBuilder
 preferecePagesCodeGenerateName = Code Generate
 preferecePagesPortsName = Port
 preferecePagesDocumentName = Activity, Document

--- a/jp.go.aist.rtm.rtcbuilder/plugin.xml
+++ b/jp.go.aist.rtm.rtcbuilder/plugin.xml
@@ -36,7 +36,7 @@
         point="org.eclipse.ui.actionSets">
      <actionSet
            id="jp.go.aist.rtm.rtcbuilder.ui.actionSet"
-           label="RTC Builder Actions">
+           label="RTCBuilder Actions">
 			<action
 				id="jp.go.aist.rtm.rtcbuilder.ui.action.NewRtcBuilderEditorAction" 
 				label="%NewRtcBuilderEditorActionLabel"

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/NewWizard.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/NewWizard.java
@@ -41,7 +41,7 @@ public class NewWizard extends Wizard implements INewWizard, IExecutableExtensio
 
 	public NewWizard() {
 		super();
-		setWindowTitle("RT-Component Builder Project");
+		setWindowTitle("RTCBuilder Project");
 	}
 
 	public boolean performFinish() {

--- a/jp.go.aist.rtm.systemeditor.nl1/plugin_ja.properties
+++ b/jp.go.aist.rtm.systemeditor.nl1/plugin_ja.properties
@@ -22,7 +22,7 @@ providerName = AIST
 EditPartFactory = EditPartFactory
 
 # perspectives
-RT_System_Editor = RT System Editor
+RT_System_Editor = RTSystemEditor
 
 # editors
 System_Editor = System Editor
@@ -44,7 +44,7 @@ OfflineEditor = \u30aa\u30d5\u30e9\u30a4\u30f3\u30fb\u30a8\u30c7\u30a3\u30bf
 OnlineEditor = \u30aa\u30f3\u30e9\u30a4\u30f3\u30fb\u30a8\u30c7\u30a3\u30bf 
 
 # actionSets
-RT_System_Editor_Actions = RT System Editor Actions
+RT_System_Editor_Actions = RTSystemEditor Actions
 
 Open_New_Offline_System_Editor = &Open New Offline System Editor
 Open_New_Offline_System_Editor_Label = Open New Offline System Editor

--- a/jp.go.aist.rtm.systemeditor/plugin.properties
+++ b/jp.go.aist.rtm.systemeditor/plugin.properties
@@ -22,7 +22,7 @@ providerName =AIST
 EditPartFactory =EditPartFactory
 
 # perspectives
-RT_System_Editor =RT System Editor
+RT_System_Editor =RTSystemEditor
 
 # editors
 System_Editor =System Editor
@@ -44,7 +44,7 @@ OfflineEditor =Offline Editor
 OnlineEditor =Online Editor 
 
 # actionSets
-RT_System_Editor_Actions =RT System Editor Actions
+RT_System_Editor_Actions =RTSystemEditor Actions
 
 Open_New_Offline_System_Editor =&Open New Offline System Editor
 Open_New_Offline_System_Editor_Label =Open New Offline System Editor


### PR DESCRIPTION
## Identify the Bug

Link to #278

## Description of the Change

"RT System Editor"となっていた部分を"RTSystemEditor"に
"RTC Builder"となっていた部分を"RTCBuilder"に
それぞれ変更させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests? ユニットテストなし