### PR TITLE
[RTSE]ネームサーバ起動コマンドを修正

### DIFF
--- a/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/util/NameServiceProcessHandler.java
+++ b/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/util/NameServiceProcessHandler.java
@@ -13,8 +13,11 @@ public class NameServiceProcessHandler {
 	public static String SCRIPT_WINDOWS = System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "rtm-naming.bat";
 	public static String SCRIPT_WINDOWS_STOP = System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "kill-rtm-naming.bat";
 
-	public static String SCRIPT_UNIX = "/usr/bin/rtm-naming";
-	private String[] UNIX_CANDIDATE_LIST = {"/usr/bin/rtm-naming",
+	public static String SCRIPT_UNIX = "/usr/bin/rtm2-naming";
+	private String[] UNIX_CANDIDATE_LIST = {"/usr/bin/rtm2-naming",
+											"/usr/local/bin/rtm2-naming",
+											System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "rtm2-naming",
+											"/usr/bin/rtm-naming",
 											"/usr/local/bin/rtm-naming",
 											System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "rtm-naming"};
 	


### PR DESCRIPTION
## Identify the Bug

Link to #475

## Description of the Change

Linux環境のネームサーバ起動コマンドに，rtm2-namingを追加し，最初にこのコマンドを探索するように修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2020-06を使用
- [x] No warnings for the build?  Windows上でEclipse2020-06を使用
- [x] Have you passed the unit tests? ユニットテストなし