### PR TITLE
RELENG_1_2ブランチのdebパッケージバージョン番号の1.2.2-1への更新

### DIFF
--- a/packages/deb/debian/changelog
+++ b/packages/deb/debian/changelog
@@ -1,3 +1,10 @@
+openrtp (1.2.2-1) experimental; urgency=low
+
+  * SWT_GTK3 environment variable has been set to zero.
+  * Updated doxyfile.in.
+
+ -- Noriaki Ando <n-ando@aist.go.jp>  Mon, 30 Nov 2020 11:16:08 +0900
+
 openrtp (1.2.2-0) experimental; urgency=low
 
   * 1.2.2-0 (1.2.2-RELEASE). OpenRTP-1.2.2-RELEASE


### PR DESCRIPTION
## Identify the Bug
Link to #382 

## Description of the Change
- changelog でバージョン1.2.2-1を定義した



## Verification 
- ubuntu20.04用debパッケージを生成してテストリポジトリ（150.29.99.185）へアップロードし、apt upgrade にてopenrtpが1.2.2-0から1.2.2-1へアップグレードされたことを確認した

- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
