### PR TITLE
[RTCB] idl/CMakeLists.txtをLinuxのPython3環境に対応するように修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/resource/100/DataPortIDL/idl/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/DataPortIDL/idl/CMakeLists.txt
@@ -21,8 +21,14 @@ macro(_COMPILE_IDL _idl_file)
     set(_idl_srcs_var ${_idl}_SRCS)
     _IDL_OUTPUTS(${_idl} ${CMAKE_CURRENT_BINARY_DIR} ${_idl_srcs_var})
 
+    if(WIN32)
+        set(_python_command "python")
+    else(WIN32)
+        set(_python_command "python3")
+    endif(WIN32)
+ 
     add_custom_command(OUTPUT ${${_idl_srcs_var}}
-        COMMAND python ${OPENRTM_DIR}/bin/${_rtm_skelwrapper_command} --include-dir= --skel-suffix=Skel --stub-suffix=Stub --idl-file=${_idl}.idl
+        COMMAND ${_python_command} ${OPENRTM_DIR}/bin/${_rtm_skelwrapper_command} --include-dir= --skel-suffix=Skel --stub-suffix=Stub --idl-file=${_idl}.idl
         COMMAND ${OPENRTM_IDLC} ${OPENRTM_IDLFLAGS} ${_idl_file}
         WORKING_DIRECTORY ${CURRENT_BINARY_DIR}
         DEPENDS ${_idl_file}

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePort/idl/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePort/idl/CMakeLists.txt
@@ -21,8 +21,14 @@ macro(_COMPILE_IDL _idl_file)
     set(_idl_srcs_var ${_idl}_SRCS)
     _IDL_OUTPUTS(${_idl} ${CMAKE_CURRENT_BINARY_DIR} ${_idl_srcs_var})
 
+    if(WIN32)
+        set(_python_command "python")
+    else(WIN32)
+        set(_python_command "python3")
+    endif(WIN32)
+ 
     add_custom_command(OUTPUT ${${_idl_srcs_var}}
-        COMMAND python ${OPENRTM_DIR}/bin/${_rtm_skelwrapper_command} --include-dir= --skel-suffix=Skel --stub-suffix=Stub --idl-file=${_idl}.idl
+        COMMAND ${_python_command} ${OPENRTM_DIR}/bin/${_rtm_skelwrapper_command} --include-dir= --skel-suffix=Skel --stub-suffix=Stub --idl-file=${_idl}.idl
         COMMAND ${OPENRTM_IDLC} ${OPENRTM_IDLFLAGS} ${_idl_file}
         WORKING_DIRECTORY ${CURRENT_BINARY_DIR}
         DEPENDS ${_idl_file}

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/XXX/idl/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/XXX/idl/CMakeLists.txt
@@ -21,8 +21,14 @@ macro(_COMPILE_IDL _idl_file)
     set(_idl_srcs_var ${_idl}_SRCS)
     _IDL_OUTPUTS(${_idl} ${CMAKE_CURRENT_BINARY_DIR} ${_idl_srcs_var})
 
+    if(WIN32)
+        set(_python_command "python")
+    else(WIN32)
+        set(_python_command "python3")
+    endif(WIN32)
+ 
     add_custom_command(OUTPUT ${${_idl_srcs_var}}
-        COMMAND python ${OPENRTM_DIR}/bin/${_rtm_skelwrapper_command} --include-dir= --skel-suffix=Skel --stub-suffix=Stub --idl-file=${_idl}.idl
+        COMMAND ${_python_command} ${OPENRTM_DIR}/bin/${_rtm_skelwrapper_command} --include-dir= --skel-suffix=Skel --stub-suffix=Stub --idl-file=${_idl}.idl
         COMMAND ${OPENRTM_IDLC} ${OPENRTM_IDLFLAGS} ${_idl_file}
         WORKING_DIRECTORY ${CURRENT_BINARY_DIR}
         DEPENDS ${_idl_file}

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/YYY/idl/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/YYY/idl/CMakeLists.txt
@@ -21,8 +21,14 @@ macro(_COMPILE_IDL _idl_file)
     set(_idl_srcs_var ${_idl}_SRCS)
     _IDL_OUTPUTS(${_idl} ${CMAKE_CURRENT_BINARY_DIR} ${_idl_srcs_var})
 
+    if(WIN32)
+        set(_python_command "python")
+    else(WIN32)
+        set(_python_command "python3")
+    endif(WIN32)
+ 
     add_custom_command(OUTPUT ${${_idl_srcs_var}}
-        COMMAND python ${OPENRTM_DIR}/bin/${_rtm_skelwrapper_command} --include-dir= --skel-suffix=Skel --stub-suffix=Stub --idl-file=${_idl}.idl
+        COMMAND ${_python_command} ${OPENRTM_DIR}/bin/${_rtm_skelwrapper_command} --include-dir= --skel-suffix=Skel --stub-suffix=Stub --idl-file=${_idl}.idl
         COMMAND ${OPENRTM_IDLC} ${OPENRTM_IDLFLAGS} ${_idl_file}
         WORKING_DIRECTORY ${CURRENT_BINARY_DIR}
         DEPENDS ${_idl_file}

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/idl/IdlCMakeLists.txt.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/idl/IdlCMakeLists.txt.vsl
@@ -21,8 +21,14 @@ macro(_COMPILE_IDL _idl_file)
     set(_idl_srcs_var ${dol}{_idl}_SRCS)
     _IDL_OUTPUTS(${dol}{_idl} ${dol}{CMAKE_CURRENT_BINARY_DIR} ${dol}{_idl_srcs_var})
 
+    if(WIN32)
+        set(_python_command "python")
+    else(WIN32)
+        set(_python_command "python3")
+    endif(WIN32)
+ 
     add_custom_command(OUTPUT ${dol}{${dol}{_idl_srcs_var}}
-        COMMAND python ${dol}{OPENRTM_DIR}/bin/${dol}{_rtm_skelwrapper_command} --include-dir= --skel-suffix=Skel --stub-suffix=Stub --idl-file=${dol}{_idl}.idl
+        COMMAND ${dol}{_python_command} ${dol}{OPENRTM_DIR}/bin/${dol}{_rtm_skelwrapper_command} --include-dir= --skel-suffix=Skel --stub-suffix=Stub --idl-file=${dol}{_idl}.idl
         COMMAND ${dol}{OPENRTM_IDLC} ${dol}{OPENRTM_IDLFLAGS} ${dol}{_idl_file}
         WORKING_DIRECTORY ${dol}{CURRENT_BINARY_DIR}
         DEPENDS ${dol}{_idl_file}


### PR DESCRIPTION
## Identify the Bug

Link to #387

## Description of the Change

idl/CMakeLists.txtをご提示頂いた形で修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-12を使用
- [x] No warnings for the build?  Windows上でEclipse2019-12を使用
- [x] Have you passed the unit tests? 既存のユニットテストを修正し，正常に実行されることを確認