### PR TITLE
ファイル選択ダイアログのオプションを修正

### DIFF
--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ProfileInformationDialog.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ProfileInformationDialog.java
@@ -179,7 +179,7 @@ public class ProfileInformationDialog extends Dialog {
 		checkButton.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
-				FileDialog dialog = new FileDialog(getShell());
+				FileDialog dialog = new FileDialog(getShell(), SWT.SAVE);
 				dialog.setFilterExtensions(new String[] { "*.xml" }); //$NON-NLS-1$
 				if (txtPathLocal.getText().length() > 0)
 					dialog.setFileName(txtPathLocal.getText());


### PR DESCRIPTION
## Identify the Bug

Link to #287

## Description of the Change

ファイル選択ダイアログの起動時のオプションを修正してみました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests? ユニットテストなし