### PR TITLE
[RTSE] Property View のリフレッシュ方法を修正

### DIFF
--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/ui/views/propertysheetview/RtcPropertySheetPage.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/ui/views/propertysheetview/RtcPropertySheetPage.java
@@ -206,6 +206,7 @@ public class RtcPropertySheetPage implements IPropertySheetPage,
 			if (c.isCompositeComponent()) {
 				kind = "composite";
 			}
+			componentView.setVisible(false);
 			componentViewer.setInput(new ComponentWrapper(component));
 			componentViewer.reveal(component);// 表示後、上にスクロールする
 


### PR DESCRIPTION
## Identify the Bug

Link to #484

## Description of the Change

RTSEのPropertyViewの表示更新方法を修正させて頂きました．
ただ，各コンポーネントを最初に選択したタイミングでは，ツリービューを構築する必要があるため，どうしても表示がちらついてしまいます．
同じコンポーネントを再度，選択した場合に，ツリービューを一旦非表示とすることで，表示がちらつかないようにしてみました．

また，propertiesの項目が展開されてしまう現象も確認してみたのですが，上記と同様の理由で，初回選択時は展開されてしまうようでした．

更に，前回のお打ち合わせ時にお話の出ていた，｢同じコンポーネントを選択した際にはツリーを再構築しない｣という処理なのですが，こちらはすでに実装しておりました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2020-06を使用
- [x] No warnings for the build?  Windows上でEclipse2020-06を使用
- [x] Have you passed the unit tests? ユニットテストなし