### PR TITLE
Linux環境でのバージョン1.2のopenrtp起動スクリプト更新

### DIFF
--- a/openrtp
+++ b/openrtp
@@ -273,11 +273,12 @@ find_OPENRTP_DIR()
         debug_echo "OPENRTP_DIR: $OPENRTP_DIR"
         if test -f $OPENRTP_DIR/eclipse ; then
             OPENRTP_EXECUTABLE=$OPENRTP_DIR/eclipse
+	    debug_echo "OPENRTP_EXECUTABLE: $OPENRTP_EXECUTABLE"
         else
             echo "WARNING: No OpenRTP installation under OpenRTM libdir."
         fi
     fi
-    openrtp_dir=`find /usr/lib /usr/lib/i386-linux-gnu /usr/lib/x86_64-linux-gnu /usr/lib32 /usr/lib64 -name 'openrtp'  2>/dev/null`
+    openrtp_dir=`find /usr/lib $OPENRTP_DIR /usr/lib32 /usr/lib64 -name 'openrtp'  2>/dev/null`
     eclipse_dir=`find ./ -name 'eclipse'  2>/dev/null`
 
     if test "x$eclipse_dir" != "x" ; then
@@ -290,17 +291,6 @@ find_OPENRTP_DIR()
         echo "ERROR: No OpenRTP installation found. Aborting."
         exit 1
     fi
-    for d in $openrtp_dir ; do
-        if test -f $d/eclipse ; then
-            OPENRTP_DIR=$d
-            OPENRTP_EXECUTABLE="./eclipse"
-            debug_echo "OPENRTP_DIR: $OPENRTP_DIR"
-            debug_echo "OPENRTP_EXECUTABLE: $OPENRTP_EXECUTABLE"
-            return 0
-        fi
-    done
-    echo "ERROR: No OpenRTP installation found. Aborting."
-    exit 1
 }
 #------------------------------
 # main

--- a/packages/deb/debian/changelog
+++ b/packages/deb/debian/changelog
@@ -1,3 +1,9 @@
+openrtp (1.2.2-4) experimental; urgency=low
+
+  * Updated openrtp startup script.
+
+ -- Noriaki Ando <n-ando@aist.go.jp>  Tue, 19 Apr 2022 13:53:28 +0900
+
 openrtp (1.2.2-3) experimental; urgency=low
 
   * Changed Java dependency of deb package to JDK8 only.


### PR DESCRIPTION
close #477 
## Identify the Bug
Link to #477 

## Description of the Change
- openrtp_dir へ openrtp ファイルの場所を入力する処理で、修正前は「/usr/lib/i386-linux-gnu /usr/lib/x86_64-linux-gnu」を検索パスに追加していた
- この処理の直前に、「OPENRTP_DIR=`rtm-config --libdir`/openrtp」を実行しているので、この$OPENRTP_DIRを利用するように変更した
- また、不要なOPENRTP_DIRパス取得処理を削除した



## Verification 
- 動作確認はdebパッケージでインストールしたUbuntu18.04を利用
```
$ dpkg -l | grep openrt
ii  openrtm-aist:amd64                         1.2.2-0
ii  openrtm-aist-dev:amd64                     1.2.2-0
ii  openrtm-aist-doc                           1.2.2-0
ii  openrtm-aist-example:amd64                 1.2.2-0
ii  openrtm-aist-idl:amd64                     1.2.2-0
ii  openrtm2:amd64                             2.0.0-0
ii  openrtm2-dev:amd64                         2.0.0-0
ii  openrtm2-example:amd64                     2.0.0-0
ii  openrtm2-idl:amd64                         2.0.0-0
ii  openrtp:amd64                              1.2.2-4  
```
- openrtp コマンドを実行して、1.2のEclipse4.7.3が起動することを確認
- OpenRTP1.2の全部入りパッケージをHOME下に展開し、openrtp があるディレクトリへ移動し、./openrtp を実行しても起動に問題ないことを確認
- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  