### PR TITLE
OutPortEditPart.javaで型を間違えている箇所があったため修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editpart/OutPortEditPart.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editpart/OutPortEditPart.java
@@ -43,7 +43,7 @@ public class OutPortEditPart extends PortEditPartBase {
 	 * {@inheritDoc}
 	 */
 	protected void refreshVisuals() {
-		OutPortFigure outport = (OutPortFigure)getFigure();
+		OutPortBaseFigure outport = (OutPortBaseFigure)getFigure();
 		originalChildren = outport.getParent().getChildren();
 		super.refreshVisuals();
 	}


### PR DESCRIPTION
1.2.2に関わる修正のため早急にレビューをお願いします・

## Identify the Bug

1.2.2のRTシステムエディタ実行時に以下のエラーが発生する。

![image](https://user-images.githubusercontent.com/6216077/91270752-1cb56180-e7b4-11ea-8d1f-53409a743f70.png)


## Description of the Change

OutPortEditPart.javaでOutPortBaseFigureとする箇所でOutPortFigureとなっていたため修正した。

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse4.7.3を使用
- [x] No warnings for the build?  Windows上でEclipse4.7.3を使用
- [ ] Have you passed the unit tests? 