### PR TITLE
[RTSE]マネージャ起動コマンドを修正

### DIFF
--- a/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/ui/action/StartManagerAction.java
+++ b/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/ui/action/StartManagerAction.java
@@ -21,10 +21,21 @@ public class StartManagerAction implements IViewActionDelegate {
 	private NameServiceView view;
 
 	private static String SCRIPT_WINDOWS = System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "rtcd-cxx-daemon.bat";
-	private static String SCRIPT_LINUX = "/usr/bin/rtcd";
+	
+	private static String SCRIPT_LINUX = "/usr/bin/rtcd2";
+	private String[] UNIX_CANDIDATE_LIST = {"/usr/bin/rtcd2",
+									"/usr/bin/rtcd"};
 
 	public void init(IViewPart view) {
 		this.view = (NameServiceView) view;
+		// find rtcd
+		for(String each :  UNIX_CANDIDATE_LIST) {
+			File targetFile = new File(each);
+			if(targetFile.exists() == true) {
+				SCRIPT_LINUX = each;
+				break;
+			}
+		}
 	}
 
 	public void run(IAction action) {

--- a/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/ui/action/StartManagerAction.java
+++ b/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/ui/action/StartManagerAction.java
@@ -24,7 +24,12 @@ public class StartManagerAction implements IViewActionDelegate {
 	
 	private static String SCRIPT_LINUX = "/usr/bin/rtcd2";
 	private String[] UNIX_CANDIDATE_LIST = {"/usr/bin/rtcd2",
-									"/usr/bin/rtcd"};
+											"/usr/local/bin/rtcd2",
+											System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "rtcd2",
+									"/usr/bin/rtcd",
+									"/usr/local/bin/rtcd",
+									System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "rtcd"};
+
 
 	public void init(IViewPart view) {
 		this.view = (NameServiceView) view;


### PR DESCRIPTION
## Identify the Bug

Link to #482

## Description of the Change

Linux環境のマネージャ起動コマンドに，rtcd2を追加し，最初にこのコマンドを探索するように修正させて頂きました．

ただ，ネームサーバ起動コマンドにつきましては，
　/usr/bin/
　/usr/local/bin/
　System.getenv("RTM_ROOT")/bin/
からコマンドを探すようになっていたのですが，
マネージャ起動コマンドにつきましては，
　/usr/bin/
に存在するという形になっており，
　/usr/local/bin/
　System.getenv("RTM_ROOT")/bin/
の下は見に行かない形となっておりました．
現状では，この形のまま，探索するコマンドのみを増やしております．
もしも，ネームサーバ起動コマンド同様，
　/usr/local/bin/
　System.getenv("RTM_ROOT")/bin/
の下もチェックする形に修正した方が良いようでしたら，ご連絡を頂ければ幸いです．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2020-06を使用
- [x] No warnings for the build?  Windows上でEclipse2020-06を使用
- [x] Have you passed the unit tests? ユニットテストなし