### PR TITLE
RTC.xmlの保存処理を修正

### DIFF
--- a/jp.go.aist.rtm.toolscommon.profiles/src/org/openrtp/namespaces/rtc/version03/RtcProfile.java
+++ b/jp.go.aist.rtm.toolscommon.profiles/src/org/openrtp/namespaces/rtc/version03/RtcProfile.java
@@ -124,6 +124,9 @@ public class RtcProfile {
      *     
      */
     public ConfigurationSet getConfigurationSet() {
+        if (configurationSet == null) {
+        	configurationSet = new ConfigurationSet();
+        }
         return configurationSet;
     }
 


### PR DESCRIPTION
## Identify the Bug

Link to #315

## Description of the Change

コンフィギュレーションパラメータを追加したRTCをコード生成/保存する際に，RTC.xmlの生成に失敗していたのを修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests? ユニットテストなし