### PR TITLE
subscription typeのデフォルト値ががflushとなるように修正(1.2)

### DIFF
--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
@@ -113,7 +113,7 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 			connectorProfile.setName(outName + "_" + inName);
 		}
 		connectorProfile.setIsReverse(isReverse);
-		
+
 
 		setShellStyle(this.getShellStyle() | SWT.RESIZE);
 		open();
@@ -381,7 +381,7 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 			}
 		});
 		createLabel(portProfileEditComposite, "");
-		
+
 		final Button detailCheck = new Button(portProfileEditComposite,
 				SWT.CHECK);
 		detailCheck.setText(LABEL_DETAIL);
@@ -431,9 +431,9 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 
 		ib = new BufferPackage();
 		createBufferComposite(detailComposite, "Buffer (Inport)", ib);
-		
+
 		additionalTableViewer = createAdditionalTableViewer(detailComposite);
-		
+
 		loadDetailData();
 
 		defaultDialogSize = getShell().getSize();
@@ -648,8 +648,11 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 			types = Arrays.asList(preference.getSubscriptionTypes());
 			isAllowAny = false;
 		}
-		value = loadCombo(subscriptionTypeCombo, types, connectorProfile
-				.getSubscriptionType(), isAllowAny);
+		String defaultVal = connectorProfile.getSubscriptionType();
+		if(defaultVal==null || defaultVal.length()==0) {
+			defaultVal = "flush";
+		}
+		value = loadCombo(subscriptionTypeCombo, types, defaultVal, isAllowAny);
 		connectorProfile.setSubscriptionType(value);
 		//
 		if (!isOffline()) {
@@ -760,7 +763,7 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 
 	/**
 	 * コンボにおいて、「表示候補のリスト」と、「どのような文字列でも設定可能であるかどうか」を引数に取り、初期表示の文字列を決定する
-	 * 
+	 *
 	 * @param candidateList
 	 *            表示候補リスト
 	 * @param isAllowAny


### PR DESCRIPTION
## Identify the Bug

Link to #311

## Description of the Change

データポート間を接続する際に，ConnectorProfileのダイアログの subscription typeのデフォルト値が｢flush｣となるように修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse4.7.3を使用
- [x] No warnings for the build?  Windows上でEclipse4.7.3を使用
- [ ] Have you passed the unit tests? ユニットテストなし