### PR TITLE
[RTSE]RTCから取得したインターフェース型名の前方の空白を削除

### DIFF
--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
@@ -1191,7 +1191,7 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 		String interfaceType = targetPort.getInterfaceType();
 		String[] ifTypes = interfaceType.split(",");
 		for(String each : ifTypes) {
-			propertyList.put(each, new ArrayList<DataConnectorCreaterDialog.PropertyElem>());
+			propertyList.put(each.trim(), new ArrayList<DataConnectorCreaterDialog.PropertyElem>());
 		}
 		
 		List<String> portType = new ArrayList<String>();

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
@@ -323,7 +323,7 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 				.isAllowAnyInterfaceType(outport, inport) ? Messages.getString("DataConnectorCreaterDialog.2") : ""); //$NON-NLS-1$ //$NON-NLS-2$
 		
 		Label serializerTypeLabel = new Label(portProfileEditComposite, SWT.NONE);
-		serializerTypeLabel.setText("marshaling Type :"); //$NON-NLS-1$
+		serializerTypeLabel.setText("Marshaling Type :"); //$NON-NLS-1$
 		style = ConnectorUtil.isAllowAnyDataType(outport, inport) ? SWT.DROP_DOWN
 				: SWT.DROP_DOWN | SWT.READ_ONLY;
 		serializerTypeCombo = new Combo(portProfileEditComposite, style);

--- a/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/util/ConnectorUtil.java
+++ b/jp.go.aist.rtm.toolscommon/src/jp/go/aist/rtm/toolscommon/util/ConnectorUtil.java
@@ -208,7 +208,8 @@ public class ConnectorUtil {
 		String serializers = target.getProperty("dataport.marshaling_types");
 		if(serializers!=null && 0<serializers.length()) {
 			String[] serArray = serializers.split(",");
-			result = Arrays.asList(serArray);
+			result = new ArrayList<String>(serArray.length);
+			for (String item : serArray) result.add(item.trim());
 			result.sort( (a, b) -> a.length() == b.length() ? a.compareTo(b) : b.length() - a.length());
 		}
 		return result;


### PR DESCRIPTION
## Identify the Bug

Link to #508

## Description of the Change

ポートプロファイルのdataport.interface_typeを取得する際に，型名の前のスペースを削除するように修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2020-06を使用
- [x] No warnings for the build?  Windows上でEclipse2020-06を使用
- [x] Have you passed the unit tests? ユニットテストなし