### PR TITLE
RCP版RESTのスプラッシュウインドウの設定を修正

### DIFF
--- a/jp.go.aist.rtm.systemeditor.RCP/build.properties
+++ b/jp.go.aist.rtm.systemeditor.RCP/build.properties
@@ -3,4 +3,5 @@ output.. = bin/
 bin.includes = plugin.xml,\
                META-INF/,\
                .,\
-               icons/
+               icons/,\
+               splash.bmp


### PR DESCRIPTION
## Identify the Bug

Link to #337

## Description of the Change

jp.go.aist.rtm.systemeditor.RCPのJARファイルにsplash.bmpを含むようにbuild.propertiesの設定を修正させて頂きました．


## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests? ユニットテストなし