### PR TITLE
[RTSE]ネームサービスコマンド認識機能を修正

### DIFF
--- a/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/ui/action/StartManagerAction.java
+++ b/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/ui/action/StartManagerAction.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import jp.go.aist.rtm.nameserviceview.ui.views.nameserviceview.NameServiceView;
+import jp.go.aist.rtm.nameserviceview.util.NameServiceProcessHandler;
 import jp.go.aist.rtm.toolscommon.model.manager.RTCManager;
 import jp.go.aist.rtm.toolscommon.util.AdapterUtil;
 
@@ -22,25 +23,12 @@ public class StartManagerAction implements IViewActionDelegate {
 
 	private static String SCRIPT_WINDOWS = System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "rtcd-cxx-daemon.bat";
 	
-	private static String SCRIPT_LINUX = "/usr/bin/rtcd2";
-	private String[] UNIX_CANDIDATE_LIST = {"/usr/bin/rtcd2",
-											"/usr/local/bin/rtcd2",
-											System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "rtcd2",
-									"/usr/bin/rtcd",
-									"/usr/local/bin/rtcd",
-									System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "rtcd"};
-
+	private static String SCRIPT_LINUX = "";
 
 	public void init(IViewPart view) {
 		this.view = (NameServiceView) view;
 		// find rtcd
-		for(String each :  UNIX_CANDIDATE_LIST) {
-			File targetFile = new File(each);
-			if(targetFile.exists() == true) {
-				SCRIPT_LINUX = each;
-				break;
-			}
-		}
+		SCRIPT_LINUX = NameServiceProcessHandler.searchCommand("rtcd2");
 	}
 
 	public void run(IAction action) {
@@ -92,6 +80,10 @@ public class StartManagerAction implements IViewActionDelegate {
 			target = SCRIPT_WINDOWS;
 		} else {
 			target = SCRIPT_LINUX;
+			if(target == null || target.length()==0) {
+				action.setEnabled(false);
+				return;
+			}
 		}
 		File targetFile = new File(target);
 		if(targetFile.exists()==false) {

--- a/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/ui/action/StartNameServiceAction.java
+++ b/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/ui/action/StartNameServiceAction.java
@@ -73,6 +73,10 @@ public class StartNameServiceAction implements IViewActionDelegate {
 			}
 
 		} else {
+			if(NameServiceProcessHandler.SCRIPT_UNIX == null || NameServiceProcessHandler.SCRIPT_UNIX.length() == 0) {
+				action.setEnabled(false);
+				return;
+			}
 			File targetFile = new File(NameServiceProcessHandler.SCRIPT_UNIX);
 			if(targetFile.exists()==false) {
 				action.setEnabled(false);

--- a/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/ui/action/StopNameServiceAction.java
+++ b/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/ui/action/StopNameServiceAction.java
@@ -40,6 +40,10 @@ public class StopNameServiceAction implements IViewActionDelegate {
 			target = NameServiceProcessHandler.SCRIPT_WINDOWS_STOP; 
 		} else {
 			target = NameServiceProcessHandler.SCRIPT_UNIX;
+			if(target == null || target.length() == 0) {
+				action.setEnabled(false);
+				return;
+			}
 		}
 		File targetFile = new File(target);
 		if(targetFile.exists()==false) {

--- a/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/util/NameServiceProcessHandler.java
+++ b/jp.go.aist.rtm.nameserviceview/src/jp/go/aist/rtm/nameserviceview/util/NameServiceProcessHandler.java
@@ -1,7 +1,8 @@
 package jp.go.aist.rtm.nameserviceview.util;
 
-import java.io.File;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.dialogs.Dialog;
@@ -13,23 +14,11 @@ public class NameServiceProcessHandler {
 	public static String SCRIPT_WINDOWS = System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "rtm-naming.bat";
 	public static String SCRIPT_WINDOWS_STOP = System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "kill-rtm-naming.bat";
 
-	public static String SCRIPT_UNIX = "/usr/bin/rtm2-naming";
-	private String[] UNIX_CANDIDATE_LIST = {"/usr/bin/rtm2-naming",
-											"/usr/local/bin/rtm2-naming",
-											System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "rtm2-naming",
-											"/usr/bin/rtm-naming",
-											"/usr/local/bin/rtm-naming",
-											System.getenv("RTM_ROOT") + "bin" + Path.SEPARATOR + "rtm-naming"};
+	public static String SCRIPT_UNIX = "";
 	
 	public void initialize() {
 		// find rtm-naming
-		for(String each :  UNIX_CANDIDATE_LIST) {
-			File targetFile = new File(each);
-			if(targetFile.exists() == true) {
-				SCRIPT_UNIX = each;
-				break;
-			}
-		}
+		SCRIPT_UNIX = searchCommand("rtm2-naming");
 	}
 	
 	public String stopNameService(NameServiceView view, boolean isWindows) {
@@ -74,6 +63,20 @@ public class NameServiceProcessHandler {
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
+	}
+	
+	public static String searchCommand(String target) {
+		String result = "";
+		try {
+			String command = "which " + target;
+			Process process = Runtime.getRuntime().exec(command);
+			
+			BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+			result = reader.readLine();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return result;
 	}
 
 }


### PR DESCRIPTION
## Identify the Bug

Link to #517

## Description of the Change

ご連絡を頂きました内容を基に，Windows以外で動作している場合の各種コマンドの認識処理を修正させて頂きました．
具体的には，ネームサービスコマンドにつきましては，whichコマンドで｢rtm2-naming｣を探す形としております．
また，マネージャにつきましても，whichコマンドで｢rtcd2｣を探す形としております．
どちらも，whichコマンドで対象ファイルが見つからなかった場合には，対象ボタンをDisableにするようにしております．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2020-06を使用
- [x] No warnings for the build?  Windows上でEclipse2020-06を使用
- [x] Have you passed the unit tests? ユニットテストなし