### PR TITLE
｢コンフィグレーション｣タブの｢Add｣ボタンを選択した際の挙動を修正(1.2)

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/ConfigurationEditorFormPage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/ConfigurationEditorFormPage.java
@@ -304,6 +304,7 @@ public class ConfigurationEditorFormPage extends AbstractEditorFormPage {
 			@SuppressWarnings("unchecked")
 			@Override
 			public void widgetSelected(SelectionEvent e) {
+				String selected = typeCombo.getText();
 				updateDefaultValue();
 				String confNum = Integer.valueOf(((List) configSetTableViewer.getInput()).size()).toString();
 				ConfigSetParam selectParam = new ConfigSetParam(defaultConfigName + confNum, defaultConfigType, defaultConfigVarName, defaultConfigDefault, defaultConfigConstraint, defaultConfigUnit);
@@ -311,6 +312,7 @@ public class ConfigurationEditorFormPage extends AbstractEditorFormPage {
 				configSetTableViewer.refresh();
 				update();
 				configSetTableViewer.setSelection(new StructuredSelection(selectParam), true);
+				typeCombo.setText(selected);
 			}
 		});
 		GridData gd = new GridData(GridData.FILL_HORIZONTAL);


### PR DESCRIPTION
## Identify the Bug

Link to #142

## Description of the Change

｢コンフィギュレーション｣タブ内の｢Add｣ボタンをクリックした際に，直前に設定されていた｢データ型｣をデフォルトで設定するように修正しました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse4.7.3を使用
- [x] No warnings for the build?  Windows上でEclipse4.7.3を使用
- [ ] Have you passed the unit tests? ユニットテストなし