### PR TITLE
IDLファイルのパース処理を修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/Generator.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/Generator.java
@@ -399,6 +399,14 @@ public class Generator {
 			try {
 				String idlContent = FileUtil.readFile(sv.getName());
 				if (idlContent == null) continue;
+				
+				String[] eachLines = idlContent.split("\r\n");
+				StringBuffer tmpBuf= new StringBuffer();
+				for(String eachLine : eachLines) {
+					tmpBuf.append(eachLine.trim()  + "\r\n");
+			    }
+				idlContent = tmpBuf.toString();
+				
 				List<String> pathList = new ArrayList<String>();
 				for(IdlPathParam path : rtcParam.getIdlSearchPathList()) {
 					pathList.add(path.getPath());

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/Generator.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/Generator.java
@@ -391,6 +391,7 @@ public class Generator {
 		List<ServiceClassParam> result = new ArrayList<ServiceClassParam>();
 		List<String> includeFiles = new ArrayList<String>();
 
+		String lineSeparator = System.getProperty("line.separator");
 		for (int intIdx = 0; intIdx < IDLPathes.size(); intIdx++) {
 			ServiceClassParam sv = IDLPathes.get(intIdx);
 			if (sv == null) continue;
@@ -400,10 +401,10 @@ public class Generator {
 				String idlContent = FileUtil.readFile(sv.getName());
 				if (idlContent == null) continue;
 				
-				String[] eachLines = idlContent.split("\r\n");
+				String[] eachLines = idlContent.split(lineSeparator);
 				StringBuffer tmpBuf= new StringBuffer();
 				for(String eachLine : eachLines) {
-					tmpBuf.append(eachLine.trim()  + "\r\n");
+					tmpBuf.append(eachLine.trim()  + lineSeparator);
 			    }
 				idlContent = tmpBuf.toString();
 				

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/GuiRtcBuilder.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/GuiRtcBuilder.java
@@ -102,6 +102,10 @@ public class GuiRtcBuilder {
 			MessageDialog.openError(PlatformUI.getWorkbench().getDisplay()
 					.getActiveShell(), "Error", e.getMessage());
 			return false;
+		} catch (Error e) {
+			MessageDialog.openError(PlatformUI.getWorkbench().getDisplay()
+					.getActiveShell(), "Error", e.getMessage());
+			return false;
 		}
 	}
 


### PR DESCRIPTION
## Identify the Bug

Link to #487

## Description of the Change

IDLファイルをパースする際に，ファイル内の各行に含まれる余計なスペースを削除してから，パースを行うように修正させて頂きました．

また，IDLファイルのパースに失敗した際に，エラーダイアログを表示するように修正させて頂きました．
(ただし，現状では発生したエラー内容をそのままメッセージとして表示する形になっております)

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2020-06を使用
- [x] No warnings for the build?  Windows上でEclipse2020-06を使用
- [x] Have you passed the unit tests? ユニットテストなし