### PR TITLE
RTCBuilderが生成するC++ファイルをOpenRTM-aist 1.2、2.0の両方でビルドできるように修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/AIST2/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/AIST2/ModuleName.cpp
@@ -9,7 +9,11 @@
 #include "ModuleName.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleName",
     "type_name",         "ModuleName",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/CheckIDL/Sample.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/CheckIDL/Sample.cpp
@@ -9,7 +9,11 @@
 #include "Sample.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const sample_spec[] =
+#else
+static const char* sample_spec[] =
+#endif
   {
     "implementation_id", "Sample",
     "type_name",         "Sample",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/CheckIDLDef/Sample.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/CheckIDLDef/Sample.cpp
@@ -9,7 +9,11 @@
 #include "Sample.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const sample_spec[] =
+#else
+static const char* sample_spec[] =
+#endif
   {
     "implementation_id", "Sample",
     "type_name",         "Sample",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/ConfigType/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/ConfigType/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset1/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset1/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset2/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset2/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset3/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset3/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset4/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ConfigSet/configset4/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Content/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Content/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/DataPortIDL/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/DataPortIDL/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Doc/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Doc/foo.cpp
@@ -15,7 +15,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ExecutionCxt/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/ExecutionCxt/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Manip/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Manip/ModuleName.cpp
@@ -9,7 +9,11 @@
 #include "ModuleName.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleName",
     "type_name",         "ModuleName",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ConMulti/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ConMulti/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ProConMulti/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ProConMulti/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ProMulti/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Multi/ProMulti/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/confprefix/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/confprefix/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/confsuffix/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/confsuffix/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/dtprefix/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/dtprefix/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/dtsuffix/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/dtsuffix/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/prefix/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/prefix/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/siprefix/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/siprefix/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/sisuffix/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/sisuffix/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/suffix/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/suffix/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/svprefix/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/svprefix/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/svsuffix/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/PrefixSuffix/svsuffix/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/DataPort/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/DataPort/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/ServicePort1/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/ServicePort1/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/ServicePort2/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/Variable/ServicePort2/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/attribute/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/attribute/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/inport2/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/inport2/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/operation/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/operation/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/outport2/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/outport2/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/service2/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/basic/service2/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/cmake1/src/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/cmake1/src/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/cmake2/src/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/build/cmake2/src/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint1/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint1/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint2/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint2/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint3/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/constraint/Constraint3/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlinherit/inherit1/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlinherit/inherit1/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlinherit/inherit2/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlinherit/inherit2/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceArg/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceArg/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceArgStruct/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceArgStruct/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceCon/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceCon/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceM/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlmodule/serviceM/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath1/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath1/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath2/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath2/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath3/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlpath/IDLPath3/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlstruct/TestModule.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idlstruct/TestModule.cpp
@@ -9,7 +9,11 @@
 #include "TestModule.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const testmodule_spec[] =
+#else
+static const char* testmodule_spec[] =
+#endif
   {
     "implementation_id", "TestModule",
     "type_name",         "TestModule",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/IDLType1/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/IDLType1/ModuleName.cpp
@@ -9,7 +9,11 @@
 #include "ModuleName.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleName",
     "type_name",         "ModuleName",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/SeqString/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/SeqString/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/Struct/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/Struct/ModuleName.cpp
@@ -9,7 +9,11 @@
 #include "ModuleName.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleName",
     "type_name",         "ModuleName",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/Struct2/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/Struct2/ModuleName.cpp
@@ -9,7 +9,11 @@
 #include "ModuleName.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleName",
     "type_name",         "ModuleName",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/type/test.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/idltype/type/test.cpp
@@ -9,7 +9,11 @@
 #include "test.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const test_spec[] =
+#else
+static const char* test_spec[] =
+#endif
   {
     "implementation_id", "test",
     "type_name",         "test",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/all/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/all/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/execute/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/execute/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/finalize/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/finalize/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/initialize/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/impl/initialize/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/library/library1/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/library/library1/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/library/library2/foo.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/CXX/library/library2/foo.cpp
@@ -9,7 +9,11 @@
 #include "foo.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const foo_spec[] =
+#else
+static const char* foo_spec[] =
+#endif
   {
     "implementation_id", "foo",
     "type_name",         "foo",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/DataPortIDL/idl/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/DataPortIDL/idl/CMakeLists.txt
@@ -1,34 +1,37 @@
 set(idls ${CMAKE_CURRENT_SOURCE_DIR}/ArUco.idl ${CMAKE_CURRENT_SOURCE_DIR}/GameFramework.idl ${CMAKE_CURRENT_SOURCE_DIR}/Img.idl )
-
 macro(_IDL_OUTPUTS _idl _dir _result)
     set(${_result} ${_dir}/${_idl}Skel.cpp ${_dir}/${_idl}Skel.h)
 endmacro(_IDL_OUTPUTS)
-
 macro(_COMPILE_IDL _idl_file)
-    if(NOT WIN32)
-        execute_process(COMMAND rtm-config --prefix OUTPUT_VARIABLE OPENRTM_DIR
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-        execute_process(COMMAND rtm-config --idlflags OUTPUT_VARIABLE OPENRTM_IDLFLAGS
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-        separate_arguments(OPENRTM_IDLFLAGS)
-        execute_process(COMMAND rtm-config --idlc OUTPUT_VARIABLE OPENRTM_IDLC
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-        set(_rtm_skelwrapper_command "rtm-skelwrapper")
-    else(NOT WIN32)
-        set(_rtm_skelwrapper_command "rtm-skelwrapper.py")
-    endif(NOT WIN32)
     get_filename_component(_idl ${_idl_file} NAME_WE)
     set(_idl_srcs_var ${_idl}_SRCS)
     _IDL_OUTPUTS(${_idl} ${CMAKE_CURRENT_BINARY_DIR} ${_idl_srcs_var})
-
     if(WIN32)
         set(_python_command "python")
     else(WIN32)
         set(_python_command "python3")
     endif(WIN32)
- 
+    if(${OPENRTM_VERSION_MAJOR} LESS 2)
+        if(NOT WIN32)
+            execute_process(COMMAND rtm-config --prefix OUTPUT_VARIABLE OPENRTM_DIR
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+            execute_process(COMMAND rtm-config --idlflags OUTPUT_VARIABLE OPENRTM_IDLFLAGS
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+            separate_arguments(OPENRTM_IDLFLAGS)
+            execute_process(COMMAND rtm-config --idlc OUTPUT_VARIABLE OPENRTM_IDLC
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+            set(_rtm_skelwrapper_command "rtm-skelwrapper")
+        else(NOT WIN32)
+            set(_rtm_skelwrapper_command "rtm-skelwrapper.py")
+        endif(NOT WIN32)
+        get_filename_component(_idl ${_idl_file} NAME_WE)
+        set(_idl_srcs_var ${_idl}_SRCS)
+        _IDL_OUTPUTS(${_idl} ${CMAKE_CURRENT_BINARY_DIR} ${_idl_srcs_var})
+        set(OPENRTM_IDL_WRAPPER ${_rtm_skelwrapper_command})
+        set(OPENRTM_IDL_WRAPPER_FLAGS --include-dir= --skel-suffix=Skel --stub-suffix=Stub --idl-file=${_idl}.idl)
+    endif()
     add_custom_command(OUTPUT ${${_idl_srcs_var}}
-        COMMAND ${_python_command} ${OPENRTM_DIR}/bin/${_rtm_skelwrapper_command} --include-dir= --skel-suffix=Skel --stub-suffix=Stub --idl-file=${_idl}.idl
+        COMMAND ${_python_command} ${OPENRTM_DIR}/bin/${OPENRTM_IDL_WRAPPER} ${OPENRTM_IDL_WRAPPER_FLAGS} --idl-file=${_idl}.idl
         COMMAND ${OPENRTM_IDLC} ${OPENRTM_IDLFLAGS} ${_idl_file}
         WORKING_DIRECTORY ${CURRENT_BINARY_DIR}
         DEPENDS ${_idl_file}
@@ -40,15 +43,12 @@ macro(_COMPILE_IDL _idl_file)
     endif(NOT TARGET ALL_IDL_TGT)
     add_dependencies(ALL_IDL_TGT ${_idl}_TGT)
 endmacro(_COMPILE_IDL)
-
 # Module exposed to the user
 macro(OPENRTM_COMPILE_IDL_FILES)
     foreach(idl ${ARGN})
         _COMPILE_IDL(${idl})
     endforeach(idl)
 endmacro(OPENRTM_COMPILE_IDL_FILES)
-
-
 OPENRTM_COMPILE_IDL_FILES(${idls})
 set(ALL_IDL_SRCS ${ALL_IDL_SRCS} PARENT_SCOPE)
 FILTER_LIST("ALL_IDL_SRCS" "hh$" idl_headers)

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/DataPortIDL/src/MarkerPosition.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/DataPortIDL/src/MarkerPosition.cpp
@@ -9,7 +9,11 @@
 #include "MarkerPosition.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const markerposition_spec[] =
+#else
+static const char* markerposition_spec[] =
+#endif
   {
     "implementation_id", "MarkerPosition",
     "type_name",         "MarkerPosition",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePort/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePort/ModuleName.cpp
@@ -9,7 +9,11 @@
 #include "ModuleName.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleName",
     "type_name",         "ModuleName",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePort/idl/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePort/idl/CMakeLists.txt
@@ -1,34 +1,37 @@
 set(idls ${CMAKE_CURRENT_SOURCE_DIR}/CalibrationService.idl )
-
 macro(_IDL_OUTPUTS _idl _dir _result)
     set(${_result} ${_dir}/${_idl}Skel.cpp ${_dir}/${_idl}Skel.h)
 endmacro(_IDL_OUTPUTS)
-
 macro(_COMPILE_IDL _idl_file)
-    if(NOT WIN32)
-        execute_process(COMMAND rtm-config --prefix OUTPUT_VARIABLE OPENRTM_DIR
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-        execute_process(COMMAND rtm-config --idlflags OUTPUT_VARIABLE OPENRTM_IDLFLAGS
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-        separate_arguments(OPENRTM_IDLFLAGS)
-        execute_process(COMMAND rtm-config --idlc OUTPUT_VARIABLE OPENRTM_IDLC
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-        set(_rtm_skelwrapper_command "rtm-skelwrapper")
-    else(NOT WIN32)
-        set(_rtm_skelwrapper_command "rtm-skelwrapper.py")
-    endif(NOT WIN32)
     get_filename_component(_idl ${_idl_file} NAME_WE)
     set(_idl_srcs_var ${_idl}_SRCS)
     _IDL_OUTPUTS(${_idl} ${CMAKE_CURRENT_BINARY_DIR} ${_idl_srcs_var})
-
     if(WIN32)
         set(_python_command "python")
     else(WIN32)
         set(_python_command "python3")
     endif(WIN32)
- 
+    if(${OPENRTM_VERSION_MAJOR} LESS 2)
+        if(NOT WIN32)
+            execute_process(COMMAND rtm-config --prefix OUTPUT_VARIABLE OPENRTM_DIR
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+            execute_process(COMMAND rtm-config --idlflags OUTPUT_VARIABLE OPENRTM_IDLFLAGS
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+            separate_arguments(OPENRTM_IDLFLAGS)
+            execute_process(COMMAND rtm-config --idlc OUTPUT_VARIABLE OPENRTM_IDLC
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+            set(_rtm_skelwrapper_command "rtm-skelwrapper")
+        else(NOT WIN32)
+            set(_rtm_skelwrapper_command "rtm-skelwrapper.py")
+        endif(NOT WIN32)
+        get_filename_component(_idl ${_idl_file} NAME_WE)
+        set(_idl_srcs_var ${_idl}_SRCS)
+        _IDL_OUTPUTS(${_idl} ${CMAKE_CURRENT_BINARY_DIR} ${_idl_srcs_var})
+        set(OPENRTM_IDL_WRAPPER ${_rtm_skelwrapper_command})
+        set(OPENRTM_IDL_WRAPPER_FLAGS --include-dir= --skel-suffix=Skel --stub-suffix=Stub --idl-file=${_idl}.idl)
+    endif()
     add_custom_command(OUTPUT ${${_idl_srcs_var}}
-        COMMAND ${_python_command} ${OPENRTM_DIR}/bin/${_rtm_skelwrapper_command} --include-dir= --skel-suffix=Skel --stub-suffix=Stub --idl-file=${_idl}.idl
+        COMMAND ${_python_command} ${OPENRTM_DIR}/bin/${OPENRTM_IDL_WRAPPER} ${OPENRTM_IDL_WRAPPER_FLAGS} --idl-file=${_idl}.idl
         COMMAND ${OPENRTM_IDLC} ${OPENRTM_IDLFLAGS} ${_idl_file}
         WORKING_DIRECTORY ${CURRENT_BINARY_DIR}
         DEPENDS ${_idl_file}
@@ -40,15 +43,12 @@ macro(_COMPILE_IDL _idl_file)
     endif(NOT TARGET ALL_IDL_TGT)
     add_dependencies(ALL_IDL_TGT ${_idl}_TGT)
 endmacro(_COMPILE_IDL)
-
 # Module exposed to the user
 macro(OPENRTM_COMPILE_IDL_FILES)
     foreach(idl ${ARGN})
         _COMPILE_IDL(${idl})
     endforeach(idl)
 endmacro(OPENRTM_COMPILE_IDL_FILES)
-
-
 OPENRTM_COMPILE_IDL_FILES(${idls})
 set(ALL_IDL_SRCS ${ALL_IDL_SRCS} PARENT_SCOPE)
 FILTER_LIST("ALL_IDL_SRCS" "hh$" idl_headers)

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/ServicePortJARA/ModuleName.cpp
@@ -9,7 +9,11 @@
 #include "ModuleName.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleName",
     "type_name",         "ModuleName",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/XXX/idl/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/XXX/idl/CMakeLists.txt
@@ -1,34 +1,37 @@
 set(idls ${CMAKE_CURRENT_SOURCE_DIR}/MyServiceTest.idl )
-
 macro(_IDL_OUTPUTS _idl _dir _result)
     set(${_result} ${_dir}/${_idl}Skel.cpp ${_dir}/${_idl}Skel.h)
 endmacro(_IDL_OUTPUTS)
-
 macro(_COMPILE_IDL _idl_file)
-    if(NOT WIN32)
-        execute_process(COMMAND rtm-config --prefix OUTPUT_VARIABLE OPENRTM_DIR
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-        execute_process(COMMAND rtm-config --idlflags OUTPUT_VARIABLE OPENRTM_IDLFLAGS
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-        separate_arguments(OPENRTM_IDLFLAGS)
-        execute_process(COMMAND rtm-config --idlc OUTPUT_VARIABLE OPENRTM_IDLC
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-        set(_rtm_skelwrapper_command "rtm-skelwrapper")
-    else(NOT WIN32)
-        set(_rtm_skelwrapper_command "rtm-skelwrapper.py")
-    endif(NOT WIN32)
     get_filename_component(_idl ${_idl_file} NAME_WE)
     set(_idl_srcs_var ${_idl}_SRCS)
     _IDL_OUTPUTS(${_idl} ${CMAKE_CURRENT_BINARY_DIR} ${_idl_srcs_var})
-
     if(WIN32)
         set(_python_command "python")
     else(WIN32)
         set(_python_command "python3")
     endif(WIN32)
- 
+    if(${OPENRTM_VERSION_MAJOR} LESS 2)
+        if(NOT WIN32)
+            execute_process(COMMAND rtm-config --prefix OUTPUT_VARIABLE OPENRTM_DIR
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+            execute_process(COMMAND rtm-config --idlflags OUTPUT_VARIABLE OPENRTM_IDLFLAGS
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+            separate_arguments(OPENRTM_IDLFLAGS)
+            execute_process(COMMAND rtm-config --idlc OUTPUT_VARIABLE OPENRTM_IDLC
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+            set(_rtm_skelwrapper_command "rtm-skelwrapper")
+        else(NOT WIN32)
+            set(_rtm_skelwrapper_command "rtm-skelwrapper.py")
+        endif(NOT WIN32)
+        get_filename_component(_idl ${_idl_file} NAME_WE)
+        set(_idl_srcs_var ${_idl}_SRCS)
+        _IDL_OUTPUTS(${_idl} ${CMAKE_CURRENT_BINARY_DIR} ${_idl_srcs_var})
+        set(OPENRTM_IDL_WRAPPER ${_rtm_skelwrapper_command})
+        set(OPENRTM_IDL_WRAPPER_FLAGS --include-dir= --skel-suffix=Skel --stub-suffix=Stub --idl-file=${_idl}.idl)
+    endif()
     add_custom_command(OUTPUT ${${_idl_srcs_var}}
-        COMMAND ${_python_command} ${OPENRTM_DIR}/bin/${_rtm_skelwrapper_command} --include-dir= --skel-suffix=Skel --stub-suffix=Stub --idl-file=${_idl}.idl
+        COMMAND ${_python_command} ${OPENRTM_DIR}/bin/${OPENRTM_IDL_WRAPPER} ${OPENRTM_IDL_WRAPPER_FLAGS} --idl-file=${_idl}.idl
         COMMAND ${OPENRTM_IDLC} ${OPENRTM_IDLFLAGS} ${_idl_file}
         WORKING_DIRECTORY ${CURRENT_BINARY_DIR}
         DEPENDS ${_idl_file}
@@ -40,15 +43,12 @@ macro(_COMPILE_IDL _idl_file)
     endif(NOT TARGET ALL_IDL_TGT)
     add_dependencies(ALL_IDL_TGT ${_idl}_TGT)
 endmacro(_COMPILE_IDL)
-
 # Module exposed to the user
 macro(OPENRTM_COMPILE_IDL_FILES)
     foreach(idl ${ARGN})
         _COMPILE_IDL(${idl})
     endforeach(idl)
 endmacro(OPENRTM_COMPILE_IDL_FILES)
-
-
 OPENRTM_COMPILE_IDL_FILES(${idls})
 set(ALL_IDL_SRCS ${ALL_IDL_SRCS} PARENT_SCOPE)
 FILTER_LIST("ALL_IDL_SRCS" "hh$" idl_headers)

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/XXX/src/XXX.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/XXX/src/XXX.cpp
@@ -9,7 +9,11 @@
 #include "XXX.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const xxx_spec[] =
+#else
+static const char* xxx_spec[] =
+#endif
   {
     "implementation_id", "XXX",
     "type_name",         "XXX",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/XXX/test/src/XXXTest.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/XXX/test/src/XXXTest.cpp
@@ -9,7 +9,11 @@
 #include "XXXTest.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const xxx_spec[] =
+#else
+static const char* xxx_spec[] =
+#endif
   {
     "implementation_id", "XXXTest",
     "type_name",         "XXXTest",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/YYY/idl/CMakeLists.txt
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/YYY/idl/CMakeLists.txt
@@ -1,34 +1,37 @@
 set(idls ${CMAKE_CURRENT_SOURCE_DIR}/MyServiceTest.idl )
-
 macro(_IDL_OUTPUTS _idl _dir _result)
     set(${_result} ${_dir}/${_idl}Skel.cpp ${_dir}/${_idl}Skel.h)
 endmacro(_IDL_OUTPUTS)
-
 macro(_COMPILE_IDL _idl_file)
-    if(NOT WIN32)
-        execute_process(COMMAND rtm-config --prefix OUTPUT_VARIABLE OPENRTM_DIR
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-        execute_process(COMMAND rtm-config --idlflags OUTPUT_VARIABLE OPENRTM_IDLFLAGS
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-        separate_arguments(OPENRTM_IDLFLAGS)
-        execute_process(COMMAND rtm-config --idlc OUTPUT_VARIABLE OPENRTM_IDLC
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-        set(_rtm_skelwrapper_command "rtm-skelwrapper")
-    else(NOT WIN32)
-        set(_rtm_skelwrapper_command "rtm-skelwrapper.py")
-    endif(NOT WIN32)
     get_filename_component(_idl ${_idl_file} NAME_WE)
     set(_idl_srcs_var ${_idl}_SRCS)
     _IDL_OUTPUTS(${_idl} ${CMAKE_CURRENT_BINARY_DIR} ${_idl_srcs_var})
-
     if(WIN32)
         set(_python_command "python")
     else(WIN32)
         set(_python_command "python3")
     endif(WIN32)
- 
+    if(${OPENRTM_VERSION_MAJOR} LESS 2)
+        if(NOT WIN32)
+            execute_process(COMMAND rtm-config --prefix OUTPUT_VARIABLE OPENRTM_DIR
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+            execute_process(COMMAND rtm-config --idlflags OUTPUT_VARIABLE OPENRTM_IDLFLAGS
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+            separate_arguments(OPENRTM_IDLFLAGS)
+            execute_process(COMMAND rtm-config --idlc OUTPUT_VARIABLE OPENRTM_IDLC
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+            set(_rtm_skelwrapper_command "rtm-skelwrapper")
+        else(NOT WIN32)
+            set(_rtm_skelwrapper_command "rtm-skelwrapper.py")
+        endif(NOT WIN32)
+        get_filename_component(_idl ${_idl_file} NAME_WE)
+        set(_idl_srcs_var ${_idl}_SRCS)
+        _IDL_OUTPUTS(${_idl} ${CMAKE_CURRENT_BINARY_DIR} ${_idl_srcs_var})
+        set(OPENRTM_IDL_WRAPPER ${_rtm_skelwrapper_command})
+        set(OPENRTM_IDL_WRAPPER_FLAGS --include-dir= --skel-suffix=Skel --stub-suffix=Stub --idl-file=${_idl}.idl)
+    endif()
     add_custom_command(OUTPUT ${${_idl_srcs_var}}
-        COMMAND ${_python_command} ${OPENRTM_DIR}/bin/${_rtm_skelwrapper_command} --include-dir= --skel-suffix=Skel --stub-suffix=Stub --idl-file=${_idl}.idl
+        COMMAND ${_python_command} ${OPENRTM_DIR}/bin/${OPENRTM_IDL_WRAPPER} ${OPENRTM_IDL_WRAPPER_FLAGS} --idl-file=${_idl}.idl
         COMMAND ${OPENRTM_IDLC} ${OPENRTM_IDLFLAGS} ${_idl_file}
         WORKING_DIRECTORY ${CURRENT_BINARY_DIR}
         DEPENDS ${_idl_file}
@@ -40,15 +43,12 @@ macro(_COMPILE_IDL _idl_file)
     endif(NOT TARGET ALL_IDL_TGT)
     add_dependencies(ALL_IDL_TGT ${_idl}_TGT)
 endmacro(_COMPILE_IDL)
-
 # Module exposed to the user
 macro(OPENRTM_COMPILE_IDL_FILES)
     foreach(idl ${ARGN})
         _COMPILE_IDL(${idl})
     endforeach(idl)
 endmacro(OPENRTM_COMPILE_IDL_FILES)
-
-
 OPENRTM_COMPILE_IDL_FILES(${idls})
 set(ALL_IDL_SRCS ${ALL_IDL_SRCS} PARENT_SCOPE)
 FILTER_LIST("ALL_IDL_SRCS" "hh$" idl_headers)

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/YYY/src/YYY.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/YYY/src/YYY.cpp
@@ -9,7 +9,11 @@
 #include "YYY.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const yyy_spec[] =
+#else
+static const char* yyy_spec[] =
+#endif
   {
     "implementation_id", "YYY",
     "type_name",         "YYY",

--- a/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/YYY/test/src/YYYTest.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/100/TestComp/YYY/test/src/YYYTest.cpp
@@ -9,7 +9,11 @@
 #include "YYYTest.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const yyy_spec[] =
+#else
+static const char* yyy_spec[] =
+#endif
   {
     "implementation_id", "YYYTest",
     "type_name",         "YYYTest",

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/src/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/src/ModuleName.cpp
@@ -9,7 +9,11 @@
 #include "ModuleName.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleName",
     "type_name",         "ModuleName",

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/test/src/ModuleNameTest.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/basic/test/src/ModuleNameTest.cpp
@@ -9,7 +9,11 @@
 #include "ModuleNameTest.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleNameTest",
     "type_name",         "ModuleNameTest",

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/src/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/src/ModuleName.cpp
@@ -9,7 +9,11 @@
 #include "ModuleName.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleName",
     "type_name",         "ModuleName",

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/test/src/ModuleNameTest.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventCond/test/src/ModuleNameTest.cpp
@@ -9,7 +9,11 @@
 #include "ModuleNameTest.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleNameTest",
     "type_name",         "ModuleNameTest",

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/src/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/src/ModuleName.cpp
@@ -9,7 +9,11 @@
 #include "ModuleName.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleName",
     "type_name",         "ModuleName",

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/test/src/ModuleNameTest.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventDoc/test/src/ModuleNameTest.cpp
@@ -9,7 +9,11 @@
 #include "ModuleNameTest.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleNameTest",
     "type_name",         "ModuleNameTest",

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/src/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/src/ModuleName.cpp
@@ -9,7 +9,11 @@
 #include "ModuleName.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleName",
     "type_name",         "ModuleName",

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/test/src/ModuleNameTest.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventName/test/src/ModuleNameTest.cpp
@@ -9,7 +9,11 @@
 #include "ModuleNameTest.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleNameTest",
     "type_name",         "ModuleNameTest",

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/src/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/src/ModuleName.cpp
@@ -9,7 +9,11 @@
 #include "ModuleName.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleName",
     "type_name",         "ModuleName",

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/test/src/ModuleNameTest.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/eventType/test/src/ModuleNameTest.cpp
@@ -9,7 +9,11 @@
 #include "ModuleNameTest.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleNameTest",
     "type_name",         "ModuleNameTest",

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/src/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/src/ModuleName.cpp
@@ -9,7 +9,11 @@
 #include "ModuleName.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleName",
     "type_name",         "ModuleName",

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/test/src/ModuleNameTest.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/portName/test/src/ModuleNameTest.cpp
@@ -9,7 +9,11 @@
 #include "ModuleNameTest.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleNameTest",
     "type_name",         "ModuleNameTest",

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/src/ModuleName.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/src/ModuleName.cpp
@@ -9,7 +9,11 @@
 #include "ModuleName.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleName",
     "type_name",         "ModuleName",

--- a/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/test/src/ModuleNameTest.cpp
+++ b/jp.go.aist.rtm.rtcbuilder/resource/FSM/stateEntry/test/src/ModuleNameTest.cpp
@@ -9,7 +9,11 @@
 #include "ModuleNameTest.h"
 // Module specification
 // <rtc-template block="module_spec">
+#if RTM_MAJOR_VERSION >= 2
 static const char* const modulename_spec[] =
+#else
+static const char* modulename_spec[] =
+#endif
   {
     "implementation_id", "ModuleNameTest",
     "type_name",         "ModuleNameTest",

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/idl/IdlCMakeLists.txt.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cmake/idl/IdlCMakeLists.txt.vsl
@@ -5,19 +5,8 @@ macro(_IDL_OUTPUTS _idl _dir _result)
 endmacro(_IDL_OUTPUTS)
 
 macro(_COMPILE_IDL _idl_file)
-    if(NOT WIN32)
-        execute_process(COMMAND rtm-config --prefix OUTPUT_VARIABLE OPENRTM_DIR
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-        execute_process(COMMAND rtm-config --idlflags OUTPUT_VARIABLE OPENRTM_IDLFLAGS
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-        separate_arguments(OPENRTM_IDLFLAGS)
-        execute_process(COMMAND rtm-config --idlc OUTPUT_VARIABLE OPENRTM_IDLC
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-        set(_rtm_skelwrapper_command "rtm-skelwrapper")
-    else(NOT WIN32)
-        set(_rtm_skelwrapper_command "rtm-skelwrapper.py")
-    endif(NOT WIN32)
-    get_filename_component(_idl ${_idl_file} NAME_WE)
+
+    get_filename_component(_idl ${dol}{_idl_file} NAME_WE)
     set(_idl_srcs_var ${dol}{_idl}_SRCS)
     _IDL_OUTPUTS(${dol}{_idl} ${dol}{CMAKE_CURRENT_BINARY_DIR} ${dol}{_idl_srcs_var})
 
@@ -26,9 +15,29 @@ macro(_COMPILE_IDL _idl_file)
     else(WIN32)
         set(_python_command "python3")
     endif(WIN32)
+
+    if(${dol}{OPENRTM_VERSION_MAJOR} LESS 2)
+        if(NOT WIN32)
+            execute_process(COMMAND rtm-config --prefix OUTPUT_VARIABLE OPENRTM_DIR
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+            execute_process(COMMAND rtm-config --idlflags OUTPUT_VARIABLE OPENRTM_IDLFLAGS
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+            separate_arguments(OPENRTM_IDLFLAGS)
+            execute_process(COMMAND rtm-config --idlc OUTPUT_VARIABLE OPENRTM_IDLC
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+            set(_rtm_skelwrapper_command "rtm-skelwrapper")
+        else(NOT WIN32)
+            set(_rtm_skelwrapper_command "rtm-skelwrapper.py")
+        endif(NOT WIN32)
+        get_filename_component(_idl ${_idl_file} NAME_WE)
+        set(_idl_srcs_var ${dol}{_idl}_SRCS)
+        _IDL_OUTPUTS(${dol}{_idl} ${dol}{CMAKE_CURRENT_BINARY_DIR} ${dol}{_idl_srcs_var})
+        set(OPENRTM_IDL_WRAPPER ${dol}{_rtm_skelwrapper_command})
+        set(OPENRTM_IDL_WRAPPER_FLAGS --include-dir= --skel-suffix=Skel --stub-suffix=Stub --idl-file=${dol}{_idl}.idl)
+    endif()
  
     add_custom_command(OUTPUT ${dol}{${dol}{_idl_srcs_var}}
-        COMMAND ${dol}{_python_command} ${dol}{OPENRTM_DIR}/bin/${dol}{_rtm_skelwrapper_command} --include-dir= --skel-suffix=Skel --stub-suffix=Stub --idl-file=${dol}{_idl}.idl
+        COMMAND ${dol}{_python_command} ${dol}{OPENRTM_DIR}/bin/${dol}{OPENRTM_IDL_WRAPPER} ${dol}{OPENRTM_IDL_WRAPPER_FLAGS} --idl-file=${dol}{_idl}.idl
         COMMAND ${dol}{OPENRTM_IDLC} ${dol}{OPENRTM_IDLFLAGS} ${dol}{_idl_file}
         WORKING_DIRECTORY ${dol}{CURRENT_BINARY_DIR}
         DEPENDS ${dol}{_idl_file}

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/CXX_RTC.cpp.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/CXX_RTC.cpp.vsl
@@ -11,7 +11,11 @@ ${sharp}include "${rtcParam.name}.h"
 
 // Module specification
 // <rtc-template block="module_spec">
+${sharp}if RTM_MAJOR_VERSION >= 2
 static const char* const ${rtcParam.name.toLowerCase()}_spec[] =
+${sharp}else
+static const char* ${rtcParam.name.toLowerCase()}_spec[] =
+${sharp}endif
   {
     "implementation_id", "${rtcParam.name}",
     "type_name",         "${rtcParam.name}",

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/test/CXX_Test_RTC.cpp.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/cpp/test/CXX_Test_RTC.cpp.vsl
@@ -11,7 +11,11 @@ ${sharp}include "${rtcParam.name}Test.h"
 
 // Module specification
 // <rtc-template block="module_spec">
+${sharp}if RTM_MAJOR_VERSION >= 2
 static const char* const ${rtcParam.name.toLowerCase()}_spec[] =
+${sharp}else
+static const char* ${rtcParam.name.toLowerCase()}_spec[] =
+${sharp}endif
   {
     "implementation_id", "${rtcParam.name}Test",
     "type_name",         "${rtcParam.name}Test",


### PR DESCRIPTION
## Identify the Bug

Link to #474

## Description of the Change

ご連絡を頂きました内容を基に，RTCBuilderで生成するC++ファイルを修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2020-06を使用
- [x] No warnings for the build?  Windows上でEclipse2020-06を使用
- [x] Have you passed the unit tests? 既存のユニットテストを修正し，正常に実行されることを確認