### PR TITLE
jp.go.aist.rtm.systemeditor.RCPのJARファイルのバージョン番号を2.0.2へ更新

### DIFF
--- a/jp.go.aist.rtm.systemeditor.RCP/META-INF/MANIFEST.MF
+++ b/jp.go.aist.rtm.systemeditor.RCP/META-INF/MANIFEST.MF
@@ -2,15 +2,15 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: jp.go.aist.rtm.systemeditor.RCP; singleton:=true
-Bundle-Version: 2.0.0
+Bundle-Version: 2.0.2
 Bundle-Activator: jp.go.aist.rtm.systemeditor.rcp.SystemEditorActivator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- jp.go.aist.rtm.nameserviceview;bundle-version="2.0.0",
- jp.go.aist.rtm.repositoryView;bundle-version="2.0.0",
- jp.go.aist.rtm.systemeditor;bundle-version="2.0.0",
- jp.go.aist.rtm.toolscommon;bundle-version="2.0.0",
- jp.go.aist.rtm.toolscommon.profiles;bundle-version="2.0.0"
+ jp.go.aist.rtm.nameserviceview;bundle-version="2.0.2",
+ jp.go.aist.rtm.repositoryView;bundle-version="2.0.2",
+ jp.go.aist.rtm.systemeditor;bundle-version="2.0.2",
+ jp.go.aist.rtm.toolscommon;bundle-version="2.0.2",
+ jp.go.aist.rtm.toolscommon.profiles;bundle-version="2.0.2"
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
 Export-Package: jp.go.aist.rtm.systemeditor.rcp


### PR DESCRIPTION
close #528 
## Identify the Bug
Link to #528

## Description of the Change
Issueに記載の通り、jp.go.aist.rtm.systemeditor.RCP/META-INF/MANIFEST.MF に記載されているバージョン番号を2.0.2へ更新した。

## Verification 
- 修正ソースからWindows用msiに含めるRCP版RTSEのビルドで、RCPプラグインの2.0.2版jarファイルが生成されることを確認した。（jp.go.aist.rtm.systemeditor.RCP_2.0.2.jar）
- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  