### PR TITLE
データポート接続時シリアライザを設定できるように修正

### DIFF
--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
@@ -16,12 +16,14 @@ import jp.go.aist.rtm.toolscommon.util.SDOUtil;
 
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.IMessageProvider;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -447,12 +449,35 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 		gd = new GridData();
 		gd.horizontalSpan = 3;
 		serializerTypeCombo.setLayoutData(gd);
+		serializerTypeCombo.addSelectionListener(new SelectionListener() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				if(0<serializerTypeCombo.getText().trim().length()) {
+					outPortCombo.setText(serializerTypeCombo.getText());
+					inPortCombo.setText(serializerTypeCombo.getText());
+				}
+			}
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) {
+			}
+		});
 		
 		createLabel(serializerComposite, "OutPort Serializer :");
 		outPortCombo = new Combo(serializerComposite, style);
 		gd = new GridData(GridData.FILL_BOTH);
 		gd.grabExcessHorizontalSpace = true;
 		outPortCombo.setLayoutData(gd);
+		outPortCombo.addSelectionListener(new SelectionListener() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				connectorProfile.setOutportSerializerType(outPortCombo.getText());
+				notifyModified();
+				serializerTypeCombo.setText("");
+			}
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) {
+			}
+		});
 		outPortCombo.addModifyListener(new ModifyListener() {
 			public void modifyText(ModifyEvent e) {
 				connectorProfile.setOutportSerializerType(outPortCombo.getText());
@@ -465,6 +490,17 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 		gd = new GridData(GridData.FILL_BOTH);
 		gd.grabExcessHorizontalSpace = true;
 		inPortCombo.setLayoutData(gd);
+		inPortCombo.addSelectionListener(new SelectionListener() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				connectorProfile.setInportSerializerType(inPortCombo.getText());
+				notifyModified();
+				serializerTypeCombo.setText("");
+			}
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) {
+			}
+		});
 		inPortCombo.addModifyListener(new ModifyListener() {
 			public void modifyText(ModifyEvent e) {
 				connectorProfile.setInportSerializerType(inPortCombo.getText());
@@ -736,21 +772,26 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 		if(serializerTypeCombo != null) {
 			List<String> outSerList = new ArrayList<String>();
 			List<String> inSerList = new ArrayList<String>();
+			outSerList.add("");
+			inSerList.add("");
 			if(outport!=null) {
-				String outportSer = outport.getProperty("dataport.serializer_type");
+				String outportSer = outport.getProperty("dataport.marshaling_types");
 				if(outportSer!=null) {
 					outSerList = SDOUtil.getValueList(outportSer);
 				}
 			}
 			if(inport!=null) {
-				String inportSer = inport.getProperty("dataport.serializer_type");
+				String inportSer = inport.getProperty("dataport.marshaling_types");
 				if(inportSer!=null) {
 					inSerList = SDOUtil.getValueList(inportSer);
 				}
 			}
 			
 			List<String> typeList = new ArrayList<String>();
-			typeList.add("corba");
+			typeList.add("");
+			typeList.add("cdr");
+			outSerList.add("cdr");
+			inSerList.add("cdr");
 			
 			List<String> outTypeList = new ArrayList<String>();
 			for(String serType : outSerList) {
@@ -770,6 +811,8 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 				if(outTypeList.contains(types[0].trim())) {
 					if(typeList.contains(types[0].trim())==false) {
 						typeList.add(types[0].trim());
+						outSerList.add(types[0].trim());
+						inSerList.add(types[0].trim());
 					}
 				}
 			}

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
@@ -733,12 +733,22 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 			emptyTypes = Arrays.asList(preference.getBufferEmptyPolicies());
 		}
 		
-		String outportSer = outport.getProperty("dataport.serializer_type");
-		List<String> outSerList = SDOUtil.getValueList(outportSer);
-		String inportSer = inport.getProperty("dataport.serializer_type");
-		List<String> inSerList = SDOUtil.getValueList(inportSer);
-		
 		if(serializerTypeCombo != null) {
+			List<String> outSerList = new ArrayList<String>();
+			List<String> inSerList = new ArrayList<String>();
+			if(outport!=null) {
+				String outportSer = outport.getProperty("dataport.serializer_type");
+				if(outportSer!=null) {
+					outSerList = SDOUtil.getValueList(outportSer);
+				}
+			}
+			if(inport!=null) {
+				String inportSer = inport.getProperty("dataport.serializer_type");
+				if(inportSer!=null) {
+					inSerList = SDOUtil.getValueList(inportSer);
+				}
+			}
+			
 			List<String> typeList = new ArrayList<String>();
 			typeList.add("corba");
 			
@@ -767,16 +777,17 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 				serializerTypeCombo.add(serType);
 			}
 			serializerTypeCombo.select(0);
-		}
-		if(outPortCombo != null) {
-			value = loadCombo(outPortCombo, outSerList, connectorProfile
-					.getOutportSerializerType(), false);
-			connectorProfile.setOutportSerializerType(value);
-		}
-		if(inPortCombo != null) {
-			value = loadCombo(inPortCombo, inSerList, connectorProfile
-					.getInportSerializerType(), false);
-			connectorProfile.setInportSerializerType(value);
+			
+			if(outPortCombo != null) {
+				value = loadCombo(outPortCombo, outSerList, connectorProfile
+						.getOutportSerializerType(), false);
+				connectorProfile.setOutportSerializerType(value);
+			}
+			if(inPortCombo != null) {
+				value = loadCombo(inPortCombo, inSerList, connectorProfile
+						.getInportSerializerType(), false);
+				connectorProfile.setInportSerializerType(value);
+			}
 		}
 
 		if (ob != null && ob.enable) {

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
@@ -788,10 +788,6 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 			}
 			
 			List<String> typeList = new ArrayList<String>();
-			typeList.add("");
-			typeList.add("cdr");
-			outSerList.add("cdr");
-			inSerList.add("cdr");
 			
 			List<String> outTypeList = new ArrayList<String>();
 			for(String serType : outSerList) {
@@ -816,6 +812,7 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 					}
 				}
 			}
+			typeList.add("");
 			for(String serType : typeList) {
 				serializerTypeCombo.add(serType);
 			}
@@ -830,6 +827,15 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 				value = loadCombo(inPortCombo, inSerList, connectorProfile
 						.getInportSerializerType(), false);
 				connectorProfile.setInportSerializerType(value);
+			}
+			if(0<=serializerTypeCombo.indexOf("cdr")) {
+				serializerTypeCombo.setText("cdr");
+				outPortCombo.setText("cdr");
+				inPortCombo.setText("cdr");
+			} else {
+				serializerTypeCombo.select(0);
+				outPortCombo.select(0);
+				inPortCombo.select(0);
 			}
 		}
 

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
@@ -816,7 +816,6 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 			for(String serType : typeList) {
 				serializerTypeCombo.add(serType);
 			}
-			serializerTypeCombo.select(0);
 			
 			if(outPortCombo != null) {
 				value = loadCombo(outPortCombo, outSerList, connectorProfile

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ServiceConnectorCreaterDialog.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ServiceConnectorCreaterDialog.java
@@ -511,6 +511,7 @@ public class ServiceConnectorCreaterDialog extends ConnectorDialogBase {
 	protected void configureShell(Shell shell) {
 		super.configureShell(shell);
 		shell.setText("Connector Profile");
+		this.setHelpAvailable(false);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component.ecore
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component.ecore
@@ -273,6 +273,9 @@
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDoubleObject"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="timestampPolicy" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="isReverse" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="outportSerializerType"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="inportSerializerType" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="EIntegerObjectToPointMapEntry" instanceClassName="java.util.Map$Entry">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="key" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EIntegerObject"/>

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/Component.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/Component.java
@@ -20,6 +20,7 @@ import org.eclipse.emf.ecore.EStructuralFeature;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.Component#getConfigurationSets <em>Configuration Sets</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.Component#getActiveConfigurationSet <em>Active Configuration Set</em>}</li>
@@ -53,7 +54,6 @@ import org.eclipse.emf.ecore.EStructuralFeature;
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.Component#getInitialize <em>Initialize</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.Component#getFinalize <em>Finalize</em>}</li>
  * </ul>
- * </p>
  *
  * @see jp.go.aist.rtm.toolscommon.model.component.ComponentPackage#getComponent()
  * @model abstract="true"

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/ComponentPackage.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/ComponentPackage.java
@@ -1971,13 +1971,31 @@ public interface ComponentPackage extends EPackage {
 	int CONNECTOR_PROFILE__IS_REVERSE = CorePackage.WRAPPER_OBJECT_FEATURE_COUNT + 26;
 
 	/**
+	 * The feature id for the '<em><b>Outport Serializer Type</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int CONNECTOR_PROFILE__OUTPORT_SERIALIZER_TYPE = CorePackage.WRAPPER_OBJECT_FEATURE_COUNT + 27;
+
+	/**
+	 * The feature id for the '<em><b>Inport Serializer Type</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int CONNECTOR_PROFILE__INPORT_SERIALIZER_TYPE = CorePackage.WRAPPER_OBJECT_FEATURE_COUNT + 28;
+
+	/**
 	 * The number of structural features of the '<em>Connector Profile</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int CONNECTOR_PROFILE_FEATURE_COUNT = CorePackage.WRAPPER_OBJECT_FEATURE_COUNT + 27;
+	int CONNECTOR_PROFILE_FEATURE_COUNT = CorePackage.WRAPPER_OBJECT_FEATURE_COUNT + 29;
 
 	/**
 	 * The feature id for the '<em><b>Key</b></em>' attribute.
@@ -2718,6 +2736,24 @@ public interface ComponentPackage extends EPackage {
 	 * @ordered
 	 */
 	int CORBA_CONNECTOR_PROFILE__IS_REVERSE = CONNECTOR_PROFILE__IS_REVERSE;
+
+	/**
+	 * The feature id for the '<em><b>Outport Serializer Type</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int CORBA_CONNECTOR_PROFILE__OUTPORT_SERIALIZER_TYPE = CONNECTOR_PROFILE__OUTPORT_SERIALIZER_TYPE;
+
+	/**
+	 * The feature id for the '<em><b>Inport Serializer Type</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int CORBA_CONNECTOR_PROFILE__INPORT_SERIALIZER_TYPE = CONNECTOR_PROFILE__INPORT_SERIALIZER_TYPE;
 
 	/**
 	 * The feature id for the '<em><b>Rtc Connector Profile</b></em>' attribute.
@@ -4319,6 +4355,17 @@ public interface ComponentPackage extends EPackage {
 	EAttribute getConnectorProfile_TargetString();
 
 	/**
+	 * Returns the meta object for the attribute '{@link jp.go.aist.rtm.toolscommon.model.component.ConnectorProfile#getOutportSerializerType <em>Outport Serializer Type</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Outport Serializer Type</em>'.
+	 * @see jp.go.aist.rtm.toolscommon.model.component.ConnectorProfile#getOutportSerializerType()
+	 * @see #getConnectorProfile()
+	 * @generated
+	 */
+	EAttribute getConnectorProfile_OutportSerializerType();
+
+	/**
 	 * Returns the meta object for the attribute '{@link jp.go.aist.rtm.toolscommon.model.component.ConnectorProfile#getOutportBufferLength <em>Outport Buffer Length</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -4427,6 +4474,17 @@ public interface ComponentPackage extends EPackage {
 	 * @generated
 	 */
 	EAttribute getConnectorProfile_InportBufferReadTimeout();
+
+	/**
+	 * Returns the meta object for the attribute '{@link jp.go.aist.rtm.toolscommon.model.component.ConnectorProfile#getInportSerializerType <em>Inport Serializer Type</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Inport Serializer Type</em>'.
+	 * @see jp.go.aist.rtm.toolscommon.model.component.ConnectorProfile#getInportSerializerType()
+	 * @see #getConnectorProfile()
+	 * @generated
+	 */
+	EAttribute getConnectorProfile_InportSerializerType();
 
 	/**
 	 * Returns the meta object for the attribute '{@link jp.go.aist.rtm.toolscommon.model.component.ConnectorProfile#getTimestampPolicy <em>Timestamp Policy</em>}'.
@@ -5757,6 +5815,14 @@ public interface ComponentPackage extends EPackage {
 		EAttribute CONNECTOR_PROFILE__TARGET_STRING = eINSTANCE.getConnectorProfile_TargetString();
 
 		/**
+		 * The meta object literal for the '<em><b>Outport Serializer Type</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute CONNECTOR_PROFILE__OUTPORT_SERIALIZER_TYPE = eINSTANCE.getConnectorProfile_OutportSerializerType();
+
+		/**
 		 * The meta object literal for the '<em><b>Outport Buffer Length</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
@@ -5835,6 +5901,14 @@ public interface ComponentPackage extends EPackage {
 		 * @generated
 		 */
 		EAttribute CONNECTOR_PROFILE__INPORT_BUFFER_READ_TIMEOUT = eINSTANCE.getConnectorProfile_InportBufferReadTimeout();
+
+		/**
+		 * The meta object literal for the '<em><b>Inport Serializer Type</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute CONNECTOR_PROFILE__INPORT_SERIALIZER_TYPE = eINSTANCE.getConnectorProfile_InportSerializerType();
 
 		/**
 		 * The meta object literal for the '<em><b>Timestamp Policy</b></em>' attribute feature.

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/ComponentSpecification.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/ComponentSpecification.java
@@ -15,12 +15,12 @@ package jp.go.aist.rtm.toolscommon.model.component;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.ComponentSpecification#getAliasName <em>Alias Name</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.ComponentSpecification#isSpecUnLoad <em>Spec Un Load</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.ComponentSpecification#getRtcType <em>Rtc Type</em>}</li>
  * </ul>
- * </p>
  *
  * @see jp.go.aist.rtm.toolscommon.model.component.ComponentPackage#getComponentSpecification()
  * @model

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/ConnectorProfile.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/ConnectorProfile.java
@@ -48,14 +48,14 @@ public interface ConnectorProfile extends WrapperObject, IPropertyMap{
 		static final String OUTPORT_WRITE_TIMEOUT = "dataport.outport.buffer.write.timeout";
 		static final String OUTPORT_EMPTY_POLICY = "dataport.outport.buffer.read.empty_policy";
 		static final String OUTPORT_READ_TIMEOUT = "dataport.outport.buffer.read.timeout";
-		static final String OUTPORT_SERIALIZER_TYPE = "dataport.out.marshaling_type";
+		static final String OUTPORT_SERIALIZER_TYPE = "dataport.outport.marshaling_type";
 		//
 		static final String INPORT_BUFF_LENGTH = "dataport.inport.buffer.length";
 		static final String INPORT_FULL_POLICY = "dataport.inport.buffer.write.full_policy";
 		static final String INPORT_WRITE_TIMEOUT = "dataport.inport.buffer.write.timeout";
 		static final String INPORT_EMPTY_POLICY = "dataport.inport.buffer.read.empty_policy";
 		static final String INPORT_READ_TIMEOUT = "dataport.inport.buffer.read.timeout";
-		static final String INPORT_SERIALIZER_TYPE = "dataport.in.marshaling_type";
+		static final String INPORT_SERIALIZER_TYPE = "dataport.inport.marshaling_type";
 	}
 
 	/**

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/ConnectorProfile.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/ConnectorProfile.java
@@ -48,12 +48,14 @@ public interface ConnectorProfile extends WrapperObject, IPropertyMap{
 		static final String OUTPORT_WRITE_TIMEOUT = "dataport.outport.buffer.write.timeout";
 		static final String OUTPORT_EMPTY_POLICY = "dataport.outport.buffer.read.empty_policy";
 		static final String OUTPORT_READ_TIMEOUT = "dataport.outport.buffer.read.timeout";
+		static final String OUTPORT_SERIALIZER_TYPE = "dataport.out.marshaling_type";
 		//
 		static final String INPORT_BUFF_LENGTH = "dataport.inport.buffer.length";
 		static final String INPORT_FULL_POLICY = "dataport.inport.buffer.write.full_policy";
 		static final String INPORT_WRITE_TIMEOUT = "dataport.inport.buffer.write.timeout";
 		static final String INPORT_EMPTY_POLICY = "dataport.inport.buffer.read.empty_policy";
 		static final String INPORT_READ_TIMEOUT = "dataport.inport.buffer.read.timeout";
+		static final String INPORT_SERIALIZER_TYPE = "dataport.in.marshaling_type";
 	}
 
 	/**
@@ -347,6 +349,32 @@ public interface ConnectorProfile extends WrapperObject, IPropertyMap{
 	void setTargetString(String value);
 
 	/**
+	 * Returns the value of the '<em><b>Outport Serializer Type</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Outport Serializer Type</em>' attribute isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Outport Serializer Type</em>' attribute.
+	 * @see #setOutportSerializerType(String)
+	 * @see jp.go.aist.rtm.toolscommon.model.component.ComponentPackage#getConnectorProfile_OutportSerializerType()
+	 * @model
+	 * @generated
+	 */
+	String getOutportSerializerType();
+
+	/**
+	 * Sets the value of the '{@link jp.go.aist.rtm.toolscommon.model.component.ConnectorProfile#getOutportSerializerType <em>Outport Serializer Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Outport Serializer Type</em>' attribute.
+	 * @see #getOutportSerializerType()
+	 * @generated
+	 */
+	void setOutportSerializerType(String value);
+
+	/**
 	 * Returns the value of the '<em><b>Outport Buffer Length</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <p>
@@ -605,6 +633,32 @@ public interface ConnectorProfile extends WrapperObject, IPropertyMap{
 	 * @generated
 	 */
 	void setInportBufferReadTimeout(Double value);
+
+	/**
+	 * Returns the value of the '<em><b>Inport Serializer Type</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Inport Serializer Type</em>' attribute isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Inport Serializer Type</em>' attribute.
+	 * @see #setInportSerializerType(String)
+	 * @see jp.go.aist.rtm.toolscommon.model.component.ComponentPackage#getConnectorProfile_InportSerializerType()
+	 * @model
+	 * @generated
+	 */
+	String getInportSerializerType();
+
+	/**
+	 * Sets the value of the '{@link jp.go.aist.rtm.toolscommon.model.component.ConnectorProfile#getInportSerializerType <em>Inport Serializer Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Inport Serializer Type</em>' attribute.
+	 * @see #getInportSerializerType()
+	 * @generated
+	 */
+	void setInportSerializerType(String value);
 
 	/**
 	 * Returns the value of the '<em><b>Timestamp Policy</b></em>' attribute.

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/CorbaComponent.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/CorbaComponent.java
@@ -25,6 +25,7 @@ import jp.go.aist.rtm.toolscommon.model.component.util.ICorbaPortEventObserver;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.CorbaComponent#getRTCComponentProfile <em>RTC Component Profile</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.CorbaComponent#getRTCExecutionContexts <em>RTC Execution Contexts</em>}</li>
@@ -37,7 +38,6 @@ import jp.go.aist.rtm.toolscommon.model.component.util.ICorbaPortEventObserver;
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.CorbaComponent#getStatusObserver <em>Status Observer</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.CorbaComponent#getLogObserver <em>Log Observer</em>}</li>
  * </ul>
- * </p>
  *
  * @see jp.go.aist.rtm.toolscommon.model.component.ComponentPackage#getCorbaComponent()
  * @model

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/CorbaConfigurationSet.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/CorbaConfigurationSet.java
@@ -14,10 +14,10 @@ package jp.go.aist.rtm.toolscommon.model.component;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.CorbaConfigurationSet#getSDOConfigurationSet <em>SDO Configuration Set</em>}</li>
  * </ul>
- * </p>
  *
  * @see jp.go.aist.rtm.toolscommon.model.component.ComponentPackage#getCorbaConfigurationSet()
  * @model

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/CorbaConnectorProfile.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/CorbaConnectorProfile.java
@@ -14,10 +14,10 @@ package jp.go.aist.rtm.toolscommon.model.component;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.CorbaConnectorProfile#getRtcConnectorProfile <em>Rtc Connector Profile</em>}</li>
  * </ul>
- * </p>
  *
  * @see jp.go.aist.rtm.toolscommon.model.component.ComponentPackage#getCorbaConnectorProfile()
  * @model

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/CorbaObserver.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/CorbaObserver.java
@@ -18,11 +18,11 @@ import org.omg.PortableServer.Servant;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.CorbaObserver#getServiceProfile <em>Service Profile</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.CorbaObserver#getServant <em>Servant</em>}</li>
  * </ul>
- * </p>
  *
  * @see jp.go.aist.rtm.toolscommon.model.component.ComponentPackage#getCorbaObserver()
  * @model superTypes="jp.go.aist.rtm.toolscommon.model.component.IPropertyMap jp.go.aist.rtm.toolscommon.model.core.IAdaptable"

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/CorbaPortSynchronizer.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/CorbaPortSynchronizer.java
@@ -16,10 +16,10 @@ import jp.go.aist.rtm.toolscommon.model.core.CorbaWrapperObject;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.CorbaPortSynchronizer#getRTCPortProfile <em>RTC Port Profile</em>}</li>
  * </ul>
- * </p>
  *
  * @see jp.go.aist.rtm.toolscommon.model.component.ComponentPackage#getCorbaPortSynchronizer()
  * @model

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/PortConnector.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/PortConnector.java
@@ -38,7 +38,7 @@ public interface PortConnector extends WrapperObject {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Routing Constraint</em>' map.
 	 * @see jp.go.aist.rtm.toolscommon.model.component.ComponentPackage#getPortConnector_RoutingConstraint()
-	 * @model mapType="jp.go.aist.rtm.toolscommon.model.component.EIntegerObjectToPointMapEntry<org.eclipse.emf.ecore.EIntegerObject, jp.go.aist.rtm.toolscommon.model.core.Point>"
+	 * @model mapType="jp.go.aist.rtm.toolscommon.model.component.EIntegerObjectToPointMapEntry&lt;org.eclipse.emf.ecore.EIntegerObject, jp.go.aist.rtm.toolscommon.model.core.Point&gt;"
 	 * @generated
 	 */
 	EMap<Integer, Point> getRoutingConstraint();

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/PortSynchronizer.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/PortSynchronizer.java
@@ -15,10 +15,10 @@ import java.util.List;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.PortSynchronizer#getOriginalPortString <em>Original Port String</em>}</li>
  * </ul>
- * </p>
  *
  * @see jp.go.aist.rtm.toolscommon.model.component.ComponentPackage#getPortSynchronizer()
  * @model

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/SystemDiagramKind.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/SystemDiagramKind.java
@@ -95,6 +95,8 @@ public enum SystemDiagramKind implements Enumerator
 	 * Returns the '<em><b>System Diagram Kind</b></em>' literal with the specified literal value.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * @param literal the literal.
+	 * @return the matching enumerator or <code>null</code>.
 	 * @generated
 	 */
 	public static SystemDiagramKind get(String literal) {
@@ -111,6 +113,8 @@ public enum SystemDiagramKind implements Enumerator
 	 * Returns the '<em><b>System Diagram Kind</b></em>' literal with the specified name.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * @param name the name.
+	 * @return the matching enumerator or <code>null</code>.
 	 * @generated
 	 */
 	public static SystemDiagramKind getByName(String name) {
@@ -127,6 +131,8 @@ public enum SystemDiagramKind implements Enumerator
 	 * Returns the '<em><b>System Diagram Kind</b></em>' literal with the specified integer value.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * @param value the integer value.
+	 * @return the matching enumerator or <code>null</code>.
 	 * @generated
 	 */
 	public static SystemDiagramKind get(int value) {

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ComponentFactoryImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ComponentFactoryImpl.java
@@ -32,6 +32,7 @@ import _SDOPackage.ConfigurationHelper;
 import _SDOPackage.Organization;
 import _SDOPackage.ServiceProfile;
 import jp.go.aist.rtm.toolscommon.corba.CorbaUtil;
+import jp.go.aist.rtm.toolscommon.model.component.*;
 import jp.go.aist.rtm.toolscommon.model.component.ComponentFactory;
 import jp.go.aist.rtm.toolscommon.model.component.ComponentPackage;
 import jp.go.aist.rtm.toolscommon.model.component.ComponentSpecification;

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ComponentImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ComponentImpl.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.ComponentImpl#getConfigurationSets <em>Configuration Sets</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.ComponentImpl#getActiveConfigurationSet <em>Active Configuration Set</em>}</li>
@@ -82,7 +83,6 @@ import org.slf4j.LoggerFactory;
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.ComponentImpl#getInitialize <em>Initialize</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.ComponentImpl#getFinalize <em>Finalize</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ComponentPackageImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ComponentPackageImpl.java
@@ -383,7 +383,7 @@ public class ComponentPackageImpl extends EPackageImpl implements ComponentPacka
 
 	/**
 	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
-	 *
+	 * 
 	 * <p>This method is used to initialize {@link ComponentPackage#eINSTANCE} when that field is accessed.
 	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
 	 * <!-- begin-user-doc -->
@@ -418,7 +418,7 @@ public class ComponentPackageImpl extends EPackageImpl implements ComponentPacka
 		// Mark meta-data to indicate it can't be changed
 		theComponentPackage.freeze();
 
-
+  
 		// Update the registry and return the package
 		EPackage.Registry.INSTANCE.put(ComponentPackage.eNS_URI, theComponentPackage);
 		return theComponentPackage;
@@ -1329,6 +1329,15 @@ public class ComponentPackageImpl extends EPackageImpl implements ComponentPacka
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public EAttribute getConnectorProfile_OutportSerializerType() {
+		return (EAttribute)connectorProfileEClass.getEStructuralFeatures().get(27);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public EAttribute getConnectorProfile_OutportBufferLength() {
 		return (EAttribute)connectorProfileEClass.getEStructuralFeatures().get(15);
 	}
@@ -1412,6 +1421,15 @@ public class ComponentPackageImpl extends EPackageImpl implements ComponentPacka
 	 */
 	public EAttribute getConnectorProfile_InportBufferReadTimeout() {
 		return (EAttribute)connectorProfileEClass.getEStructuralFeatures().get(24);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getConnectorProfile_InportSerializerType() {
+		return (EAttribute)connectorProfileEClass.getEStructuralFeatures().get(28);
 	}
 
 	/**
@@ -1980,6 +1998,8 @@ public class ComponentPackageImpl extends EPackageImpl implements ComponentPacka
 		createEAttribute(connectorProfileEClass, CONNECTOR_PROFILE__INPORT_BUFFER_READ_TIMEOUT);
 		createEAttribute(connectorProfileEClass, CONNECTOR_PROFILE__TIMESTAMP_POLICY);
 		createEAttribute(connectorProfileEClass, CONNECTOR_PROFILE__IS_REVERSE);
+		createEAttribute(connectorProfileEClass, CONNECTOR_PROFILE__OUTPORT_SERIALIZER_TYPE);
+		createEAttribute(connectorProfileEClass, CONNECTOR_PROFILE__INPORT_SERIALIZER_TYPE);
 
 		eIntegerObjectToPointMapEntryEClass = createEClass(EINTEGER_OBJECT_TO_POINT_MAP_ENTRY);
 		createEAttribute(eIntegerObjectToPointMapEntryEClass, EINTEGER_OBJECT_TO_POINT_MAP_ENTRY__KEY);
@@ -2346,6 +2366,8 @@ public class ComponentPackageImpl extends EPackageImpl implements ComponentPacka
 		initEAttribute(getConnectorProfile_InportBufferReadTimeout(), ecorePackage.getEDoubleObject(), "inportBufferReadTimeout", null, 0, 1, ConnectorProfile.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getConnectorProfile_TimestampPolicy(), ecorePackage.getEString(), "timestampPolicy", null, 0, 1, ConnectorProfile.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getConnectorProfile_IsReverse(), ecorePackage.getEBoolean(), "isReverse", null, 0, 1, ConnectorProfile.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getConnectorProfile_OutportSerializerType(), ecorePackage.getEString(), "outportSerializerType", null, 0, 1, ConnectorProfile.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getConnectorProfile_InportSerializerType(), ecorePackage.getEString(), "inportSerializerType", null, 0, 1, ConnectorProfile.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(eIntegerObjectToPointMapEntryEClass, Map.Entry.class, "EIntegerObjectToPointMapEntry", !IS_ABSTRACT, !IS_INTERFACE, !IS_GENERATED_INSTANCE_CLASS);
 		initEAttribute(getEIntegerObjectToPointMapEntry_Key(), ecorePackage.getEIntegerObject(), "key", null, 0, 1, Map.Entry.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ComponentSpecificationImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ComponentSpecificationImpl.java
@@ -44,12 +44,12 @@ import org.slf4j.LoggerFactory;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.ComponentSpecificationImpl#getAliasName <em>Alias Name</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.ComponentSpecificationImpl#isSpecUnLoad <em>Spec Un Load</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.ComponentSpecificationImpl#getRtcType <em>Rtc Type</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ConfigurationSetImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ConfigurationSetImpl.java
@@ -29,11 +29,11 @@ import org.eclipse.emf.ecore.util.InternalEList;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.ConfigurationSetImpl#getId <em>Id</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.ConfigurationSetImpl#getConfigurationData <em>Configuration Data</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ConnectorProfileImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ConnectorProfileImpl.java
@@ -23,6 +23,7 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.ConnectorProfileImpl#getDataflowType <em>Dataflow Type</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.ConnectorProfileImpl#getSubscriptionType <em>Subscription Type</em>}</li>
@@ -51,8 +52,9 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.ConnectorProfileImpl#getInportBufferReadTimeout <em>Inport Buffer Read Timeout</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.ConnectorProfileImpl#getTimestampPolicy <em>Timestamp Policy</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.ConnectorProfileImpl#isIsReverse <em>Is Reverse</em>}</li>
+ *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.ConnectorProfileImpl#getOutportSerializerType <em>Outport Serializer Type</em>}</li>
+ *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.ConnectorProfileImpl#getInportSerializerType <em>Inport Serializer Type</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
@@ -547,6 +549,46 @@ public class ConnectorProfileImpl extends WrapperObjectImpl implements
 	 */
 	protected boolean isReverse = IS_REVERSE_EDEFAULT;
 
+	/**
+	 * The default value of the '{@link #getOutportSerializerType() <em>Outport Serializer Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getOutportSerializerType()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final String OUTPORT_SERIALIZER_TYPE_EDEFAULT = null;
+
+	/**
+	 * The cached value of the '{@link #getOutportSerializerType() <em>Outport Serializer Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getOutportSerializerType()
+	 * @generated
+	 * @ordered
+	 */
+	protected String outportSerializerType = OUTPORT_SERIALIZER_TYPE_EDEFAULT;
+
+	/**
+	 * The default value of the '{@link #getInportSerializerType() <em>Inport Serializer Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getInportSerializerType()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final String INPORT_SERIALIZER_TYPE_EDEFAULT = null;
+
+	/**
+	 * The cached value of the '{@link #getInportSerializerType() <em>Inport Serializer Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getInportSerializerType()
+	 * @generated
+	 * @ordered
+	 */
+	protected String inportSerializerType = INPORT_SERIALIZER_TYPE_EDEFAULT;
+
 	IPropertyMap properties;
 
 	/**
@@ -851,6 +893,27 @@ public class ConnectorProfileImpl extends WrapperObjectImpl implements
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public String getOutportSerializerType() {
+		return outportSerializerType;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setOutportSerializerType(String newOutportSerializerType) {
+		String oldOutportSerializerType = outportSerializerType;
+		outportSerializerType = newOutportSerializerType;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, ComponentPackage.CONNECTOR_PROFILE__OUTPORT_SERIALIZER_TYPE, oldOutportSerializerType, outportSerializerType));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public Integer getOutportBufferLength() {
 		return outportBufferLength;
 	}
@@ -1061,6 +1124,27 @@ public class ConnectorProfileImpl extends WrapperObjectImpl implements
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public String getInportSerializerType() {
+		return inportSerializerType;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setInportSerializerType(String newInportSerializerType) {
+		String oldInportSerializerType = inportSerializerType;
+		inportSerializerType = newInportSerializerType;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, ComponentPackage.CONNECTOR_PROFILE__INPORT_SERIALIZER_TYPE, oldInportSerializerType, inportSerializerType));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public String getTimestampPolicy() {
 		return timestampPolicy;
 	}
@@ -1205,6 +1289,10 @@ public class ConnectorProfileImpl extends WrapperObjectImpl implements
 				return getTimestampPolicy();
 			case ComponentPackage.CONNECTOR_PROFILE__IS_REVERSE:
 				return isIsReverse();
+			case ComponentPackage.CONNECTOR_PROFILE__OUTPORT_SERIALIZER_TYPE:
+				return getOutportSerializerType();
+			case ComponentPackage.CONNECTOR_PROFILE__INPORT_SERIALIZER_TYPE:
+				return getInportSerializerType();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
@@ -1285,6 +1373,12 @@ public class ConnectorProfileImpl extends WrapperObjectImpl implements
 				return;
 			case ComponentPackage.CONNECTOR_PROFILE__IS_REVERSE:
 				setIsReverse((Boolean)newValue);
+				return;
+			case ComponentPackage.CONNECTOR_PROFILE__OUTPORT_SERIALIZER_TYPE:
+				setOutportSerializerType((String)newValue);
+				return;
+			case ComponentPackage.CONNECTOR_PROFILE__INPORT_SERIALIZER_TYPE:
+				setInportSerializerType((String)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -1367,6 +1461,12 @@ public class ConnectorProfileImpl extends WrapperObjectImpl implements
 			case ComponentPackage.CONNECTOR_PROFILE__IS_REVERSE:
 				setIsReverse(IS_REVERSE_EDEFAULT);
 				return;
+			case ComponentPackage.CONNECTOR_PROFILE__OUTPORT_SERIALIZER_TYPE:
+				setOutportSerializerType(OUTPORT_SERIALIZER_TYPE_EDEFAULT);
+				return;
+			case ComponentPackage.CONNECTOR_PROFILE__INPORT_SERIALIZER_TYPE:
+				setInportSerializerType(INPORT_SERIALIZER_TYPE_EDEFAULT);
+				return;
 		}
 		super.eUnset(featureID);
 	}
@@ -1433,6 +1533,10 @@ public class ConnectorProfileImpl extends WrapperObjectImpl implements
 				return TIMESTAMP_POLICY_EDEFAULT == null ? timestampPolicy != null : !TIMESTAMP_POLICY_EDEFAULT.equals(timestampPolicy);
 			case ComponentPackage.CONNECTOR_PROFILE__IS_REVERSE:
 				return isReverse != IS_REVERSE_EDEFAULT;
+			case ComponentPackage.CONNECTOR_PROFILE__OUTPORT_SERIALIZER_TYPE:
+				return OUTPORT_SERIALIZER_TYPE_EDEFAULT == null ? outportSerializerType != null : !OUTPORT_SERIALIZER_TYPE_EDEFAULT.equals(outportSerializerType);
+			case ComponentPackage.CONNECTOR_PROFILE__INPORT_SERIALIZER_TYPE:
+				return INPORT_SERIALIZER_TYPE_EDEFAULT == null ? inportSerializerType != null : !INPORT_SERIALIZER_TYPE_EDEFAULT.equals(inportSerializerType);
 		}
 		return super.eIsSet(featureID);
 	}
@@ -1492,6 +1596,10 @@ public class ConnectorProfileImpl extends WrapperObjectImpl implements
 		result.append(timestampPolicy);
 		result.append(", isReverse: ");
 		result.append(isReverse);
+		result.append(", outportSerializerType: ");
+		result.append(outportSerializerType);
+		result.append(", inportSerializerType: ");
+		result.append(inportSerializerType);
 		result.append(')');
 		return result.toString();
 	}

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ContextHandlerImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ContextHandlerImpl.java
@@ -29,8 +29,6 @@ import org.eclipse.ui.views.properties.IPropertySource;
  * <!-- begin-user-doc -->
  * An implementation of the model object '<em><b>Context Handler</b></em>'.
  * <!-- end-user-doc -->
- * <p>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaComponentImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaComponentImpl.java
@@ -20,6 +20,7 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.util.EDataTypeEList;
 import org.eclipse.emf.ecore.util.EDataTypeUniqueEList;
@@ -78,6 +79,7 @@ import jp.go.aist.rtm.toolscommon.util.SDOUtil;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.CorbaComponentImpl#getCorbaObject <em>Corba Object</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.CorbaComponentImpl#getRTCComponentProfile <em>RTC Component Profile</em>}</li>
@@ -91,7 +93,6 @@ import jp.go.aist.rtm.toolscommon.util.SDOUtil;
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.CorbaComponentImpl#getStatusObserver <em>Status Observer</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.CorbaComponentImpl#getLogObserver <em>Log Observer</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaConfigurationSetImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaConfigurationSetImpl.java
@@ -31,10 +31,10 @@ import _SDOPackage.ConfigurationSet;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.CorbaConfigurationSetImpl#getSDOConfigurationSet <em>SDO Configuration Set</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaConnectorProfileImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaConnectorProfileImpl.java
@@ -35,10 +35,10 @@ import _SDOPackage.NameValue;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.CorbaConnectorProfileImpl#getRtcConnectorProfile <em>Rtc Connector Profile</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
@@ -257,6 +257,8 @@ public class CorbaConnectorProfileImpl extends ConnectorProfileImpl implements C
 				PROP.OUTPORT_EMPTY_POLICY);
 		addProperty(result, profile.getOutportBufferReadTimeout(),
 				PROP.OUTPORT_READ_TIMEOUT);
+		addProperty(result, profile.getOutportSerializerType(),
+				PROP.OUTPORT_SERIALIZER_TYPE);
 		//
 		addProperty(result, profile.getInportBufferLength(),
 				PROP.INPORT_BUFF_LENGTH);
@@ -268,6 +270,8 @@ public class CorbaConnectorProfileImpl extends ConnectorProfileImpl implements C
 				PROP.INPORT_EMPTY_POLICY);
 		addProperty(result, profile.getInportBufferReadTimeout(),
 				PROP.INPORT_READ_TIMEOUT);
+		addProperty(result, profile.getInportSerializerType(),
+				PROP.INPORT_SERIALIZER_TYPE);
 
 		for (String key : profile.getPropertyKeys()) {
 			addProperty(result, profile.getProperty(key), key);

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaContextHandlerImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaContextHandlerImpl.java
@@ -22,8 +22,6 @@ import org.eclipse.emf.ecore.EClass;
  * <!-- begin-user-doc -->
  * An implementation of the model object '<em><b>Corba Context Handler</b></em>'.
  * <!-- end-user-doc -->
- * <p>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaExecutionContextImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaExecutionContextImpl.java
@@ -51,11 +51,11 @@ import jp.go.aist.rtm.toolscommon.synchronizationframework.mapping.ReferenceMapp
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.CorbaExecutionContextImpl#getCorbaObject <em>Corba Object</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.CorbaExecutionContextImpl#getRtcExecutionContextProfile <em>Rtc Execution Context Profile</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaLogObserverImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaLogObserverImpl.java
@@ -23,8 +23,6 @@ import static jp.go.aist.rtm.toolscommon.util.RTMixin.*;
  * <!-- begin-user-doc -->
  * An implementation of the model object '<em><b>Corba Log Observer</b></em>'.
  * <!-- end-user-doc -->
- * <p>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaObserverImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaObserverImpl.java
@@ -36,11 +36,11 @@ import _SDOPackage.ServiceProfile;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.CorbaObserverImpl#getServiceProfile <em>Service Profile</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.CorbaObserverImpl#getServant <em>Servant</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaPortSynchronizerImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaPortSynchronizerImpl.java
@@ -45,11 +45,11 @@ import _SDOPackage.NameValue;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.CorbaPortSynchronizerImpl#getOriginalPortString <em>Original Port String</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.CorbaPortSynchronizerImpl#getRTCPortProfile <em>RTC Port Profile</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaStatusObserverImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/CorbaStatusObserverImpl.java
@@ -47,8 +47,6 @@ import jp.go.aist.rtm.toolscommon.model.component.util.ICorbaPortEventObserver;
  * <!-- begin-user-doc -->
  * An implementation of the model object '<em><b>Corba Status Observer</b></em>'.
  * <!-- end-user-doc -->
- * <p>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/EIntegerObjectToPointMapEntryImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/EIntegerObjectToPointMapEntryImpl.java
@@ -23,11 +23,11 @@ import org.eclipse.emf.ecore.impl.EObjectImpl;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.EIntegerObjectToPointMapEntryImpl#getTypedKey <em>Key</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.EIntegerObjectToPointMapEntryImpl#getTypedValue <em>Value</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ExecutionContextImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ExecutionContextImpl.java
@@ -29,6 +29,7 @@ import org.eclipse.ui.views.properties.IPropertySource;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.ExecutionContextImpl#getKindL <em>Kind L</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.ExecutionContextImpl#getRateL <em>Rate L</em>}</li>
@@ -36,7 +37,6 @@ import org.eclipse.ui.views.properties.IPropertySource;
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.ExecutionContextImpl#getOwner <em>Owner</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.ExecutionContextImpl#getParticipants <em>Participants</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/InPortImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/InPortImpl.java
@@ -18,8 +18,6 @@ import org.eclipse.ui.views.properties.IPropertySource;
 /**
  * <!-- begin-user-doc --> An implementation of the model object '<em><b>In Port</b></em>'.
  * <!-- end-user-doc -->
- * <p>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/NameValueImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/NameValueImpl.java
@@ -24,12 +24,12 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.NameValueImpl#getName <em>Name</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.NameValueImpl#getValue <em>Value</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.NameValueImpl#getTypeName <em>Type Name</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/OutPortImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/OutPortImpl.java
@@ -20,8 +20,6 @@ import org.eclipse.ui.views.properties.IPropertySource;
 /**
  * <!-- begin-user-doc --> An implementation of the model object '<em><b>Out Port</b></em>'.
  * <!-- end-user-doc -->
- * <p>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/PortConnectorImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/PortConnectorImpl.java
@@ -31,13 +31,13 @@ import org.eclipse.ui.views.properties.IPropertySource;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.PortConnectorImpl#getConnectorProfile <em>Connector Profile</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.PortConnectorImpl#getRoutingConstraint <em>Routing Constraint</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.PortConnectorImpl#getSource <em>Source</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.PortConnectorImpl#getTarget <em>Target</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/PortImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/PortImpl.java
@@ -35,6 +35,7 @@ import org.eclipse.emf.ecore.util.EObjectResolvingEList;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.PortImpl#getOriginalPortString <em>Original Port String</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.PortImpl#getSynchronizer <em>Synchronizer</em>}</li>
@@ -50,7 +51,6 @@ import org.eclipse.emf.ecore.util.EObjectResolvingEList;
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.PortImpl#getDataType <em>Data Type</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.PortImpl#getInterfaceType <em>Interface Type</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
@@ -372,6 +372,10 @@ public class PortImpl extends WrapperObjectImpl implements Port {
 		return SDOUtil.getValueList(getSubscriptionType());
 	}
 
+	public List<String> getSerializerTypes() {
+		return SDOUtil.getValueList(getSubscriptionType());
+	}
+	
 	/**
 	 * nameValueから値を取得する
 	 * 

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/PortSynchronizerImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/PortSynchronizerImpl.java
@@ -33,10 +33,10 @@ import org.eclipse.emf.ecore.impl.EObjectImpl;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.PortSynchronizerImpl#getOriginalPortString <em>Original Port String</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ServicePortImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/ServicePortImpl.java
@@ -17,8 +17,6 @@ import org.eclipse.ui.views.properties.IPropertySource;
 /**
  * <!-- begin-user-doc --> An implementation of the model object '<em><b>Service Port</b></em>'.
  * <!-- end-user-doc -->
- * <p>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/SystemDiagramImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/SystemDiagramImpl.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.SystemDiagramImpl#getComponents <em>Components</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.SystemDiagramImpl#getKind <em>Kind</em>}</li>
@@ -59,7 +60,6 @@ import org.slf4j.LoggerFactory;
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.SystemDiagramImpl#getParentSystemDiagram <em>Parent System Diagram</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.component.impl.SystemDiagramImpl#getCompositeComponent <em>Composite Component</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/core/impl/CorbaWrapperObjectImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/core/impl/CorbaWrapperObjectImpl.java
@@ -18,10 +18,10 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.core.impl.CorbaWrapperObjectImpl#getCorbaObject <em>Corba Object</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/core/impl/CoreFactoryImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/core/impl/CoreFactoryImpl.java
@@ -16,6 +16,7 @@ import org.eclipse.emf.ecore.impl.EFactoryImpl;
 import org.eclipse.emf.ecore.plugin.EcorePlugin;
 
 import jp.go.aist.rtm.toolscommon.corba.CorbaUtil;
+import jp.go.aist.rtm.toolscommon.model.core.*;
 import jp.go.aist.rtm.toolscommon.model.core.CoreFactory;
 import jp.go.aist.rtm.toolscommon.model.core.CorePackage;
 import jp.go.aist.rtm.toolscommon.model.core.ModelElement;

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/core/impl/ModelElementImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/core/impl/ModelElementImpl.java
@@ -22,10 +22,10 @@ import org.eclipse.emf.ecore.impl.EObjectImpl;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.core.impl.ModelElementImpl#getConstraint <em>Constraint</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/core/impl/WrapperObjectImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/core/impl/WrapperObjectImpl.java
@@ -15,8 +15,6 @@ import org.eclipse.emf.ecore.EClass;
 /**
  * <!-- begin-user-doc --> An implementation of the model object '<em><b>Wrapper Object</b></em>'.
  * <!-- end-user-doc -->
- * <p>
- * </p>
  *
  * @generated
  */

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/core/util/CoreAdapterFactory.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/core/util/CoreAdapterFactory.java
@@ -6,6 +6,7 @@
  */
 package jp.go.aist.rtm.toolscommon.model.core.util;
 
+import jp.go.aist.rtm.toolscommon.model.core.*;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.common.notify.Notifier;

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/core/util/CoreSwitch.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/core/util/CoreSwitch.java
@@ -8,6 +8,7 @@ package jp.go.aist.rtm.toolscommon.model.core.util;
 
 import java.util.List;
 
+import jp.go.aist.rtm.toolscommon.model.core.*;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/manager/RTCManager.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/manager/RTCManager.java
@@ -24,6 +24,7 @@ import RTM.ModuleProfile;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.manager.RTCManager#getManagerProfile <em>Manager Profile</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.manager.RTCManager#getInstanceNameL <em>Instance Name L</em>}</li>
@@ -37,7 +38,6 @@ import RTM.ModuleProfile;
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.manager.RTCManager#getSlaveManagers <em>Slave Managers</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.manager.RTCManager#getConfiguratoins <em>Configuratoins</em>}</li>
  * </ul>
- * </p>
  *
  * @see jp.go.aist.rtm.toolscommon.model.manager.ManagerPackage#getRTCManager()
  * @model

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/manager/impl/RTCManagerImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/manager/impl/RTCManagerImpl.java
@@ -16,6 +16,7 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.util.EDataTypeUniqueEList;
+import org.eclipse.emf.ecore.util.EObjectResolvingEList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +48,7 @@ import jp.go.aist.rtm.toolscommon.util.SDOUtil;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.manager.impl.RTCManagerImpl#getManagerProfile <em>Manager Profile</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.manager.impl.RTCManagerImpl#getInstanceNameL <em>Instance Name L</em>}</li>
@@ -60,7 +62,6 @@ import jp.go.aist.rtm.toolscommon.util.SDOUtil;
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.manager.impl.RTCManagerImpl#getSlaveManagers <em>Slave Managers</em>}</li>
  *   <li>{@link jp.go.aist.rtm.toolscommon.model.manager.impl.RTCManagerImpl#getConfiguratoins <em>Configuratoins</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */


### PR DESCRIPTION
## Identify the Bug

Link to #290

## Description of the Change

データポート間を接続する際に，コネクタプロファイル設定画面で，使用するシリアライザを設定できるように修正しました．
(ただし，手元の環境ではシリアライザが設定されたポートを持つコンポーネントを動作させる事ができなかったため，動作確認は行えておりません)

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests? ユニットテストなし