### PR TITLE
Ubuntu20.04環境RTCBuilderでのラジオボタン、チェックボックス表示不具合修正(1.2)

### DIFF
--- a/openrtp
+++ b/openrtp
@@ -330,6 +330,7 @@ fi
 
 find_OPENRTP_DIR
 
+export SWT_GTK3=0
 export GDK_NATIVE_WINDOWS=1
 cd $OPENRTP_DIR
 $OPENRTP_EXECUTABLE $ECLIPSE_ARGS -vmargs -Djava.util.logging.config.file=$OPENRTP_DIR/logger.properties


### PR DESCRIPTION
## Identify the Bug
Link to #369 #370 

## Description of the Change
- Linux用のopenrtp起動スクリプト内に「export SWT_GTK3=0」を追加した
- この設定により、下記ワーニングも出なくなった
```
(eclipse:34763): Gdk-WARNING **: 12:31:52.066: The GDK_NATIVE_WINDOWS environment variable is not supported in GTK3.
```


## Verification 
- この修正で、Ubuntu20.04環境でのラジオボタン、チェックボックス表示の不具合は改善した
- Ubuntu16.04, 18.04環境では元々表示に問題がなく、今回の追加定義を加えても影響がないことを確認した

- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  