### PR TITLE
IDLファイルのパースに失敗した場合に，詳細情報を表示するように修正(1.2)

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/generator/IDLParamConverter.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/generator/IDLParamConverter.java
@@ -239,7 +239,7 @@ public class IDLParamConverter {
 		return builder.toString();
 	}
 
-	public static boolean extractTypeDef(List<DataTypeParam> sources, List<String> result) {
+	public static boolean extractTypeDef(List<DataTypeParam> sources, List<String> result, StringBuilder builder) {
 		boolean ret = true;
 		for( Iterator<DataTypeParam> iter = sources.iterator(); iter.hasNext(); ) {
 			DataTypeParam targetParam = iter.next();
@@ -250,6 +250,8 @@ public class IDLParamConverter {
 			try {
 				spec = parser.specification();
 			} catch (ParseException e) {
+				builder.append("Target File : ").append(targetParam.getDispPath()).append(System.lineSeparator());
+				builder.append(e.getMessage()).append(System.lineSeparator());
 				ret = false;
 				continue;
 			}

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/AbstractEditorFormPage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/AbstractEditorFormPage.java
@@ -467,8 +467,10 @@ public abstract class AbstractEditorFormPage extends FormPage {
 		}
 		String[] defaultTypeList = new String[0];
 		List<String> dataTypes = new ArrayList<String>();
-		if( IDLParamConverter.extractTypeDef(sourceContents, dataTypes)==false ) {
-			MessageDialog.openWarning(RtcBuilderPlugin.getDefault().getWorkbench().getActiveWorkbenchWindow().getShell(), "IDL Parse", IMessageConstants.IDL_PARSE_EROOR);
+		StringBuilder builder = new StringBuilder();
+		if( IDLParamConverter.extractTypeDef(sourceContents, dataTypes, builder)==false ) {
+			MessageDialog.openWarning(RtcBuilderPlugin.getDefault().getWorkbench().getActiveWorkbenchWindow().getShell(),
+					"IDL Parse", IMessageConstants.IDL_PARSE_EROOR + System.lineSeparator() + builder.toString());
 		}
 		defaultTypeList = new String[dataTypes.size()];
 		defaultTypeList = dataTypes.toArray(defaultTypeList);

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/DataPortEditorFormPage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/DataPortEditorFormPage.java
@@ -108,7 +108,11 @@ public class DataPortEditorFormPage extends AbstractEditorFormPage {
 		super(editor, "id", Messages.getString("IMessageConstants.DATAPORT_SECTION"));
 		//
 		preSelection = null;
-		updateDefaultValue();
+
+		IPreferenceStore store = RtcBuilderPlugin.getDefault().getPreferenceStore();
+		defaultPortName = ComponentPreferenceManager.getInstance().getDataPort_Name();
+		defaultPortType = store.getString(ComponentPreferenceManager.Generate_DataPort_Type);
+		defaultPortVarName = store.getString(ComponentPreferenceManager.Generate_DataPort_VarName);
 	}
 
 	public void updateDefaultValue() {

--- a/jp.go.aist.rtm.rtcbuilder/test/jp/go/aist/rtm/rtcbuilder/_test/parse/CORBAParseTest.java
+++ b/jp.go.aist.rtm.rtcbuilder/test/jp/go/aist/rtm/rtcbuilder/_test/parse/CORBAParseTest.java
@@ -15,32 +15,34 @@ public class CORBAParseTest extends TestBase {
 		List<String> dataTypes = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\DupliDataTypes1.idl"));
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\DupliDataTypes2.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-			
+
 		try {
-			IDLParamConverter.extractTypeDef(sourceContents, dataTypes);
+			StringBuilder builder = new StringBuilder();
+			IDLParamConverter.extractTypeDef(sourceContents, dataTypes, builder);
 		} catch (Exception e) {
 			fail();
 		}
 	}
-	
+
 	public void testMulti() throws Exception{
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\MyData.idl"));
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\Basic5DataTypes.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-			
-		IDLParamConverter.extractTypeDef(sourceContents, results);
-		
+
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
+
 		assertEquals(7, results.size());
 		assertTrue(results.contains("RTC::MyData"));
 		assertTrue(results.contains("RTC::TimedMyData"));
@@ -50,51 +52,54 @@ public class CORBAParseTest extends TestBase {
 		assertTrue(results.contains("RTC::TimedShortSeq"));
 		assertTrue(results.contains("RTC::TimedStringSeq"));
 	}
-	
+
 	public void testMyData() throws Exception{
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\MyData.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-			
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(2, results.size());
 		assertTrue(results.contains("RTC::MyData"));
 		assertTrue(results.contains("RTC::TimedMyData"));
 	}
-	
+
 	public void testMyServiceTypeDef() throws Exception{
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\MyServiceTypeDef.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(2, results.size());
 		assertTrue(results.contains("Time"));
 		assertTrue(results.contains("TimedState"));
 	}
-	
+
 	public void testNoModule5Basics() throws Exception{
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\NoModule5DataTypes.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(5, results.size());
 		assertTrue(results.contains("Time"));
@@ -108,25 +113,27 @@ public class CORBAParseTest extends TestBase {
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\MyService.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 		assertEquals(0, results.size());
 	}
-	
+
 	public void test5Basics() throws Exception{
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\Basic5DataTypes.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(5, results.size());
 		assertTrue(results.contains("RTC::Time"));
@@ -140,12 +147,13 @@ public class CORBAParseTest extends TestBase {
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\BasicDataTypeOrg.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(22, results.size());
 		assertTrue(results.contains("RTC::Time"));
@@ -176,12 +184,13 @@ public class CORBAParseTest extends TestBase {
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\BasicDataType.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(22, results.size());
 		assertTrue(results.contains("RTC::Time"));
@@ -207,38 +216,40 @@ public class CORBAParseTest extends TestBase {
 		assertTrue(results.contains("RTC::TimedOctetSeq"));
 		assertTrue(results.contains("RTC::TimedStringSeq"));
 	}
-	
+
 	public void testBasic() throws Exception{
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\Basic.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(1, results.size());
 		assertTrue(results.contains("RTC::Time"));
 	}
-	
+
 	public void testError() throws Exception{
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\Error.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
 		try {
-			IDLParamConverter.extractTypeDef(sourceContents, results);
+			StringBuilder builder = new StringBuilder();
+			IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 		} catch (Exception ex) {
 			System.out.println("Error");
 			fail();
-			
+
 		}
 	}
-	
+
 }

--- a/jp.go.aist.rtm.rtcbuilder/test/jp/go/aist/rtm/rtcbuilder/_test/parse/CORBAParseTypeTest.java
+++ b/jp.go.aist.rtm.rtcbuilder/test/jp/go/aist/rtm/rtcbuilder/_test/parse/CORBAParseTypeTest.java
@@ -14,28 +14,30 @@ public class CORBAParseTypeTest extends TestBase {
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\Modules.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(1, results.size());
 		assertTrue(results.contains("AAA::BBB::CCC::TimeBBB"));
 	}
-	
+
 	public void testException() throws Exception{
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\SDOPackage.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
-		
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
+
 		assertEquals(9, results.size());
 		assertTrue(results.contains("SDOPackage::NameValue"));
 		assertTrue(results.contains("SDOPackage::EnumerationType"));
@@ -47,71 +49,75 @@ public class CORBAParseTypeTest extends TestBase {
 		assertTrue(results.contains("SDOPackage::ServiceProfile"));
 		assertTrue(results.contains("SDOPackage::ConfigurationSet"));
 	}
-	
+
 	public void testInclude() throws Exception{
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\Manager.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-			
-		IDLParamConverter.extractTypeDef(sourceContents, results);
-		
+
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
+
 		assertEquals(2, results.size());
 		assertTrue(results.contains("RTM::ModuleProfile"));
 		assertTrue(results.contains("RTM::ManagerProfile"));
 	}
-	
+
 	public void testDuplicate2() throws Exception{
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\Basic.idl"));
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\BasicNonMod.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
-		
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
+
 		assertEquals(2, results.size());
 		assertTrue(results.contains("RTC::Time"));
 		assertTrue(results.contains("Time"));
 	}
-	
+
 	public void testDuplicate() throws Exception{
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\DupliDataTypes1.idl"));
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\DupliDataTypes2.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-			
+
 		try {
-			IDLParamConverter.extractTypeDef(sourceContents, results);
+			StringBuilder builder = new StringBuilder();
+			IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 		} catch (Exception e) {
 			fail();
 		}
 	}
-	
+
 	public void testMulti() throws Exception{
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\MyData.idl"));
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\Basic5DataTypes.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
-		
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
+
 		assertEquals(7, results.size());
 		assertTrue(results.contains("RTC::MyData"));
 		assertTrue(results.contains("RTC::TimedMyData"));
@@ -121,49 +127,52 @@ public class CORBAParseTypeTest extends TestBase {
 		assertTrue(results.contains("RTC::TimedShortSeq"));
 		assertTrue(results.contains("RTC::TimedStringSeq"));
 	}
-	
+
 	public void testMyData() throws Exception{
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\MyData.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(2, results.size());
 		assertTrue(results.contains("RTC::MyData"));
 		assertTrue(results.contains("RTC::TimedMyData"));
 	}
-	
+
 	public void testMyServiceTypeDef() throws Exception{
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\MyServiceTypeDef.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(2, results.size());
 		assertTrue(results.contains("Time"));
 		assertTrue(results.contains("TimedState"));
 	}
-	
+
 	public void testNoModule5Basics() throws Exception{
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\NoModule5DataTypes.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(5, results.size());
 		assertTrue(results.contains("Time"));
@@ -177,25 +186,27 @@ public class CORBAParseTypeTest extends TestBase {
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\MyService.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 		assertEquals(0, results.size());
 	}
-	
+
 	public void test5Basics() throws Exception{
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\Basic5DataTypes.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(5, results.size());
 		assertTrue(results.contains("RTC::Time"));
@@ -209,12 +220,13 @@ public class CORBAParseTypeTest extends TestBase {
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\BasicDataTypeOrg.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(22, results.size());
 		assertTrue(results.contains("RTC::Time"));
@@ -245,12 +257,13 @@ public class CORBAParseTypeTest extends TestBase {
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\BasicDataType.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(22, results.size());
 		assertTrue(results.contains("RTC::Time"));
@@ -276,37 +289,39 @@ public class CORBAParseTypeTest extends TestBase {
 		assertTrue(results.contains("RTC::TimedOctetSeq"));
 		assertTrue(results.contains("RTC::TimedStringSeq"));
 	}
-	
+
 	public void testBasic() throws Exception{
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\Basic.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
-		IDLParamConverter.extractTypeDef(sourceContents, results);
+		StringBuilder builder = new StringBuilder();
+		IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 
 		assertEquals(1, results.size());
 		assertTrue(results.contains("RTC::Time"));
 	}
-	
+
 	public void testError() throws Exception{
 		List<DataTypeParam> sourceContents = new ArrayList<DataTypeParam>();
 		List<String> results = new ArrayList<String>();
 		sourceContents.add(new DataTypeParam(rootPath + "\\resource\\IDL\\Error.idl"));
-		
+
 		for(int intidx=0;intidx<sourceContents.size();intidx++) {
 			String idlContent = FileUtil.readFile(sourceContents.get(intidx).getFullPath());
 			sourceContents.get(intidx).setContent(idlContent);
 		}
 		try {
-			IDLParamConverter.extractTypeDef(sourceContents, results);
+			StringBuilder builder = new StringBuilder();
+			IDLParamConverter.extractTypeDef(sourceContents, results, builder);
 		} catch (Exception ex) {
 			fail();
 			System.out.println("Error");
 		}
 	}
-	
+
 }


### PR DESCRIPTION
## Identify the Bug

Link to #253

## Description of the Change

IDLファイルの不備などで，パースに失敗した場合に，以下の詳細情報を表示するように修正しました．
- 対象ファイル名
- パースに失敗した箇所

また，RTCBuilder起動時にIDLファイルのパースに失敗すると，メッセージが複数回表示されていたので，１回だけ表示するように修正しました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse4.7.3を使用
- [x] No warnings for the build?  Windows上でEclipse4.7.3を使用
- [ ] Have you passed the unit tests? ユニットテストなし