### PR TITLE
[RTSE]Transition Editorに入力した内容が消えないように修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/TransitionParam.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/TransitionParam.java
@@ -52,6 +52,9 @@ public class TransitionParam {
 	public EventParam getEventParam() {
 		return eventParam;
 	}
+	public void setEventParam(EventParam eventParam) {
+		this.eventParam = eventParam;
+	}
 	public boolean existEventParam() {
 		return eventParam != null;
 	}
@@ -75,14 +78,15 @@ public class TransitionParam {
 	public void searchEventParam(RtcParam rtcParam) {
 		String transName = this.event;
 		if(transName == null) transName = "";
+		
 		String transCondition = this.condition;
 		if(transCondition == null) transCondition = "";
+		
 		String transSource = this.source;
 		if(transSource == null) transSource = "";
-		else transSource = transSource;
+		
 		String transTarget = this.target;
 		if(transTarget == null) transTarget = "";
-		else transTarget = transTarget;
 
 		EventPortParam eventPort = rtcParam.getEventport();
 		if(eventPort==null) return;

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/editor/editor/scxml/eleditor/SCXMLTransitionEditor.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/fsm/editor/editor/scxml/eleditor/SCXMLTransitionEditor.java
@@ -186,6 +186,7 @@ public class SCXMLTransitionEditor extends SCXMLEditorRoot {
 		edge.setCondition(txtCondition.getText());
 		//
 		targetParam.setName(txtEvent.getText());
+		targetParam.setCondition(txtCondition.getText());
 		targetParam.setDataType((String)cmbType.getSelectedItem());
 		targetParam.setDoc_description(txtDescription.getText());
 		targetParam.setDoc_type(txtType.getText());

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/generator/param/RtcParam.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/generator/param/RtcParam.java
@@ -938,19 +938,23 @@ public class RtcParam extends AbstractRecordedParam implements Serializable {
 		
 		for(TransitionParam trans : fsmParam.getAllTransList()) {
 			boolean isExist = false;
-			EventParam eventp = new EventParam();
-			eventp.setName(trans.getEvent());
-			eventp.setCondition(trans.getCondition());
-			eventp.setSource(trans.getSource());
-			eventp.setTarget(trans.getTarget());
-			
-			for(EventParam orgEv : eventList) {
-				if(orgEv.checkSame(eventp)) {
+			for(EventParam eventp : eventList) {
+				if(eventp.getName().equals(trans.getEvent())
+						&& eventp.getCondition().equals(trans.getCondition())
+						&& eventp.getSource().equals(trans.getSource())
+						&& eventp.getTarget().equals(trans.getTarget()) ) {
+					trans.setEventParam(eventp);
 					isExist = true;
 					break;
 				}
 			}
-			if(isExist==false) {
+			if(isExist == false) {
+				EventParam eventp = new EventParam();
+				eventp.setName(trans.getEvent());
+				eventp.setCondition(trans.getCondition());
+				eventp.setSource(trans.getSource());
+				eventp.setTarget(trans.getTarget());
+				trans.setEventParam(eventp);
 				eventList.add(eventp);
 			}
 		}

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/FSMEditorFormPage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/FSMEditorFormPage.java
@@ -364,6 +364,10 @@ public class FSMEditorFormPage extends AbstractEditorFormPage {
 					StringBuffer buffer = new StringBuffer();
 					StateParam rootState = scHandler.parseSCXML(strPath, buffer);
 					if(rootState!=null) {
+						editor.getRtcParam().getEventports().get(0).getEvents().clear();
+						clearText();
+						sourceText.setText("");
+						targetText.setText("");
 						editor.getRtcParam().setFsmParam(rootState);
 						editor.getRtcParam().setFsmContents(buffer.toString());
 						editor.getRtcParam().parseEvent();
@@ -577,22 +581,6 @@ public class FSMEditorFormPage extends AbstractEditorFormPage {
 			}
 		}
 		//
-		String targetFile = editor.getRtcParam().getName() + "FSM.scxml";
-		IWorkspace workspace = ResourcesPlugin.getWorkspace();
-		IWorkspaceRoot root = workspace.getRoot();
-		IProject project = root.getProject(editor.getRtcParam().getOutputProject());
-		IFile fsmFile  = project.getFile(targetFile);
-		if(fsmFile.exists()) {
-			targetFile = fsmFile.getLocation().toOSString();
-			ScXMLHandler handler = new ScXMLHandler();
-			StringBuffer buffer = new StringBuffer();
-			StateParam rootState = handler.parseSCXML(targetFile, buffer);
-			if(rootState!=null) {
-				rtcParam.setFsmParam(rootState);
-				rtcParam.setFsmContents(buffer.toString());
-			}
-		}
-		//
 		if(0<rtcParam.getEventports().size()) {
 			EventPortParam eport = rtcParam.getEventports().get(0);
 			portNameText.setText(eport.getName());
@@ -736,18 +724,26 @@ public class FSMEditorFormPage extends AbstractEditorFormPage {
 				StateParam target = rootState.getStateParam(trans.getTarget());
 				if(source.isInitial() || target.isInitial()) continue;
 				
-				EventParam newParam = new EventParam();
-				newParam.setName(trans.getEvent());
-				newParam.setCondition(trans.getCondition());
-				newParam.setSource(trans.getSource());
-				newParam.setTarget(trans.getTarget());
-				for(EventParam event : eventList) {
-					if(newParam.checkSame(event)) {
-						newParam.replaceContents(event);
+				boolean isExist = false;
+				for(EventParam eventp : eventList) {
+					if(trans.getSource().equals(eventp.getSource())
+							&& trans.getTarget().equals(eventp.getTarget())
+							&& trans.getCondition().equals(eventp.getCondition())
+							&& trans.getEvent().equals(eventp.getName()) ) {
+						newEventList.add(eventp);
+						isExist = true;
 						break;
 					}
 				}
-				newEventList.add(newParam);
+				
+				if(isExist==false) {
+					EventParam newParam = new EventParam();
+					newParam.setName(trans.getEvent());
+					newParam.setCondition(trans.getCondition());
+					newParam.setSource(trans.getSource());
+					newParam.setTarget(trans.getTarget());
+					newEventList.add(newParam);
+				}
 			}
 			rtcParam.getEventports().get(0).getEvents().clear();
 			rtcParam.getEventports().get(0).getEvents().addAll(newEventList);

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/util/FileUtil.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/util/FileUtil.java
@@ -12,12 +12,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants;
-import jp.go.aist.rtm.rtcbuilder.nl.Messages;
-import jp.go.aist.rtm.rtcbuilder.ui.preference.ComponentPreferenceManager;
-
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.swt.SWT;
@@ -27,6 +22,10 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
+
+import jp.go.aist.rtm.rtcbuilder.IRtcBuilderConstants;
+import jp.go.aist.rtm.rtcbuilder.nl.Messages;
+import jp.go.aist.rtm.rtcbuilder.ui.preference.ComponentPreferenceManager;
 
 /**
  * ユーティリティクラス


### PR DESCRIPTION
## Identify the Bug

Link to #249 

## Description of the Change

イベント名やガード条件を変更しても，Transition Editorで入力した概要説明などの情報が消えないように修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2019-12を使用
- [x] No warnings for the build?  Windows上でEclipse2019-12を使用
- [x] Have you passed the unit tests? ユニットテストなし