### PR TITLE
FSMでイベント名が設定されていない場合，状態遷移するコードを出力

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/basic/src/FinalState.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/basic/src/FinalState.java
@@ -11,6 +11,7 @@ public class FinalState extends Top {
     // But an onInit function is called only at the target state.
     @Override
     public void onInit() {
+    
     }
 //    @Override
 //    public void onEntry() {

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/basic/src/State01.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/basic/src/State01.java
@@ -13,6 +13,7 @@ public class State01 extends Top {
     // But an onInit function is called only at the target state.
     @Override
     public void onInit() {
+        setState(new State(State02.class));
     }
 
 //    @Override

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/basic/src/State02.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/basic/src/State02.java
@@ -13,6 +13,7 @@ public class State02 extends Top {
     // But an onInit function is called only at the target state.
     @Override
     public void onInit() {
+        setState(new State(FinalState.class));
     }
 
 //    @Override

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventCond/src/FinalState.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventCond/src/FinalState.java
@@ -11,6 +11,7 @@ public class FinalState extends Top {
     // But an onInit function is called only at the target state.
     @Override
     public void onInit() {
+    
     }
 //    @Override
 //    public void onEntry() {

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventCond/src/State01.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventCond/src/State01.java
@@ -18,6 +18,7 @@ public class State01 extends Top {
     // But an onInit function is called only at the target state.
     @Override
     public void onInit() {
+    
     }
 
 //    @Override

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventCond/src/State02.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventCond/src/State02.java
@@ -18,6 +18,7 @@ public class State02 extends Top {
     // But an onInit function is called only at the target state.
     @Override
     public void onInit() {
+    
     }
 
 //    @Override

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventName/src/FinalState.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventName/src/FinalState.java
@@ -11,6 +11,7 @@ public class FinalState extends Top {
     // But an onInit function is called only at the target state.
     @Override
     public void onInit() {
+    
     }
 //    @Override
 //    public void onEntry() {

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventName/src/State01.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventName/src/State01.java
@@ -18,6 +18,7 @@ public class State01 extends Top {
     // But an onInit function is called only at the target state.
     @Override
     public void onInit() {
+    
     }
 
 //    @Override

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventName/src/State02.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/eventName/src/State02.java
@@ -18,6 +18,7 @@ public class State02 extends Top {
     // But an onInit function is called only at the target state.
     @Override
     public void onInit() {
+    
     }
 
 //    @Override

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateEntry/src/FinalState.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateEntry/src/FinalState.java
@@ -11,6 +11,7 @@ public class FinalState extends Top {
     // But an onInit function is called only at the target state.
     @Override
     public void onInit() {
+    
     }
 //    @Override
 //    public void onEntry() {

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateEntry/src/State01.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateEntry/src/State01.java
@@ -19,6 +19,7 @@ public class State01 extends Top {
     // But an onInit function is called only at the target state.
     @Override
     public void onInit() {
+    
     }
 
     @Override

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateEntry/src/State02.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateEntry/src/State02.java
@@ -19,6 +19,7 @@ public class State02 extends Top {
     // But an onInit function is called only at the target state.
     @Override
     public void onInit() {
+    
     }
 
     @Override

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateName/src/FinalState.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateName/src/FinalState.java
@@ -11,6 +11,7 @@ public class FinalState extends Top {
     // But an onInit function is called only at the target state.
     @Override
     public void onInit() {
+    
     }
 //    @Override
 //    public void onEntry() {

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateName/src/State_01.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateName/src/State_01.java
@@ -13,6 +13,7 @@ public class State_01 extends Top {
     // But an onInit function is called only at the target state.
     @Override
     public void onInit() {
+        setState(new State(State_02.class));
     }
 
 //    @Override

--- a/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateName/src/State_02.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/resource/FSM/stateName/src/State_02.java
@@ -13,6 +13,7 @@ public class State_02 extends Top {
     // But an onInit function is called only at the target state.
     @Override
     public void onInit() {
+        setState(new State(FinalState.class));
     }
 
 //    @Override

--- a/jp.go.aist.rtm.rtcbuilder.java/src/jp/go/aist/rtm/rtcbuilder/java/manager/TemplateHelperJava.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/src/jp/go/aist/rtm/rtcbuilder/java/manager/TemplateHelperJava.java
@@ -141,4 +141,19 @@ public class TemplateHelperJava {
 		
 		return result;
 	}
+	
+	public String checkTransition(StateParam state) {
+		TransitionParam targetTans = null;
+		for(TransitionParam trans : state.getTransList()) {
+			if(trans.getEvent().trim().length()==0) {
+				targetTans = trans;
+			}
+		}
+		if(targetTans!=null) {
+			StringBuilder builder = new StringBuilder();
+			builder.append("    setState(new State(").append(targetTans.getTarget()).append(".class));");
+			return builder.toString();
+		}
+		return "";
+	}
 }

--- a/jp.go.aist.rtm.rtcbuilder.java/src/jp/go/aist/rtm/rtcbuilder/java/template/java/fsm/Java_FSM.java.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.java/src/jp/go/aist/rtm/rtcbuilder/java/template/java/fsm/Java_FSM.java.vsl
@@ -31,6 +31,7 @@ public class ${targetFsm.name} extends ${targetFsm.parentName} {
     // But an onInit function is called only at the target state.
     @Override
     public void onInit() {
+    ${tmpltHelperJava.checkTransition(${targetFsm})}
     }
 
 #if( !${targetFsm.hasEntry} )//#else#end    @Override

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/basic/ModuleNameFSM.py
@@ -27,6 +27,7 @@ class State01(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        self.set_state(StaticFSM.State(State02))
         return RTC.RTC_OK
   
 @StaticFSM.FSM_SUBSTATE(Top)
@@ -35,6 +36,7 @@ class State02(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        self.set_state(StaticFSM.State(FinalState))
         return RTC.RTC_OK
   
 @StaticFSM.FSM_SUBSTATE(Top)
@@ -43,5 +45,6 @@ class FinalState(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        
         return RTC.RTC_OK
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventCond/ModuleNameFSM.py
@@ -37,6 +37,7 @@ class State01(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        
         return RTC.RTC_OK
 
     def Event01_02(self):
@@ -48,6 +49,7 @@ class State02(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        
         return RTC.RTC_OK
 
     def Event02_Final(self):
@@ -59,5 +61,6 @@ class FinalState(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        
         return RTC.RTC_OK
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventDoc/ModuleNameFSM.py
@@ -49,6 +49,7 @@ class State01(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        
         return RTC.RTC_OK
 
     def Event01_02(self, data):
@@ -60,6 +61,7 @@ class State02(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        
         return RTC.RTC_OK
 
     def Event02_Final(self, data):
@@ -71,5 +73,6 @@ class FinalState(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        
         return RTC.RTC_OK
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventName/ModuleNameFSM.py
@@ -37,6 +37,7 @@ class State01(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        
         return RTC.RTC_OK
 
     def Event01_02(self):
@@ -48,6 +49,7 @@ class State02(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        
         return RTC.RTC_OK
 
     def Event02_Final(self):
@@ -59,5 +61,6 @@ class FinalState(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        
         return RTC.RTC_OK
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/eventType/ModuleNameFSM.py
@@ -37,6 +37,7 @@ class State01(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        
         return RTC.RTC_OK
 
     def Event01_02(self, data):
@@ -48,6 +49,7 @@ class State02(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        
         return RTC.RTC_OK
 
     def Event02_Final(self, data):
@@ -59,5 +61,6 @@ class FinalState(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        
         return RTC.RTC_OK
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/portName/ModuleNameFSM.py
@@ -27,6 +27,7 @@ class State01(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        self.set_state(StaticFSM.State(State02))
         return RTC.RTC_OK
   
 @StaticFSM.FSM_SUBSTATE(Top)
@@ -35,6 +36,7 @@ class State02(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        self.set_state(StaticFSM.State(FinalState))
         return RTC.RTC_OK
   
 @StaticFSM.FSM_SUBSTATE(Top)
@@ -43,5 +45,6 @@ class FinalState(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        
         return RTC.RTC_OK
 

--- a/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/ModuleNameFSM.py
+++ b/jp.go.aist.rtm.rtcbuilder.python/resource/FSM/stateEntry/ModuleNameFSM.py
@@ -49,6 +49,7 @@ class State01(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        
         return RTC.RTC_OK
 
     def onEntry(self):
@@ -66,6 +67,7 @@ class State02(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        
         return RTC.RTC_OK
 
     def onEntry(self):
@@ -83,5 +85,6 @@ class FinalState(StaticFSM.Link):
     # On state transition, onEntry functions are called at the target state and its superstate.
     # But an onInit function is called only at the target state.
     def onInit(self):
+        
         return RTC.RTC_OK
 

--- a/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/manager/TemplateHelperPy.java
+++ b/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/manager/TemplateHelperPy.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants;
 import jp.go.aist.rtm.rtcbuilder.fsm.StateParam;
+import jp.go.aist.rtm.rtcbuilder.fsm.TransitionParam;
 import jp.go.aist.rtm.rtcbuilder.generator.param.RtcParam;
 import jp.go.aist.rtm.rtcbuilder.generator.param.idl.IdlFileParam;
 import jp.go.aist.rtm.rtcbuilder.python.IRtcBuilderConstantsPython;
@@ -155,5 +156,20 @@ public class TemplateHelperPy {
 			return "@StaticFSM.history";
 		}
 		return "  ";
+	}
+	
+	public String checkTransition(StateParam state) {
+		TransitionParam targetTans = null;
+		for(TransitionParam trans : state.getTransList()) {
+			if(trans.getEvent().trim().length()==0) {
+				targetTans = trans;
+			}
+		}
+		if(targetTans!=null) {
+			StringBuilder builder = new StringBuilder();
+			builder.append("self.set_state(StaticFSM.State(").append(targetTans.getTarget()).append("))");
+			return builder.toString();
+		}
+		return "";
 	}
 }

--- a/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/fsm/Py_FSM.py.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/python/fsm/Py_FSM.py.vsl
@@ -63,6 +63,7 @@ class ${eachState.name}(StaticFSM.Link):
     ${sharp} On state transition, onEntry functions are called at the target state and its superstate.
     ${sharp} But an onInit function is called only at the target state.
     def onInit(self):
+        ${tmpltHelperPy.checkTransition(${eachState})}
         return RTC.RTC_OK
 
 #if( ${eachState.hasEntry} )

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/src/ModuleNameFSM.cpp
@@ -26,6 +26,7 @@ RTC::ReturnCode_t Top::onExit() {
 //============================================================
 // State State01
 RTC::ReturnCode_t State01::onInit() {
+  setState<State02>();
   return RTC::RTC_OK;
 }
 
@@ -34,6 +35,7 @@ RTC::ReturnCode_t State01::onInit() {
 //============================================================
 // State State02
 RTC::ReturnCode_t State02::onInit() {
+  setState<FinalState>();
   return RTC::RTC_OK;
 }
 
@@ -42,6 +44,7 @@ RTC::ReturnCode_t State02::onInit() {
 //============================================================
 // State FinalState
 RTC::ReturnCode_t FinalState::onInit() {
+
   return RTC::RTC_OK;
 }
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/src/ModuleNameFSM.cpp
@@ -26,6 +26,7 @@ RTC::ReturnCode_t Top::onExit() {
 //============================================================
 // State State01
 RTC::ReturnCode_t State01::onInit() {
+
   return RTC::RTC_OK;
 }
 
@@ -38,6 +39,7 @@ void State01::Event01_02() {
 //============================================================
 // State State02
 RTC::ReturnCode_t State02::onInit() {
+
   return RTC::RTC_OK;
 }
 
@@ -50,6 +52,7 @@ void State02::Event02_Final() {
 //============================================================
 // State FinalState
 RTC::ReturnCode_t FinalState::onInit() {
+
   return RTC::RTC_OK;
 }
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/src/ModuleNameFSM.cpp
@@ -26,6 +26,7 @@ RTC::ReturnCode_t Top::onExit() {
 //============================================================
 // State State01
 RTC::ReturnCode_t State01::onInit() {
+
   return RTC::RTC_OK;
 }
 
@@ -38,6 +39,7 @@ void State01::Event01_02(RTC::TimedLong data) {
 //============================================================
 // State State02
 RTC::ReturnCode_t State02::onInit() {
+
   return RTC::RTC_OK;
 }
 
@@ -50,6 +52,7 @@ void State02::Event02_Final(RTC::TimedString data) {
 //============================================================
 // State FinalState
 RTC::ReturnCode_t FinalState::onInit() {
+
   return RTC::RTC_OK;
 }
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/src/ModuleNameFSM.cpp
@@ -26,6 +26,7 @@ RTC::ReturnCode_t Top::onExit() {
 //============================================================
 // State State01
 RTC::ReturnCode_t State01::onInit() {
+
   return RTC::RTC_OK;
 }
 
@@ -38,6 +39,7 @@ void State01::Event01_02() {
 //============================================================
 // State State02
 RTC::ReturnCode_t State02::onInit() {
+
   return RTC::RTC_OK;
 }
 
@@ -50,6 +52,7 @@ void State02::Event02_Final() {
 //============================================================
 // State FinalState
 RTC::ReturnCode_t FinalState::onInit() {
+
   return RTC::RTC_OK;
 }
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/src/ModuleNameFSM.cpp
@@ -26,6 +26,7 @@ RTC::ReturnCode_t Top::onExit() {
 //============================================================
 // State State01
 RTC::ReturnCode_t State01::onInit() {
+
   return RTC::RTC_OK;
 }
 
@@ -38,6 +39,7 @@ void State01::Event01_02(RTC::TimedLong data) {
 //============================================================
 // State State02
 RTC::ReturnCode_t State02::onInit() {
+
   return RTC::RTC_OK;
 }
 
@@ -50,6 +52,7 @@ void State02::Event02_Final(RTC::TimedString data) {
 //============================================================
 // State FinalState
 RTC::ReturnCode_t FinalState::onInit() {
+
   return RTC::RTC_OK;
 }
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/src/ModuleNameFSM.cpp
@@ -26,6 +26,7 @@ RTC::ReturnCode_t Top::onExit() {
 //============================================================
 // State State01
 RTC::ReturnCode_t State01::onInit() {
+  setState<State02>();
   return RTC::RTC_OK;
 }
 
@@ -34,6 +35,7 @@ RTC::ReturnCode_t State01::onInit() {
 //============================================================
 // State State02
 RTC::ReturnCode_t State02::onInit() {
+  setState<FinalState>();
   return RTC::RTC_OK;
 }
 
@@ -42,6 +44,7 @@ RTC::ReturnCode_t State02::onInit() {
 //============================================================
 // State FinalState
 RTC::ReturnCode_t FinalState::onInit() {
+
   return RTC::RTC_OK;
 }
 

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/src/ModuleNameFSM.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/src/ModuleNameFSM.cpp
@@ -26,6 +26,7 @@ RTC::ReturnCode_t Top::onExit() {
 //============================================================
 // State State01
 RTC::ReturnCode_t State01::onInit() {
+
   return RTC::RTC_OK;
 }
 
@@ -44,6 +45,7 @@ void State01::Event01_02(RTC::TimedLong data) {
 //============================================================
 // State State02
 RTC::ReturnCode_t State02::onInit() {
+
   return RTC::RTC_OK;
 }
 
@@ -62,6 +64,7 @@ void State02::Event02_Final(RTC::TimedString data) {
 //============================================================
 // State FinalState
 RTC::ReturnCode_t FinalState::onInit() {
+
   return RTC::RTC_OK;
 }
 

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/TemplateHelper.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/TemplateHelper.java
@@ -396,6 +396,21 @@ public class TemplateHelper {
 		return startNode;
 	}
 	
+	public String checkTransition(StateParam state) {
+		TransitionParam targetTans = null;
+		for(TransitionParam trans : state.getTransList()) {
+			if(trans.getEvent().trim().length()==0) {
+				targetTans = trans;
+			}
+		}
+		if(targetTans!=null) {
+			StringBuilder builder = new StringBuilder();
+			builder.append("  setState<").append(targetTans.getTarget()).append(">();");
+			return builder.toString();
+		}
+		return "";
+	}
+	
 	public String getConnectorString(RtcParam param) {
 		StringBuilder builder = new StringBuilder();
 		

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/fsm/CXX_FSM.cpp.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/fsm/CXX_FSM.cpp.vsl
@@ -27,6 +27,7 @@ RTC::ReturnCode_t ${fsmParam.name}::onExit() {
 //============================================================
 // State ${eachState.name}
 RTC::ReturnCode_t ${eachState.name}::onInit() {
+${tmpltHelper.checkTransition(${eachState})}
   return RTC::RTC_OK;
 }
 


### PR DESCRIPTION
## Identify the Bug

Link to #276

## Description of the Change

FSMコンポーネントで，遷移にイベント名が指定されていない場合に，遷移先の状態へ自動的に遷移するコードをonInit関数内に出力するように修正しました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [x] Have you passed the unit tests? 既存のユニットテストを修正し，正常に実行されることを確認