### PR TITLE
コード生成時のデータ型比較方法を修正(1.2)

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/DataPortEditorFormPage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/DataPortEditorFormPage.java
@@ -214,6 +214,7 @@ public class DataPortEditorFormPage extends AbstractEditorFormPage {
 					}
 				}
 				Collections.sort(currentList, new DataParamComparator());
+				typeCombo.removeAll();
 				for(DataParam item : currentList) {
 					typeCombo.add(item.typeName);
 				}
@@ -522,7 +523,7 @@ public class DataPortEditorFormPage extends AbstractEditorFormPage {
 		}
 		checkVarSet.add(dataport.getTmplVarName());
 		//型存在チェック
-		if(Arrays.asList(defaultTypeList).contains(dataport.getType())==false) {
+		if(Arrays.asList(defaultTypeList).contains(dataport.getType().trim())==false) {
 			return IMessageConstants.DATAPORT_VALIDATE_PORTTYPE_INVALID;
 		}
 		return null;


### PR DESCRIPTION
## Identify the Bug

Link to #355

## Description of the Change

RTCBのコード生成時に，データ型の比較を行う際に，余計な空白を削除して比較を実行するように修正させて頂きました．
また，データ型のフィルタリング機能が上手く動いていなかったため，修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse4.7.3を使用
- [x] No warnings for the build?  Windows上でEclipse4.7.3を使用
- [ ] Have you passed the unit tests? ユニットテストなし