### PR TITLE
debパッケージのJava依存関係をJava8のみに変更（1.2）

### DIFF
--- a/make_packages
+++ b/make_packages
@@ -93,7 +93,7 @@ ECLIPSE_DIRS="$HOME/eclipse $HOME ../ ../../ ../..//usr/lib/ /usr/share"
 #true ${ECLIPSE_VERSION:="R-4.4.2-201502041700"}
 true ${ECLIPSE_VERSION:="R-4.7.3-201803010715"}
 #true ${DOWNLOAD_SITE:="http://ftp.jaist.ac.jp/pub/eclipse/eclipse/downloads/drops/${ECLIPSE_VERSION}"}
-true ${DOWNLOAD_SITE:="file:///home/openrtm/public_html/pub/eclipse/packages/"}
+true ${DOWNLOAD_SITE:="file://$HOME/public_html/pub/eclipse/packages/"}
 ECLIPSE_SHORTVER=`echo $ECLIPSE_VERSION | awk 'BEGIN{FS="-";}{print $2;}'`
 ECLIPSE_WIN32_32="${DOWNLOAD_SITE}/eclipse-SDK-${ECLIPSE_SHORTVER}-win32.zip"
 ECLIPSE_WIN32_64="${DOWNLOAD_SITE}/eclipse-SDK-${ECLIPSE_SHORTVER}-win32-x86_64.zip"
@@ -104,7 +104,7 @@ ECLIPSE_MACOS_64="${DOWNLOAD_SITE}/eclipse-SDK-${ECLIPSE_SHORTVER}-macosx-cocoa-
 
 # Eclipse plugins information
 #true ${REPOSITORY:="file:///home/openrtm/public_html/pub/eclipse/projects/luna,http://download.eclipse.org/releases/luna"}
-true ${REPOSITORY:="file:///home/openrtm/public_html/pub/eclipse/projects/oxygen,http://download.eclipse.org/releases/oxygen"}
+true ${REPOSITORY:="file://$HOME/public_html/pub/eclipse/projects/oxygen,http://download.eclipse.org/releases/oxygen"}
 PLUGINS="org.eclipse.emf.sdk.feature.group
          org.eclipse.emf.ecore.xcore.sdk.feature.group
          org.eclipse.gef.sdk.feature.group

--- a/packages/deb/debian/changelog
+++ b/packages/deb/debian/changelog
@@ -1,3 +1,10 @@
+openrtp (1.2.2-3) experimental; urgency=low
+
+  * Changed Java dependency of deb package to JDK8 only.
+  * Modified to display merge button when changing activity settings.
+
+ -- Noriaki Ando <n-ando@aist.go.jp>  Wed, 01 Dec 2021 12:05:07 +0900
+
 openrtp (1.2.2-2) experimental; urgency=low
 
   * Modified to not use observer.

--- a/packages/deb/debian/control
+++ b/packages/deb/debian/control
@@ -10,7 +10,7 @@ Package: openrtp
 Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: ${shlibs:Depends}, ${misc:Depends}, default-jre|openjdk-7-jre|openjdk-8-jre, openrtm-aist-dev
+Depends: ${shlibs:Depends}, ${misc:Depends}, openjdk-8-jdk, openrtm-aist-dev
 Description: OpenRTP, Open RT Platform distributed by AIST
  OpenRTP is tool package for OpenRTM-aist and its interoperable
  RT-Middleware implementations. OpenRTP is being developed and


### PR DESCRIPTION
Link to #470

## Description of the Change

- debパッケージ生成時のJava依存関係を、openjdk-8-jdk のみとした
- debパッケージのバージョン番号を、1.2.2-3 へ更新
- ソースビルド時に使用する make_packages スクリプト内で、ビルド環境のHOMEが、/home/openrtm と直書きになっていたので、この条件に合わない環境向けに $HOME へ変更

## Verification 

- [x] Did you succesed the build?
- [x] No warnings for the build?
- [ ] Have you passed the unit tests?