### PR TITLE
IPアドレスが変更された場合に警告を表示(1.2)

### DIFF
--- a/jp.go.aist.rtm.toolscommon.nl1/src/jp/go/aist/rtm/toolscommon/nl/messages_ja.properties
+++ b/jp.go.aist.rtm.toolscommon.nl1/src/jp/go/aist/rtm/toolscommon/nl/messages_ja.properties
@@ -58,4 +58,5 @@ RTCManagerWrapper.disp.loadable_modules=Loadable Modules
 RTCManagerWrapper.disp.loaded_modules=Loaded Modules
 
 IPCaution.title=\u8b66\u544a
-IPCaution.message=IP\u30a2\u30c9\u30ec\u30b9\u304c\u5909\u66f4\u3055\u308c\u307e\u3057\u305f
+IPCaution.message01=IP\u30a2\u30c9\u30ec\u30b9\u304c\u5909\u66f4\u3055\u308c\u307e\u3057\u305f
+IPCaution.message02=OpenRTP\u3001\u30cd\u30fc\u30e0\u30b5\u30fc\u30d0\u30fc\u3001RTC\u306e\u518d\u8d77\u52d5\u304c\u5fc5\u8981\u306a\u5834\u5408\u304c\u3042\u308a\u307e\u3059\u3002

--- a/jp.go.aist.rtm.toolscommon.nl1/src/jp/go/aist/rtm/toolscommon/nl/messages_ja.properties
+++ b/jp.go.aist.rtm.toolscommon.nl1/src/jp/go/aist/rtm/toolscommon/nl/messages_ja.properties
@@ -56,3 +56,6 @@ SystemDiagramPropertySource.disp.composite=Composite
 RTCManagerWrapper.disp.components=Components
 RTCManagerWrapper.disp.loadable_modules=Loadable Modules
 RTCManagerWrapper.disp.loaded_modules=Loaded Modules
+
+IPCaution.title=\u8b66\u544a
+IPCaution.message=IP\u30a2\u30c9\u30ec\u30b9\u304c\u5909\u66f4\u3055\u308c\u307e\u3057\u305f

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/SystemDiagramImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/SystemDiagramImpl.java
@@ -899,8 +899,8 @@ public class SystemDiagramImpl extends ModelElementImpl implements
 							    public void run() {
 						            MessageDialog.openError(shell,
 						            		Messages.getString("IPCaution.title"),
-						            		Messages.getString("IPCaution.message") + " (" + oldAddress + " -> " + currentIP + ")");
-							    }
+						            		Messages.getString("IPCaution.message01") + " (" + oldAddress + " -> " + currentIP + ")" + System.lineSeparator()
+						            		+ Messages.getString("IPCaution.message02"));							    }
 							});
 						}
 					}

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/nl/messages.properties
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/nl/messages.properties
@@ -56,3 +56,6 @@ SystemDiagramPropertySource.disp.composite=Composite
 RTCManagerWrapper.disp.components=Components
 RTCManagerWrapper.disp.loadable_modules=Loadable Modules
 RTCManagerWrapper.disp.loaded_modules=Loaded Modules
+
+IPCaution.title=Warning
+IPCaution.message=IP address changed.

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/nl/messages.properties
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/nl/messages.properties
@@ -58,4 +58,6 @@ RTCManagerWrapper.disp.loadable_modules=Loadable Modules
 RTCManagerWrapper.disp.loaded_modules=Loaded Modules
 
 IPCaution.title=Warning
-IPCaution.message=IP address changed.
+IPCaution.message01=IP address changed.
+IPCaution.message02=You may need to restart OpenRTP, name server, and RTC.
+


### PR DESCRIPTION
## Identify the Bug

Link to #252

## Description of the Change

RTSEのIPアドレスが変更された場合に，警告を表示するように修正させて頂きました．
なお，自IPアドレスの取得は，InetAddress.getLocalHost().getHostAddress()を使用しております．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse4.7.3を使用
- [x] No warnings for the build?  Windows上でEclipse4.7.3を使用
- [ ] Have you passed the unit tests? ユニットテストなし