### PR TITLE
[RTCB]IDLパスの設定方法を修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/util/ValidationUtil.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/util/ValidationUtil.java
@@ -89,7 +89,7 @@ public class ValidationUtil {
 			if(0<ifparam.getIdlDispFile().length()) {
 				String dispFile = ifparam.getIdlDispFile();
 				if(dispFile.startsWith("<RTM_ROOT>")) {
-					String idlFile = dispFile.replace("<RTM_ROOT>" + System.getProperty("file.separator"), System.getenv("RTM_ROOT"));
+					String idlFile = dispFile.replace("<RTM_ROOT>", System.getenv("RTM_ROOT"));
 					ifparam.setIdlFile(idlFile);
 				} else {
 					if(outputProject!=null && 0<outputProject.length()) {


### PR DESCRIPTION
## Identify the Bug

Link to #511

## Description of the Change

デフォルトでインストールされているIDLファイルを使用した際，<RTM_ROOT>というタグを使用してIDLのパスを保存しているのですが，このタグから実際のパスに戻す際に，パス区切り文字を余計に削除してしまっていたため，こちらを修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows/Ubuntu20.04上でEclipse2020-06を使用
- [x] No warnings for the build?  Windows/Ubuntu20.04上でEclipse2020-06を使用
- [x] Have you passed the unit tests? ユニットテストを修正