### PR TITLE
Ubuntu20.04環境RTCBuilderでのラジオボタン、チェックボックス表示不具合修正(2.0)

### DIFF
--- a/openrtp
+++ b/openrtp
@@ -330,6 +330,7 @@ fi
 
 find_OPENRTP_DIR
 
+export SWT_GTK3=0
 export GDK_NATIVE_WINDOWS=1
 cd $OPENRTP_DIR
 $OPENRTP_EXECUTABLE $ECLIPSE_ARGS -vmargs -Djava.util.logging.config.file=$OPENRTP_DIR/logger.properties


### PR DESCRIPTION
## Identify the Bug
Link to #369 #370 

## Description of the Change
- Linux用のopenrtp起動スクリプト内に「export SWT_GTK3=0」を追加した


## Verification 
- RELENG_1_2 ブランチソースで動作確認した結果がOKだったため、masterブランチでは動作確認をしていない

