### PR TITLE
ツールバー上のボタンの表示位置などを修正

### DIFF
--- a/jp.go.aist.rtm.systemeditor/plugin.xml
+++ b/jp.go.aist.rtm.systemeditor/plugin.xml
@@ -748,7 +748,7 @@
 		point="org.eclipse.ui.menus">
 		<menuContribution
 			allPopups="false"
-			locationURI="toolbar:org.eclipse.ui.main.toolbar?after=additions">
+			locationURI="toolbar:org.eclipse.ui.main.toolbar?after=jp.go.aist.rtm.systemeditor.ui.actionSet">
 			<toolbar
 				id="rtse.menus.toolbar.ec"
 				label="EC">

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/managercontrolview/ManagerControlView.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/views/managercontrolview/ManagerControlView.java
@@ -129,7 +129,7 @@ public class ManagerControlView extends ViewPart {
 		});
 		//
 		this.loadableModuleButton = new Button(menuButtonComposite, SWT.TOP);
-		this.loadableModuleButton.setText("Loadable Modules");
+		this.loadableModuleButton.setText("Loadable Mod.");
 		gd = new GridData();
 		gd.widthHint = MENU_BUTTON_WIDTH;
 		this.loadableModuleButton.setLayoutData(gd);
@@ -147,7 +147,7 @@ public class ManagerControlView extends ViewPart {
 		});
 		//
 		this.loadedeModuleButton = new Button(menuButtonComposite, SWT.TOP);
-		this.loadedeModuleButton.setText("Loaded Modules");
+		this.loadedeModuleButton.setText("Loaded Mod.");
 		gd = new GridData();
 		gd.widthHint = MENU_BUTTON_WIDTH;
 		this.loadedeModuleButton.setLayoutData(gd);


### PR DESCRIPTION
## Identify the Bug

Link to #334

## Description of the Change

ManagerView内のボタン名称を変更させて頂きました．
また，#88で修正していたツールバー上のボタンの位置指定を一旦戻させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests? ユニットテストなし