### PR TITLE
Makefile modified to dmg build process automation.

### DIFF
--- a/packages/dmg/Makefile
+++ b/packages/dmg/Makefile
@@ -1,13 +1,20 @@
-all: img dmg
+all: subdirs dmg
 
-icns:
-	iconutil -c icns rtmlogo.iconset
+DMGNAME=openrtp_v1.2.2.dmg
 
-img:
+# subdirs build
+SUBDIRS = bin
+.PHONY: subdirs $(SUBDIRS)
+subdirs: $(SUBDIRS)
+$(SUBDIRS):
+	$(MAKE) -C $@
+
+backImage.tiff:
+	rm -rf backImage.tiff
 	tiffutil -cathidpicheck backImage/openrtp_800x400.tif backImage/openrtp_1600x800.tif -out backImage.tiff
 
-dmg:
-	rm -f openrtp_v1.2.2.dmg
+dmg: subdirs backImage.tiff
+	rm -f $(DMGNAME)
 	create-dmg \
 		--volname "OpenRTP Installer" \
 		--volicon "icons/openrtp.icns" \
@@ -15,11 +22,12 @@ dmg:
 		--window-pos 200 120 \
 		--window-size 800 440 \
 		--icon-size 100 \
-		--icon "openrtp.app" 200 190 \
+		--icon "OpenRTP.app" 200 190 \
 		--hide-extension "OpenRTP.app" \
 		--app-drop-link 600 185 \
-		"openrtp_v1.2.2.dmg" \
-		"bin/openrtp.app/"
+		"$(DMGNAME)" \
+		"bin/OpenRTP.app/"
+	shasum -a 256 $(DMGNAME)
 
 clean:
 	rm -f .DS_store

--- a/packages/dmg/bin/Makefile
+++ b/packages/dmg/bin/Makefile
@@ -1,0 +1,55 @@
+all: download extract cleanapp modifyapp
+
+PKGFILE=eclipse473-openrtp122v20200828-macosx-cocoa-x86_64.tar.gz
+PKGURL=https://openrtm.org/pub/openrtp/packages/1.2.2.v20200828/
+APPDIR=OpenRTP.app
+RESRCDIR=$(APPDIR)/Contents/Resources
+INIFILE=$(APPDIR)/Contents/Eclipse/eclipse.ini
+PLISTFILE=$(APPDIR)/Contents/Info.plist
+CRSRCFILE=$(APPDIR)/Contents/_CodeSignature/CodeResources
+CONFIGDIR=$(APPDIR)/Contents/Eclipse/configuration
+P2DIR=$(APPDIR)/Contents/Eclipse/p2/org.eclipse.equinox.p2.engine
+
+download:
+	wget -c $(PKGURL)/$(PKGFILE)
+
+extract: download $(PKGFILE)
+	rm -rf Eclipse.app OpenRTP.app
+	tar xvzf $(PKGFILE)
+	mv Eclipse.app OpenRTP.app
+
+cleanapp:
+	rm -rf $(APPDIR)/Contents/MacOS/logback.xml
+	rm -rf $(CONFIGDIR)/*.log
+	rm -rf $(CONFIGDIR)/.settings
+	rm -rf $(CONFIGDIR)/org.eclipse.update/history
+	rm -rf $(CONFIGDIR)/org.eclipse.core.runtime
+	rm -rf $(CONFIGDIR)/org.eclipse.osgi
+	rm -rf $(CONFIGDIR)/org.eclipse.ui.intro.universal
+	rm -rf $(CONFIGDIR)/org.eclipse.equinox.app
+	rm -rf $(CONFIGDIR)/org.eclipse.e4.ui.css.swt.theme
+	rm -rf $(P2DIR)/.settings
+	rm -rf $(P2DIR)/profileRegistry/SDKProfile.profile/.data/.settings
+
+modifyapp:
+	# copy icon
+	cp ../icons/openrtp.icns $(RESRCDIR)/OpenRTP.icns
+	# Modify ini file
+	mv $(INIFILE) $(INIFILE).org
+	echo "-vm" >> $(INIFILE)
+	echo "/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/bin" >> $(INIFILE)
+	echo "-showLocation" >> $(INIFILE)
+	cat $(INIFILE).org >>  $(INIFILE)
+	rm -f $(INIFILE).org
+	# replace icon entry
+	sed -i '' 's/Eclipse.icns/OpenRTP.icns/g' $(INIFILE)
+	sed -i '' 's/Eclipse.icns/OpenRTP.icns/g' $(PLISTFILE)
+	sed -i '' 's/Eclipse.icns/OpenRTP.icns/g' $(CRSRCFILE)
+
+
+clean:
+	rm -f .DS_store
+	rm -rf OpenRTP.app Eclipse.app
+
+cleantgz:
+	rm -rf $(PKGFILE)


### PR DESCRIPTION
dmgファイルを作成するMakefileの更新
- OpenRTP.appのためのtar-ballのダウンロード・展開を自動化
- OpenRTP.app内のWS依存ファイルの削除を追加（起動するとWS情報が残るのを削除）
- OpenRTP.app内の各種ファイルの変更
  - 使用するjava vmをadoptopenjdk8に限定
  - アイコンファイルおよび設定の変更
- shasum256 を表示、Cask用