### PR TITLE
Linux用openrtp2起動スクリプトの修正

### DIFF
--- a/openrtp2
+++ b/openrtp2
@@ -108,24 +108,24 @@ set_RTM_ROOT()
 find_RTM_ROOT()
 {
     debug_echo "TRACE: find_RTM_ROOT"
-    # find RTM_ROOT by rtm-config2
-    rtm_config=`which rtm-config2`
+    # find RTM_ROOT by rtm2-config
+    rtm_config=`which rtm2-config`
     if test "x$rtm_config" = "x" ; then
-        # rtm-config2 not found
+        # rtm2-config not found
         return 1
     fi
-    debug_echo "rtm_config2: " $rtm_config
+    debug_echo "rtm2_config: " $rtm_config
 
     # check rtm-config version
     ver=`grep rtm-idldir $rtm_config`
     if test "x$var" = "x" ; then
         # old version: no --rtm-idldir option
-        RTM_ROOT=`rtm-config2 --cflags | sed -e 's/.*\-I\(\/.*\)\/rtm\/idl/\1/'`
+        RTM_ROOT=`rtm2-config --cflags | sed -e 's/.*\-I\(\/.*\)\/rtm\/idl/\1/'`
         debug_echo "RTM_ROOT: " $RTM_ROOT
         return 0
     else
         # new version: --rtm-idldir available
-        RTM_ROOT=`rtm-config2 --rtm-idldir | sed -e 's/\/rtm\/idl$//'`
+        RTM_ROOT=`rtm2-config --rtm-idldir | sed -e 's/\/rtm\/idl$//'`
         debug_echo "RTM_ROOT: " $RTM_ROOT
         return 0
     fi
@@ -267,9 +267,9 @@ check_RTM_JAVA_ROOT()
 
 find_OPENRTP_DIR()
 {
-    rtm_config=`which rtm-config2`
+    rtm_config=`which rtm2-config`
     if test "x$rtm_config" != "x" ; then
-        OPENRTP_DIR=`rtm-config2 --libdir`/openrtp
+        OPENRTP_DIR=`rtm2-config --libdir`/openrtp
         debug_echo "OPENRTP_DIR: $OPENRTP_DIR"
         if test -f $OPENRTP_DIR/eclipse ; then
             OPENRTP_EXECUTABLE=$OPENRTP_DIR/eclipse


### PR DESCRIPTION
close #506  
## Identify the Bug
Link to #506 

## Description of the Change
- Issueに記載した変更を行った

## Verification 
- openrtp2は全部入りパッケージを生成して使用。問題なく起動できることを確認した。
- 動作確認はUbuntu20.04を使用
- 環境はC++とJavaの各パッケージの2.0.1版をdpkgコマンドにてインストールしている
```
$ dpkg -l | grep openrt
ii  openrtm2:amd64                             2.0.1-0                             amd64        OpenRTM-aist, RT-Middleware distributed by AIST
ii  openrtm2-dev:amd64                         2.0.1-0                             amd64        OpenRTM-aist headers for development
ii  openrtm2-example:amd64                     2.0.1-0                             amd64        OpenRTM-aist examples
ii  openrtm2-idl:amd64                         2.0.1-0                             amd64        OpenRTM-aist idls for development
ii  openrtm2-java:amd64                        2.0.1-0                             amd64        OpenRTM-aist, RT-Middleware distributed by AIST
ii  openrtm2-java-example:amd64                2.0.1-0                             amd64        OpenRTM-aist-Java examples
```
- openrtp2スクリプトをDEBUGモードで実行し、rtm2-config のコマンド名に変更して問題なくパスを取得できていることを確認した
```
Debug mode enable.
ECLIPSE_ARGS: 
RTM_ROOT is not set.
TRACE: find_RTM_ROOT
rtm2_config:  /bin/rtm2-config
RTM_ROOT:  /usr/include/openrtm-2.0
TRACE: check_RTM_ROOT
Finding IDL files under:  /usr/include/openrtm-2.0/
idl_path:  /usr/include/openrtm-2.0/rtm/idl/BasicDataType.idl
idl_path:  /usr/include/openrtm-2.0/rtm/idl/ExtendedDataTypes.idl
idl_path:  /usr/include/openrtm-2.0/rtm/idl/InterfaceDataTypes.idl
Result: RTM_ROOT =  /usr/include/openrtm-2.0
  RTM_ROOT     :  /usr/include/openrtm-2.0
TRACE: set_RTM_JAVA_ROOT
TRACE: check_RTM_JAVA_ROOT
jar_file:  /usr/lib/x86_64-linux-gnu/openrtm-2.0/jar/OpenRTM-aist-2.0.1.jar
Result: RTM_JAVA_ROOT =  /usr/lib/x86_64-linux-gnu/openrtm-2.0
  RTM_JAVA_ROOT     :  /usr/lib/x86_64-linux-gnu/openrtm-2.0
OPENRTP_DIR: /usr/lib/x86_64-linux-gnu/openrtm-2.0/openrtp
WARNING: No OpenRTP installation under OpenRTM libdir.
OPENRTP_DIR: ./
OPENRTP_EXECUTABLE: ./eclipse
```