### PR TITLE
｢基本」タブのChoreonoidボタンの位置を修正(1.2)

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/BasicEditorFormPage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/BasicEditorFormPage.java
@@ -269,7 +269,9 @@ public class BasicEditorFormPage extends AbstractEditorFormPage {
 		fsmBtn = createRadioCheckButton(toolkit, compGroup, "FSM", SWT.CHECK);
 		multiModeBtn = createRadioCheckButton(toolkit, compGroup, "MultiMode", SWT.CHECK);
 
-		choreonoidBtn = createRadioCheckButton(toolkit, composite, "Choreonoid", SWT.CHECK);
+		Group dummyGroup = new Group(composite, SWT.SHADOW_NONE);
+		dummyGroup.setLayout(new GridLayout(1, false));
+		choreonoidBtn = createRadioCheckButton(toolkit, dummyGroup, "Choreonoid", SWT.CHECK);
 		//
 		maxInstanceText = createLabelAndText(toolkit, composite, IMessageConstants.BASIC_LBL_MAX_INSTANCES, SWT.NONE, SWT.COLOR_BLACK, 2);
 		executionTypeCombo = createLabelAndCombo(toolkit, composite, IMessageConstants.BASIC_LBL_EXECUTION_TYPE,


### PR DESCRIPTION
## Identify the Bug

Link to #118

## Description of the Change

｢基本｣タブ内のChoreonoidボタンの位置を修正
環境毎の表示位置の差異を吸収するため，他のボタンと同様に，Groupの中に配置するように修正

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse4.7.3を使用
- [x] No warnings for the build?  Windows上でEclipse4.7.3を使用
- [ ] Have you passed the unit tests? ユニットテストなし