### PR TITLE
[RTCB] Python RTCのcmake設定をPython3対応に修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/cmake/CMakeLists.txt.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/cmake/CMakeLists.txt.vsl
@@ -20,7 +20,12 @@ set(PROJECT_MAINTAINER "${rtcParam.docCreator}")
 #else
 set(PROJECT_MAINTAINER "unknown")
 #end
-set(PROJECT_TYPE "python/${rtcParam.category}")
+if(WIN32)
+    set(PYTHON_COMMAND "python")
+else()
+    set(PYTHON_COMMAND "python3")
+endif()
+set(PROJECT_TYPE "${dol}{PYTHON_COMMAND}/${rtcParam.category}")
 
 find_package(OpenRTM REQUIRED)
 set(RTM_VER ${dol}{OPENRTM_VERSION})
@@ -104,7 +109,7 @@ set(OTHER_SRCS CMakeLists.txt
                RTC.xml ${rtcParam.name}.conf rtc.conf)
 
 ${sharp} check python installed
-find_package(PythonInterp)
+find_package(PythonInterp 3)
 
 if(WIN32)
    set(OPENRTM_SHARE_PREFIX "OpenRTM-aist/${dol}{RTM_VER}/Components/${dol}{PROJECT_TYPE}")


### PR DESCRIPTION
## Identify the Bug

Link to #390

## Description of the Change

Python版RTCのCMakeLists.txtをご提示頂いた形で修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-12を使用
- [x] No warnings for the build?  Windows上でEclipse2019-12を使用
- [x] Have you passed the unit tests? 既存のユニットテストを修正し，正常に実行されることを確認