### PR TITLE
[RTSE]/usr/bin/rtm-naming以外のNS起動コマンドを使えるように修正

### DIFF
--- a/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/ui/action/StartNameServiceAction.java
+++ b/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/ui/action/StartNameServiceAction.java
@@ -23,11 +23,21 @@ public class StartNameServiceAction implements IViewActionDelegate {
 	private static String SCRIPT_WINDOWS = System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "rtm-naming.bat";
 	private static String SCRIPT_WINDOWS_STOP = System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "kill-rtm-naming.bat";
 
-	private static String SCRIPT_LINUX = "/usr/bin/rtm-naming";
-
+	private static String SCRIPT_UNIX = "/usr/bin/rtm-naming";
+	private String[] UNIX_CANDIDATE_LIST = {"/usr/bin/rtm-naming",
+											"/usr/local/bin/rtm-naming",
+											System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "rtm-naming"};
 
 	public void init(IViewPart view) {
 		this.view = (NameServiceView) view;
+		// find rtm-naming
+		for(String each :  UNIX_CANDIDATE_LIST) {
+			File targetFile = new File(each);
+			if(targetFile.exists() == true) {
+				SCRIPT_UNIX = each;
+				break;
+			}
+		}
 	}
 
 	public void run(IAction action) {
@@ -48,7 +58,7 @@ public class StartNameServiceAction implements IViewActionDelegate {
 				if(passwdDialog.open()!=Dialog.OK) return;
 
 				passWord = passwdDialog.getPassWord();
-				pb = new ProcessBuilder(SCRIPT_LINUX, "-k", "-f", "-w " + passWord);
+				pb = new ProcessBuilder(SCRIPT_UNIX, "-k", "-f", "-w " + passWord);
 			}
 			try {
 				pb.start();
@@ -70,7 +80,7 @@ public class StartNameServiceAction implements IViewActionDelegate {
 				pb = new ProcessBuilder(SCRIPT_WINDOWS);
 
 			} else {
-				pb = new ProcessBuilder(SCRIPT_LINUX, "-f", "-w " + passWord);
+				pb = new ProcessBuilder(SCRIPT_UNIX, "-f", "-w " + passWord);
 			}
 			try {
 				pb.start();
@@ -115,7 +125,7 @@ public class StartNameServiceAction implements IViewActionDelegate {
 			}
 
 		} else {
-			File targetFile = new File(SCRIPT_LINUX);
+			File targetFile = new File(SCRIPT_UNIX);
 			if(targetFile.exists()==false) {
 				action.setEnabled(false);
 			}

--- a/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/ui/action/StopNameServiceAction.java
+++ b/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/ui/action/StopNameServiceAction.java
@@ -1,28 +1,23 @@
 package jp.go.aist.rtm.nameserviceview.ui.action;
 
 import java.io.File;
-import java.io.IOException;
 
-import jp.go.aist.rtm.nameserviceview.model.manager.NameServerManager;
-import jp.go.aist.rtm.nameserviceview.ui.dialog.PasswordDialog;
-import jp.go.aist.rtm.nameserviceview.ui.views.nameserviceview.NameServiceView;
-
-import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.action.IAction;
-import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.ui.IViewActionDelegate;
 import org.eclipse.ui.IViewPart;
 
+import jp.go.aist.rtm.nameserviceview.model.manager.NameServerManager;
+import jp.go.aist.rtm.nameserviceview.ui.views.nameserviceview.NameServiceView;
+import jp.go.aist.rtm.nameserviceview.util.NameServiceProcessHandler;
+
 public class StopNameServiceAction implements IViewActionDelegate {
 	private NameServiceView view;
+	private NameServiceProcessHandler handler = new NameServiceProcessHandler();
 	
-	private static String SCRIPT_WINDOWS = System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "kill-rtm-naming.bat";
-	private static String SCRIPT_LINUX = "/usr/bin/rtm-naming";
-	
-//	@Override
 	public void init(IViewPart view) {
 		this.view = (NameServiceView) view;
+		handler.initialize();
 	}
 
 	public void run(IAction action) {
@@ -32,29 +27,9 @@ public class StopNameServiceAction implements IViewActionDelegate {
 			isWindows = true;
 		}
 		
-		ProcessBuilder pb = null;
-		if(isWindows) {
-			pb = new ProcessBuilder(SCRIPT_WINDOWS);
-			
-		} else {
-			String passWord = "";
-			PasswordDialog  passwdDialog = new PasswordDialog(view.getSite().getShell());
-			if(passwdDialog.open()!=Dialog.OK) return;
-			
-			passWord = passwdDialog.getPassWord();
-			pb = new ProcessBuilder(SCRIPT_LINUX, "-k", "-f", "-w " + passWord);
-		}
-		try {
-			pb.start();
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-		//
-		try {
-			Thread.sleep(1000);
-		} catch (InterruptedException e) {
-			e.printStackTrace();
-		}
+		//Stop NameService
+		String passWord = handler.stopNameService(view, isWindows);
+		if(passWord == null) return;
 		NameServerManager.eInstance.refreshAll();
 	}
 
@@ -62,9 +37,9 @@ public class StopNameServiceAction implements IViewActionDelegate {
 		String target = "";
 		String targetOS = System.getProperty("os.name").toLowerCase();
 		if(targetOS.toLowerCase().startsWith("windows")) {
-			target = SCRIPT_WINDOWS; 
+			target = NameServiceProcessHandler.SCRIPT_WINDOWS_STOP; 
 		} else {
-			target = SCRIPT_LINUX;
+			target = NameServiceProcessHandler.SCRIPT_UNIX;
 		}
 		File targetFile = new File(target);
 		if(targetFile.exists()==false) {

--- a/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/util/NameServiceProcessHandler.java
+++ b/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/util/NameServiceProcessHandler.java
@@ -1,0 +1,76 @@
+package jp.go.aist.rtm.nameserviceview.util;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jface.dialogs.Dialog;
+
+import jp.go.aist.rtm.nameserviceview.ui.dialog.PasswordDialog;
+import jp.go.aist.rtm.nameserviceview.ui.views.nameserviceview.NameServiceView;
+
+public class NameServiceProcessHandler {
+	public static String SCRIPT_WINDOWS = System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "rtm-naming.bat";
+	public static String SCRIPT_WINDOWS_STOP = System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "kill-rtm-naming.bat";
+
+	public static String SCRIPT_UNIX = "/usr/bin/rtm-naming";
+	private String[] UNIX_CANDIDATE_LIST = {"/usr/bin/rtm-naming",
+											"/usr/local/bin/rtm-naming",
+											System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "rtm-naming"};
+	
+	public void initialize() {
+		// find rtm-naming
+		for(String each :  UNIX_CANDIDATE_LIST) {
+			File targetFile = new File(each);
+			if(targetFile.exists() == true) {
+				SCRIPT_UNIX = each;
+				break;
+			}
+		}
+	}
+	
+	public String stopNameService(NameServiceView view, boolean isWindows) {
+		ProcessBuilder pb = null;
+		String passWord = "";
+
+		if(isWindows) {
+			pb = new ProcessBuilder(SCRIPT_WINDOWS_STOP);
+
+		} else {
+			PasswordDialog  passwdDialog = new PasswordDialog(view.getSite().getShell());
+			if(passwdDialog.open()!=Dialog.OK) return null;
+
+			passWord = passwdDialog.getPassWord();
+			pb = new ProcessBuilder(SCRIPT_UNIX, "-k", "-f", "-w " + passWord);
+		}
+		try {
+			pb.start();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		//
+		try {
+			Thread.sleep(1000);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+		
+		return passWord;
+	}
+	
+	public void startNameService(boolean isWindows, String passWord) {
+		ProcessBuilder pb = null;
+		if(isWindows) {
+			pb = new ProcessBuilder(SCRIPT_WINDOWS);
+
+		} else {
+			pb = new ProcessBuilder(SCRIPT_UNIX, "-f", "-w " + passWord);
+		}
+		try {
+			pb.start();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+}


### PR DESCRIPTION
## Identify the Bug

Link to #368

## Description of the Change

ご提示頂きましたコードを参考に，/usr/bin/rtm-naming以外のNS起動コマンドを使えるように修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-03を使用
- [x] No warnings for the build?  Windows上でEclipse2019-03を使用
- [ ] Have you passed the unit tests? ユニットテストなし