### PR TITLE
Eclipse2019-03ベースのソースビルド環境起動用Vagrantfileを追加

### DIFF
--- a/scripts/openrtp20/Vagrantfile
+++ b/scripts/openrtp20/Vagrantfile
@@ -1,0 +1,34 @@
+# -*- mode: ruby -*-
+# -*- coding: utf-8 -*-
+# vi: set ft=ruby :
+
+#--------------------------------
+VM_NAME = "openrtp20"
+BOX_IMAGE = "openrtp20"
+BOX_URL = "https://openrtm.org/pub/openrtp/vagrant-box/openrtp20-eclipse411.box"
+DISK_SIZE = "32GB"
+MEMORY = 4096
+
+# port forwarding
+SSH_PORT = 2184
+#--------------------------------
+
+Vagrant.configure("2") do |config|
+
+  config.vm.define VM_NAME do |node|
+    node.vm.hostname = VM_NAME
+    node.vm.box = BOX_IMAGE
+    node.vm.box_url = BOX_URL
+    node.disksize.size = DISK_SIZE
+    node.vm.network :forwarded_port, id: "ssh", guest: 22, host: SSH_PORT
+    node.vm.provider "virtualbox" do |v|
+      v.name = VM_NAME
+      v.memory = MEMORY
+
+      # Serial port activation off
+      v.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ]
+    end
+    node.vm.synced_folder "./share", "/home/vagrant/share", create: true, owner: "vagrant", group: "vagrant"
+    node.vm.synced_folder "./scripts", "/home/vagrant/scripts", create: true, owner: "vagrant", group: "vagrant"
+  end
+end

--- a/scripts/openrtp20/scripts/linux-make_packages.sh
+++ b/scripts/openrtp20/scripts/linux-make_packages.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+export ECLIPSE_VERSION="R-4.11-201903070500"
+export DOWNLOAD_SITE="file://${HOME}/public_html/pub/eclipse/packages/"
+export REPOSITORY="file://${HOME}/public_html/pub/eclipse/projects/2019-03,http://download.eclipse.org/releases/2019-03"
+export LANGPACK_FILE_NAME="BabelLanguagePack-eclipse-ja_4.10.0.v20190126060001.zip"
+
+export ECLIPSE_HOME=${HOME}/eclipse
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+export PATH=/usr/lib/jvm/java-8-openjdk-amd64/bin:${PATH}
+export OS=LINUX
+export WORK_DIR=./work/linux
+export BIT=64
+
+sh make_packages
+
+cd packages
+name=`find . -name "*ja-linux-gtk-x86_64.tar.gz" | xargs basename`
+cp -r $name openrtp-linux-gtk-x86_64.tar.gz
+name=`find . -name "*ja-linux-gtk.tar.gz" | xargs basename`
+cp -r $name openrtp-linux-gtk.tar.gz
+cd ..
+

--- a/scripts/openrtp20/scripts/macosx-make_packages.sh
+++ b/scripts/openrtp20/scripts/macosx-make_packages.sh
@@ -1,0 +1,16 @@
+!/bin/bash
+
+export ECLIPSE_VERSION="R-4.11-201903070500"
+export DOWNLOAD_SITE="file://${HOME}/public_html/pub/eclipse/packages/"
+export REPOSITORY="file://${HOME}/public_html/pub/eclipse/projects/2019-03,http://download.eclipse.org/releases/2019-03"
+export LANGPACK_FILE_NAME="BabelLanguagePack-eclipse-ja_4.10.0.v20190126060001.zip"
+
+export ECLIPSE_HOME=${HOME}/eclipse
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+export PATH=/usr/lib/jvm/java-8-openjdk-amd64/bin:${PATH}
+export OS=MACOS
+export WORK_DIR=./work/macosx
+export BIT=64
+
+sh make_packages
+

--- a/scripts/openrtp20/scripts/src_build_script.sh
+++ b/scripts/openrtp20/scripts/src_build_script.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export ECLIPSE_HOME=${HOME}/eclipse_envs/eclipse
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+export PATH=/usr/lib/jvm/java-8-openjdk-amd64/bin:${PATH}
+
+rm -rf openrtp-*
+rm -rf packages/*.tar.gz packages/*.zip
+sh build_all clean
+sh build_all

--- a/scripts/openrtp20/scripts/win32-make_packages.sh
+++ b/scripts/openrtp20/scripts/win32-make_packages.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+export ECLIPSE_VERSION="R-4.11-201903070500"
+export DOWNLOAD_SITE="file://${HOME}/public_html/pub/eclipse/packages/"
+export REPOSITORY="file://${HOME}/public_html/pub/eclipse/projects/2019-03,http://download.eclipse.org/releases/2019-03"
+export LANGPACK_FILE_NAME="BabelLanguagePack-eclipse-ja_4.10.0.v20190126060001.zip"
+
+export ECLIPSE_HOME=${HOME}/eclipse
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+export PATH=/usr/lib/jvm/java-8-openjdk-amd64/bin:${PATH}
+export OS=WIN32
+export WORK_DIR=./work/win32
+export BIT=64
+
+sh make_packages
+
+cd packages
+name=`find . -name *ja-win32.zip | xargs basename`
+cp -r $name openrtp.zip
+cd ..
+


### PR DESCRIPTION
Link to #264 

## Verification 

- Windows10 環境でこのVagrantfileを使いOpenRTP masterソースのビルド環境を構築できることを確認
- 手順は下記参照
https://openrtm.org/redmine/projects/rtsystemeditor/wiki/VagrantでOpenRTP20用boxファイルを使ってビルド環境を構築する

- この環境でOpenRTPのビルド動作を確認