### PR TITLE
[RTSE]NICのIP変更時のメッセージボックスは1個以上表示しないように修正

### DIFF
--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/SystemDiagramImpl.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/model/component/impl/SystemDiagramImpl.java
@@ -840,6 +840,8 @@ public class SystemDiagramImpl extends ModelElementImpl implements SystemDiagram
 		}
 	}
 
+	private MessageDialog msgDialog = null;
+	
 	void synchronizeRemote() {
 		if (getParentSystemDiagram() == null) {
 			try {
@@ -855,10 +857,15 @@ public class SystemDiagramImpl extends ModelElementImpl implements SystemDiagram
 							Shell shell = PlatformUI.getWorkbench().getWorkbenchWindows()[0].getShell();
 							shell.getDisplay().asyncExec(new Runnable() {
 							    public void run() {
-						            MessageDialog.openError(shell,
-						            		Messages.getString("IPCaution.title"),
-						            		Messages.getString("IPCaution.message01") + " (" + oldAddress + " -> " + currentIP + ")" + System.lineSeparator()
-						            		+ Messages.getString("IPCaution.message02"));
+							    	if(msgDialog != null) {
+							    		msgDialog.close();
+							    	}
+							    	String title = Messages.getString("IPCaution.title");
+							    	String message = Messages.getString("IPCaution.message01") + " (" + oldAddress + " -> " + currentIP + ")" + System.lineSeparator()
+				            							+ Messages.getString("IPCaution.message02");
+							    	String[] buttonLabels = new String[] { "OK" };
+							    	msgDialog = new MessageDialog(shell, title, null, message, MessageDialog.ERROR, buttonLabels, 0);
+							    	msgDialog.open();
 							    }
 							});
 						}
@@ -866,7 +873,7 @@ public class SystemDiagramImpl extends ModelElementImpl implements SystemDiagram
 				}
 			} catch (UnknownHostException e) {
 				e.printStackTrace();
-			}
+			}	
 			
 			for (Component component : getUnmodifiedComponents()) {
 				if (component instanceof CorbaComponentImpl) {


### PR DESCRIPTION
## Identify the Bug

Link to #486

## Description of the Change

IPアドレスが変更された際に，過去に表示したメッセージボックスが残っている場合は，そのメッセージボックスを閉じた後，再度，警告メッセージボックスを表示するように修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2020-06を使用
- [x] No warnings for the build?  Windows上でEclipse2020-06を使用
- [x] Have you passed the unit tests? ユニットテストなし