### PR TITLE
｢データポート｣の｢Add｣ボタンを選択した際の挙動を修正(1.2)

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/DataPortEditorFormPage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/DataPortEditorFormPage.java
@@ -292,12 +292,14 @@ public class DataPortEditorFormPage extends AbstractEditorFormPage {
 			@SuppressWarnings("unchecked")
 			@Override
 			public void widgetSelected(SelectionEvent e) {
+				String selected = typeCombo.getText();
 				updateDefaultValue();
 				DataPortParam selectParam = new DataPortParam(defaultPortName, defaultPortType, defaultPortVarName, initSel);
 				((List) portParamTableViewer.getInput()).add(selectParam);
 				portParamTableViewer.refresh();
 				update();
 				portParamTableViewer.setSelection(new StructuredSelection(selectParam), true);
+				typeCombo.setText(selected);
 			}
 		});
 		gd = new GridData(GridData.FILL_HORIZONTAL);


### PR DESCRIPTION
## Identify the Bug

Link to #140

## Description of the Change

｢データポート｣タブ内の｢Add｣ボタンをクリックした際に，直前に設定されていた｢データ型｣をデフォルトで設定するように修正しました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse4.7.3を使用
- [x] No warnings for the build?  Windows上でEclipse4.7.3を使用
- [ ] Have you passed the unit tests? ユニットテストなし