### PR TITLE
IPアドレスが変更された場合に警告を表示

### DIFF
--- a/jp.go.aist.rtm.toolscommon.nl1/src/jp/go/aist/rtm/toolscommon/nl/messages_ja.properties
+++ b/jp.go.aist.rtm.toolscommon.nl1/src/jp/go/aist/rtm/toolscommon/nl/messages_ja.properties
@@ -58,4 +58,5 @@ RTCManagerWrapper.disp.loadable_modules=Loadable Modules
 RTCManagerWrapper.disp.loaded_modules=Loaded Modules
 
 IPCaution.title=\u8b66\u544a
-IPCaution.message=IP\u30a2\u30c9\u30ec\u30b9\u304c\u5909\u66f4\u3055\u308c\u307e\u3057\u305f
+IPCaution.message01=IP\u30a2\u30c9\u30ec\u30b9\u304c\u5909\u66f4\u3055\u308c\u307e\u3057\u305f
+IPCaution.message02=OpenRTP\u3001\u30cd\u30fc\u30e0\u30b5\u30fc\u30d0\u30fc\u3001RTC\u306e\u518d\u8d77\u52d5\u304c\u5fc5\u8981\u306a\u5834\u5408\u304c\u3042\u308a\u307e\u3059\u3002

--- a/jp.go.aist.rtm.toolscommon.nl1/src/jp/go/aist/rtm/toolscommon/nl/messages_ja.properties
+++ b/jp.go.aist.rtm.toolscommon.nl1/src/jp/go/aist/rtm/toolscommon/nl/messages_ja.properties
@@ -56,3 +56,6 @@ SystemDiagramPropertySource.disp.composite=Composite
 RTCManagerWrapper.disp.components=Components
 RTCManagerWrapper.disp.loadable_modules=Loadable Modules
 RTCManagerWrapper.disp.loaded_modules=Loaded Modules
+
+IPCaution.title=\u8b66\u544a
+IPCaution.message=IP\u30a2\u30c9\u30ec\u30b9\u304c\u5909\u66f4\u3055\u308c\u307e\u3057\u305f

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/SystemDiagramImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/SystemDiagramImpl.java
@@ -857,7 +857,8 @@ public class SystemDiagramImpl extends ModelElementImpl implements SystemDiagram
 							    public void run() {
 						            MessageDialog.openError(shell,
 						            		Messages.getString("IPCaution.title"),
-						            		Messages.getString("IPCaution.message") + " (" + oldAddress + " -> " + currentIP + ")");
+						            		Messages.getString("IPCaution.message01") + " (" + oldAddress + " -> " + currentIP + ")" + System.lineSeparator()
+						            		+ Messages.getString("IPCaution.message02"));
 							    }
 							});
 						}

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/SystemDiagramImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/SystemDiagramImpl.java
@@ -8,28 +8,14 @@ package jp.go.aist.rtm.toolscommon.model.component.impl;
 
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-
-import jp.go.aist.rtm.toolscommon.manager.ToolsCommonPreferenceManager;
-import jp.go.aist.rtm.toolscommon.model.component.Component;
-import jp.go.aist.rtm.toolscommon.model.component.ComponentPackage;
-import jp.go.aist.rtm.toolscommon.model.component.IPropertyMap;
-import jp.go.aist.rtm.toolscommon.model.component.CorbaStatusObserver;
-import jp.go.aist.rtm.toolscommon.model.component.PortConnector;
-import jp.go.aist.rtm.toolscommon.model.component.SystemDiagram;
-import jp.go.aist.rtm.toolscommon.model.component.SystemDiagramKind;
-import jp.go.aist.rtm.toolscommon.model.component.util.CorbaObserverHandler;
-import jp.go.aist.rtm.toolscommon.model.component.util.PropertyMap;
-import jp.go.aist.rtm.toolscommon.model.core.Point;
-import jp.go.aist.rtm.toolscommon.model.core.impl.ModelElementImpl;
-import jp.go.aist.rtm.toolscommon.synchronizationframework.RefreshThread;
-import jp.go.aist.rtm.toolscommon.synchronizationframework.SynchronizationSupport;
-import jp.go.aist.rtm.toolscommon.ui.propertysource.SystemDiagramPropertySource;
 
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;
@@ -39,10 +25,30 @@ import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.util.EObjectContainmentEList;
 import org.eclipse.emf.ecore.util.InternalEList;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.views.properties.IPropertySource;
 import org.openrtp.namespaces.rts.version02.RtsProfileExt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jp.go.aist.rtm.toolscommon.manager.ToolsCommonPreferenceManager;
+import jp.go.aist.rtm.toolscommon.model.component.Component;
+import jp.go.aist.rtm.toolscommon.model.component.ComponentPackage;
+import jp.go.aist.rtm.toolscommon.model.component.CorbaStatusObserver;
+import jp.go.aist.rtm.toolscommon.model.component.IPropertyMap;
+import jp.go.aist.rtm.toolscommon.model.component.PortConnector;
+import jp.go.aist.rtm.toolscommon.model.component.SystemDiagram;
+import jp.go.aist.rtm.toolscommon.model.component.SystemDiagramKind;
+import jp.go.aist.rtm.toolscommon.model.component.util.CorbaObserverHandler;
+import jp.go.aist.rtm.toolscommon.model.component.util.PropertyMap;
+import jp.go.aist.rtm.toolscommon.model.core.Point;
+import jp.go.aist.rtm.toolscommon.model.core.impl.ModelElementImpl;
+import jp.go.aist.rtm.toolscommon.nl.Messages;
+import jp.go.aist.rtm.toolscommon.synchronizationframework.RefreshThread;
+import jp.go.aist.rtm.toolscommon.synchronizationframework.SynchronizationSupport;
+import jp.go.aist.rtm.toolscommon.ui.propertysource.SystemDiagramPropertySource;
 
 /**
  * <!-- begin-user-doc --> An implementation of the model object '<em><b>System Diagram</b></em>'.
@@ -98,6 +104,8 @@ public class SystemDiagramImpl extends ModelElementImpl implements SystemDiagram
 	protected SystemDiagramKind kind = KIND_EDEFAULT;
 
 	protected IPropertyMap properties;
+	
+	private String currentIP = null;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -834,6 +842,31 @@ public class SystemDiagramImpl extends ModelElementImpl implements SystemDiagram
 
 	void synchronizeRemote() {
 		if (getParentSystemDiagram() == null) {
+			try {
+				InetAddress addr = InetAddress.getLocalHost();
+				String address = addr.getHostAddress();
+				if(currentIP==null) {
+					currentIP = address;
+				} else {
+					if(currentIP.equals(address)==false) {
+						String oldAddress = currentIP;
+						currentIP = address;
+						if( 0 < PlatformUI.getWorkbench().getWorkbenchWindowCount() ) {
+							Shell shell = PlatformUI.getWorkbench().getWorkbenchWindows()[0].getShell();
+							shell.getDisplay().asyncExec(new Runnable() {
+							    public void run() {
+						            MessageDialog.openError(shell,
+						            		Messages.getString("IPCaution.title"),
+						            		Messages.getString("IPCaution.message") + " (" + oldAddress + " -> " + currentIP + ")");
+							    }
+							});
+						}
+					}
+				}
+			} catch (UnknownHostException e) {
+				e.printStackTrace();
+			}
+			
 			for (Component component : getUnmodifiedComponents()) {
 				if (component instanceof CorbaComponentImpl) {
 					CorbaComponentImpl corbaComp = (CorbaComponentImpl) component;

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/nl/messages.properties
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/nl/messages.properties
@@ -58,4 +58,5 @@ RTCManagerWrapper.disp.loadable_modules=Loadable Modules
 RTCManagerWrapper.disp.loaded_modules=Loaded Modules
 
 IPCaution.title=Warning
-IPCaution.message=IP address changed.
+IPCaution.message01=IP address changed.
+IPCaution.message02=You may need to restart OpenRTP, name server, and RTC.

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/nl/messages.properties
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/nl/messages.properties
@@ -56,3 +56,6 @@ SystemDiagramPropertySource.disp.composite=Composite
 RTCManagerWrapper.disp.components=Components
 RTCManagerWrapper.disp.loadable_modules=Loadable Modules
 RTCManagerWrapper.disp.loaded_modules=Loaded Modules
+
+IPCaution.title=Warning
+IPCaution.message=IP address changed.


### PR DESCRIPTION
## Identify the Bug

Link to #252

## Description of the Change

RESTのIPアドレスが変更された場合に，警告を表示するように修正させて頂きました．

コントロールパネルからネットワークアダプタのプロパティを手動で更新して動作確認を行ったのですが，こちらの環境(VMWareがインストールされている環境)では，
　元IPアドレス→VMWare用のIPアドレス→設定した新IPアドレス
という流れでIPアドレスが更新されてしまい，警告が２回表示されてしまいます．
なお，自IPアドレスの取得は，InetAddress.getLocalHost().getHostAddress()を使用しております．

まずはこの形で良いのか？をご確認頂ければ幸いです．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests? ユニットテストなし