### PR TITLE
IDLパース時に#pragmaから始まる行を無視するように修正(1.2)

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/DataPortEditorFormPage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/DataPortEditorFormPage.java
@@ -105,6 +105,8 @@ public class DataPortEditorFormPage extends AbstractEditorFormPage {
 		defaultPortName = ComponentPreferenceManager.getInstance().getDataPort_Name();
 		defaultPortType = store.getString(ComponentPreferenceManager.Generate_DataPort_Type);
 		defaultPortVarName = store.getString(ComponentPreferenceManager.Generate_DataPort_VarName);
+		
+		defaultTypeList = super.extractDataTypes();
 	}
 
 	public void updateDefaultValue() {


### PR DESCRIPTION
## Identify the Bug

Link to #354

## Description of the Change

IDLファイルの内容をパースする際に，#pragmaで始まる行を無視するように修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse4.7.3を使用
- [x] No warnings for the build?  Windows上でEclipse4.7.3を使用
- [ ] Have you passed the unit tests? ユニットテストなし