### PR TITLE
[RTCB] Python RTCのcmake policy設定を修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/cmake/CMakeLists.txt.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.python/src/jp/go/aist/rtm/rtcbuilder/python/template/cmake/CMakeLists.txt.vsl
@@ -1,10 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
-if(POLICY CMP0040)
-  cmake_policy(SET CMP0040 OLD)
-endif()
-if(POLICY CMP0053)
-  cmake_policy(SET CMP0053 OLD)
-endif()
+cmake_minimum_required(VERSION 3.5.1)
 
 project(${rtcParam.name})
 string(TOLOWER ${dol}{PROJECT_NAME} PROJECT_NAME_LOWER)


### PR DESCRIPTION
## Identify the Bug

Link to #389

## Description of the Change

ご連絡を頂きました内容で，cmake policyの部分を修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2020-06を使用
- [x] No warnings for the build?  Windows上でEclipse2020-06を使用
- [x] Have you passed the unit tests? ユニットテストを修正