### PR TITLE
Configuration変更ダイアログのスライダーの動作を修正

### DIFF
--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ConfigurationDialog.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ConfigurationDialog.java
@@ -983,7 +983,7 @@ public class ConfigurationDialog extends TitleAreaDialog {
 				// ステップから制約範囲内の値に換算
 				int step = valueSlider.getSelection();
 				String value = wd.getCondition().getValueByStep(step, wd,
-						valueSliderText.getText(), wd.getSliderStep());
+						valueSliderText.getText(), wd.getSliderStepStr());
 				if (wd.getCondition().validate(value)) {
 					wd.setValue(value);
 				}

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ConfigurationDialog.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ConfigurationDialog.java
@@ -983,7 +983,7 @@ public class ConfigurationDialog extends TitleAreaDialog {
 				// ステップから制約範囲内の値に換算
 				int step = valueSlider.getSelection();
 				String value = wd.getCondition().getValueByStep(step, wd,
-						valueSliderText.getText());
+						valueSliderText.getText(), wd.getSliderStep());
 				if (wd.getCondition().validate(value)) {
 					wd.setValue(value);
 				}

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/configurationview/configurationwrapper/ConfigurationCondition.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/configurationview/configurationwrapper/ConfigurationCondition.java
@@ -537,7 +537,7 @@ public class ConfigurationCondition {
 	 * @return 換算した値
 	 */
 	public String getValueByStep(int step, ConfigurationWidget widget,
-			String previousValue) {
+			String previousValue, double stepSize) {
 		if (this.min == null || this.max == null)
 			return "0"; //$NON-NLS-1$
 		if (step < 0) {
@@ -559,7 +559,16 @@ public class ConfigurationCondition {
 			}
 			return Integer.toString((int) dvalue);
 		} else {
-			return Double.toString(new BigDecimal(dvalue).setScale(getDigits(),
+			int digit = getDigits();
+			String strStepSize = Double.valueOf(stepSize).toString();
+			int d_point = strStepSize.indexOf(".");
+			if (d_point != -1) {
+				int digitSS = this.max.length() - d_point - 1;
+				if(digit < digitSS) {
+					digit = digitSS;
+				}
+			}
+			return Double.toString(new BigDecimal(dvalue).setScale(digit,
 					BigDecimal.ROUND_HALF_EVEN).doubleValue());
 		}
 	}

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/configurationview/configurationwrapper/ConfigurationCondition.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/configurationview/configurationwrapper/ConfigurationCondition.java
@@ -537,7 +537,7 @@ public class ConfigurationCondition {
 	 * @return 換算した値
 	 */
 	public String getValueByStep(int step, ConfigurationWidget widget,
-			String previousValue, double stepSize) {
+			String previousValue, String stepSizeStr) {
 		if (this.min == null || this.max == null)
 			return "0"; //$NON-NLS-1$
 		if (step < 0) {
@@ -551,7 +551,7 @@ public class ConfigurationCondition {
 		double dprev = Double.valueOf(previousValue);
 		double dvalue = dmin + (widget.getSliderStep() * step);
 		dvalue = (dvalue > dmax) ? dmax : dvalue;
-		if (isInt()) {
+		if (isInt() && stepSizeStr.indexOf(".") == -1) {
 			if (dvalue > dprev && dvalue < dprev + 1) {
 				dvalue = dprev + 1;
 			} else if (dvalue < dprev && dvalue > dprev - 1) {
@@ -560,10 +560,9 @@ public class ConfigurationCondition {
 			return Integer.toString((int) dvalue);
 		} else {
 			int digit = getDigits();
-			String strStepSize = Double.valueOf(stepSize).toString();
-			int d_point = strStepSize.indexOf(".");
+			int d_point = stepSizeStr.indexOf(".");
 			if (d_point != -1) {
-				int digitSS = this.max.length() - d_point - 1;
+				int digitSS = stepSizeStr.length() - d_point - 1;
 				if(digit < digitSS) {
 					digit = digitSS;
 				}

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/configurationview/configurationwrapper/ConfigurationWidget.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/configurationview/configurationwrapper/ConfigurationWidget.java
@@ -22,6 +22,7 @@ public class ConfigurationWidget {
 	private boolean valueModified = false;
 
 	double sliderStep = 1.0;
+	String sliderStepStr = "";
 	double spinStep = 0.0;
 
 	/**
@@ -136,8 +137,8 @@ public class ConfigurationWidget {
 
 	void setSliderStep(String type) {
 		try {
-			String step = type.substring(SLIDER.length() + 1);
-			sliderStep = Double.parseDouble(step);
+			this.sliderStepStr = type.substring(SLIDER.length() + 1);
+			sliderStep = Double.parseDouble(this.sliderStepStr);
 			if (sliderStep <= 0.0) {
 				sliderStep = 1.0;
 			}
@@ -250,6 +251,10 @@ public class ConfigurationWidget {
 		return this.sliderStep;
 	}
 
+	public String getSliderStepStr() {
+		return this.sliderStepStr;
+	}
+	
 	public int getSpinIncrement() {
 		double step = 1.0;
 		if (hasCondition() && condition.getDigits() > 0) {
@@ -264,6 +269,7 @@ public class ConfigurationWidget {
 		ConfigurationWidget result = new ConfigurationWidget(this.type,
 				(this.condition != null) ? this.condition.clone() : null);
 		result.sliderStep = sliderStep;
+		result.sliderStepStr = sliderStepStr;
 		result.spinStep = spinStep;
 		return result;
 	}

--- a/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/views/configurationview/configurationwrapper/ConfigurationConditionTest.java
+++ b/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/views/configurationview/configurationwrapper/ConfigurationConditionTest.java
@@ -583,39 +583,39 @@ public class ConfigurationConditionTest extends TestCase {
 		// 整数
 		actual = ConfigurationCondition.parseX("-10<x<10");
 		wd = new ConfigurationWidget("slider.1", actual);
-		assertEquals("-1", actual.getValueByStep(9, wd, "0", 1));
-		assertEquals("-10", actual.getValueByStep(-1, wd, "1", 1)); // 範囲外
-		assertEquals("10", actual.getValueByStep(21, wd, "2", 1)); // 範囲外
+		assertEquals("-1", actual.getValueByStep(9, wd, "0", "1"));
+		assertEquals("-10", actual.getValueByStep(-1, wd, "1", "1")); // 範囲外
+		assertEquals("10", actual.getValueByStep(21, wd, "2", "1")); // 範囲外
 		// 小数
 		actual = ConfigurationCondition.parseX("-0.5<x<0.5");
 		wd = new ConfigurationWidget("slider.0.05", actual);
-		assertEquals("-0.3", actual.getValueByStep(4, wd, "3", 0.05));
-		assertEquals("-0.5", actual.getValueByStep(-1, wd, "4", 0.05)); // 範囲外
-		assertEquals("0.5", actual.getValueByStep(21, wd, "5", 0.05)); // 範囲外
+		assertEquals("-0.3", actual.getValueByStep(4, wd, "3", "0.05"));
+		assertEquals("-0.5", actual.getValueByStep(-1, wd, "4", "0.05")); // 範囲外
+		assertEquals("0.5", actual.getValueByStep(21, wd, "5", "0.05")); // 範囲外
 		actual = ConfigurationCondition.parseX("-10.0<x<10.0");
 		wd = new ConfigurationWidget("slider.1", actual);
-		assertEquals("9.0", actual.getValueByStep(19, wd, "6", 1));
+		assertEquals("9.0", actual.getValueByStep(19, wd, "6", "1"));
 	}
 
 	public void testGetValueByStep2() throws Exception {
 		ConfigurationCondition actual = ConfigurationCondition
 				.parseX("0.0<x<10.0");
 		ConfigurationWidget wd = new ConfigurationWidget("slider.0.1", actual);
-		assertEquals("0.0", actual.getValueByStep(0, wd, "7", 0.1));
-		assertEquals("0.1", actual.getValueByStep(1, wd, "8", 0.1));
-		assertEquals("0.2", actual.getValueByStep(2, wd, "9", 0.1));
-		assertEquals("0.3", actual.getValueByStep(3, wd, "10", 0.1));
+		assertEquals("0.0", actual.getValueByStep(0, wd, "7", "0.1"));
+		assertEquals("0.1", actual.getValueByStep(1, wd, "8", "0.1"));
+		assertEquals("0.2", actual.getValueByStep(2, wd, "9", "0.1"));
+		assertEquals("0.3", actual.getValueByStep(3, wd, "10", "0.1"));
 		assertEquals(3, actual.getStepByValue("0.3", wd));
-		assertEquals("0.4", actual.getValueByStep(4, wd, "11", 0.1));
+		assertEquals("0.4", actual.getValueByStep(4, wd, "11", "0.1"));
 		assertEquals(4, actual.getStepByValue("0.4", wd));
-		assertEquals("0.7", actual.getValueByStep(7, wd, "12", 0.1));
+		assertEquals("0.7", actual.getValueByStep(7, wd, "12", "0.1"));
 	}
 
 	public void testGetValueByStep3() throws Exception {
 		ConfigurationCondition actual = ConfigurationCondition.parseX("0<x<10");
 		ConfigurationWidget wd = new ConfigurationWidget("slider.0.1", actual);
-		assertEquals("1", actual.getValueByStep(1, wd, "0", 0.1));
-		assertEquals("0", actual.getValueByStep(9, wd, "1", 0.1));
+		assertEquals("1", actual.getValueByStep(1, wd, "0", "0.1"));
+		assertEquals("0", actual.getValueByStep(9, wd, "1", "0.1"));
 	}
 
 	public void testAdjustMinMaxValue() throws Exception {

--- a/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/views/configurationview/configurationwrapper/ConfigurationConditionTest.java
+++ b/jp.go.aist.rtm.systemeditor/test/jp/go/aist/rtm/systemeditor/ui/views/configurationview/configurationwrapper/ConfigurationConditionTest.java
@@ -583,39 +583,39 @@ public class ConfigurationConditionTest extends TestCase {
 		// 整数
 		actual = ConfigurationCondition.parseX("-10<x<10");
 		wd = new ConfigurationWidget("slider.1", actual);
-		assertEquals("-1", actual.getValueByStep(9, wd, "0"));
-		assertEquals("-10", actual.getValueByStep(-1, wd, "1")); // 範囲外
-		assertEquals("10", actual.getValueByStep(21, wd, "2")); // 範囲外
+		assertEquals("-1", actual.getValueByStep(9, wd, "0", 1));
+		assertEquals("-10", actual.getValueByStep(-1, wd, "1", 1)); // 範囲外
+		assertEquals("10", actual.getValueByStep(21, wd, "2", 1)); // 範囲外
 		// 小数
 		actual = ConfigurationCondition.parseX("-0.5<x<0.5");
 		wd = new ConfigurationWidget("slider.0.05", actual);
-		assertEquals("-0.3", actual.getValueByStep(4, wd, "3"));
-		assertEquals("-0.5", actual.getValueByStep(-1, wd, "4")); // 範囲外
-		assertEquals("0.5", actual.getValueByStep(21, wd, "5")); // 範囲外
+		assertEquals("-0.3", actual.getValueByStep(4, wd, "3", 0.05));
+		assertEquals("-0.5", actual.getValueByStep(-1, wd, "4", 0.05)); // 範囲外
+		assertEquals("0.5", actual.getValueByStep(21, wd, "5", 0.05)); // 範囲外
 		actual = ConfigurationCondition.parseX("-10.0<x<10.0");
 		wd = new ConfigurationWidget("slider.1", actual);
-		assertEquals("9.0", actual.getValueByStep(19, wd, "6"));
+		assertEquals("9.0", actual.getValueByStep(19, wd, "6", 1));
 	}
 
 	public void testGetValueByStep2() throws Exception {
 		ConfigurationCondition actual = ConfigurationCondition
 				.parseX("0.0<x<10.0");
 		ConfigurationWidget wd = new ConfigurationWidget("slider.0.1", actual);
-		assertEquals("0.0", actual.getValueByStep(0, wd, "7"));
-		assertEquals("0.1", actual.getValueByStep(1, wd, "8"));
-		assertEquals("0.2", actual.getValueByStep(2, wd, "9"));
-		assertEquals("0.3", actual.getValueByStep(3, wd, "10"));
+		assertEquals("0.0", actual.getValueByStep(0, wd, "7", 0.1));
+		assertEquals("0.1", actual.getValueByStep(1, wd, "8", 0.1));
+		assertEquals("0.2", actual.getValueByStep(2, wd, "9", 0.1));
+		assertEquals("0.3", actual.getValueByStep(3, wd, "10", 0.1));
 		assertEquals(3, actual.getStepByValue("0.3", wd));
-		assertEquals("0.4", actual.getValueByStep(4, wd, "11"));
+		assertEquals("0.4", actual.getValueByStep(4, wd, "11", 0.1));
 		assertEquals(4, actual.getStepByValue("0.4", wd));
-		assertEquals("0.7", actual.getValueByStep(7, wd, "12"));
+		assertEquals("0.7", actual.getValueByStep(7, wd, "12", 0.1));
 	}
 
 	public void testGetValueByStep3() throws Exception {
 		ConfigurationCondition actual = ConfigurationCondition.parseX("0<x<10");
 		ConfigurationWidget wd = new ConfigurationWidget("slider.0.1", actual);
-		assertEquals("1", actual.getValueByStep(1, wd, "0"));
-		assertEquals("0", actual.getValueByStep(9, wd, "1"));
+		assertEquals("1", actual.getValueByStep(1, wd, "0", 0.1));
+		assertEquals("0", actual.getValueByStep(9, wd, "1", 0.1));
 	}
 
 	public void testAdjustMinMaxValue() throws Exception {


### PR DESCRIPTION
## Identify the Bug

Link to #310

## Description of the Change

Configuration変更ダイアログのスライダーの矢印を操作した際に，｢制約条件｣の上限値，下限値だけでなく，Stepの桁数も使用して表示文字列を判断するように修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests? ユニットテストなし