### PR TITLE
[RTSE]システムロード時にインスタンス名が異なるRTCを区別できるように修正

### DIFF
--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/RestoreComponentDialog.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/RestoreComponentDialog.java
@@ -162,7 +162,7 @@ public class RestoreComponentDialog extends Dialog {
 				ComponentInfo target = new ComponentInfo(comp, targetComp);
 				if(target.getCompRawId() != null && 0 < target.getCompRawId().length()) {
 					for(RTCInfo rtc : rtcList) {
-						if(rtc.compId.equals(target.getCompRawId())) {
+						if(rtc.compId.equals(target.getCompRawId()) && rtc.instanceName.equals(target.getCompName())) {
 							target.setSelectedRTC(rtc.component);
 							break;
 						}
@@ -759,12 +759,14 @@ public class RestoreComponentDialog extends Dialog {
 	public static class RTCInfo {
 		private String compName;
 		private String compId;
+		private String instanceName;
 
 		private CorbaComponent component;
 		
 		public RTCInfo(CorbaComponent comp) {
 			this.component = comp;
 			
+			this.instanceName = comp.getInstanceNameL();
 			this.compId = comp.getComponentId();
 			this.compName = comp.getInstanceNameL();
 		}

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/SystemDiagramEditor.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/editor/SystemDiagramEditor.java
@@ -169,7 +169,7 @@ public class SystemDiagramEditor extends AbstractSystemDiagramEditor {
 								isSkip = true;
 								break;
 							}
-							compIdMap.put(c.getComponentId(), targetComp);
+							compIdMap.put(c.getComponentId() + "_" + c.getInstanceNameL(), targetComp);
 							targetComp = info.getSelectedRTC();
 							if(targetComp == null) {
 								errMsg = info.getStatus();
@@ -301,8 +301,8 @@ public class SystemDiagramEditor extends AbstractSystemDiagramEditor {
 	}
 
 	private void replacePortInfo(Map<String, Component> compIdMap, TargetPortExt port) {
-		if(compIdMap.containsKey(port.getComponentId())) {
-			Component comp = compIdMap.get(port.getComponentId());
+		if(compIdMap.containsKey(port.getComponentId() + "_" + port.getInstanceName())) {
+			Component comp = compIdMap.get(port.getComponentId() + "_" + port.getInstanceName());
 			port.setComponentId(comp.getComponentId());
 			String portName = port.getPortName();
 			portName = portName.replace(port.getInstanceName(), comp.getInstanceNameL());


### PR DESCRIPTION
## Identify the Bug

Link to #492

## Description of the Change

システムロード時に，同じRTCでインスタンス名が異なるものが区別できていなかったので，こちらを区別するように修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2020-06を使用
- [x] No warnings for the build?  Windows上でEclipse2020-06を使用
- [x] Have you passed the unit tests? ユニットテストなし