### PR TITLE
subscription typeのデフォルト値ががflushとなるように修正

### DIFF
--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
@@ -718,8 +718,11 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 			types = Arrays.asList(preference.getSubscriptionTypes());
 			isAllowAny = false;
 		}
-		value = loadCombo(subscriptionTypeCombo, types, connectorProfile
-				.getSubscriptionType(), isAllowAny);
+		String defaultVal = connectorProfile.getSubscriptionType();
+		if(defaultVal==null || defaultVal.length()==0) {
+			defaultVal = "flush";
+		}
+		value = loadCombo(subscriptionTypeCombo, types, defaultVal, isAllowAny);
 		connectorProfile.setSubscriptionType(value);
 		//
 		if (!isOffline()) {


### PR DESCRIPTION
## Identify the Bug

Link to #311

## Description of the Change

データポート間を接続する際に，ConnectorProfileのダイアログの subscription typeのデフォルト値が｢flush｣となるように修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests? ユニットテストなし