### PR TITLE
openrtp2スクリプトで環境変数RTM_ROOTを設定するように修正

### DIFF
--- a/openrtp2
+++ b/openrtp2
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# RTM_ROOT
+#
+# This is used to find IDL files. Default IDL file directory is
+# $RTM_ROOT/rtm/idl (in Windows)
+# In the generic Linux environment, IDL directory is
+# $prefix/include/openrtm-x.y/rtm/idl
+# Therefore RTM_ROOT should be $prefix/include/openrtm-x.y
+#
+
 cd $(cd $(dirname $(readlink -f $0 || echo $0));pwd -P)
 
 debug_echo () {
@@ -46,6 +55,99 @@ done
 debug_echo "Debug mode enable."
 debug_echo "ECLIPSE_ARGS: $ECLIPSE_ARGS"
 
+#------------------------------------------------------------
+# set_RTM_ROOT
+#
+# This functions set RTM_ROOT environmental variable
+# 1. If RTM_ROOT is set, it checks RTM_ROOT validity.
+# 2. If it is not set, find IDL file by using rtm-config
+#    and set valid RTM_ROOT.
+#------------------------------------------------------------
+set_RTM_ROOT()
+{
+    if test "x$RTM_ROOT" = "x"; then
+        debug_echo "RTM_ROOT is not set."
+        find_RTM_ROOT
+        if test "x$RTM_ROOT" = "x" ; then
+            debug_echo "No OpenRTM-aist (C++) installed found."
+            debug_echo ""
+            return 1
+        fi
+    fi
+
+    # Now RTM_ROOT is set
+    check_RTM_ROOT
+    if test $? != 0 ; then
+        debug_echo ""
+        debug_echo "WARNING: Invalid RTM_ROOT"
+        debug_echo "    Environmental variable RTM_ROOT = $RTM_ROOT is invalid."
+        debug_echo "    Please check OpenRTM-aist C++ installation."
+        debug_echo "  ex."
+        debug_echo "    If BasicDataType.idl exists under:"
+        debug_echo "                       /usr/include/openrtm-2.0/rtm/idl/"
+        debug_echo "    RTM_ROOT should be /usr/include/openrtm-2.0"
+        debug_echo ""
+        return 1
+    fi
+    debug_echo "Result: RTM_ROOT = " $RTM_ROOT
+    export RTM_ROOT=$RTM_ROOT
+}
+
+#------------------------------------------------------------
+# find_RTM_ROOT
+#------------------------------------------------------------
+find_RTM_ROOT()
+{
+    debug_echo "TRACE: find_RTM_ROOT"
+    # find RTM_ROOT by rtm2-config
+    rtm_config=`which rtm2-config`
+    if test "x$rtm_config" = "x" ; then
+        # rtm2-config not found
+        return 1
+    fi
+    debug_echo "rtm2_config: " $rtm_config
+
+    # check rtm-config version
+    ver=`grep rtm-idldir $rtm_config`
+    if test "x$var" = "x" ; then
+        # old version: no --rtm-idldir option
+        RTM_ROOT=`rtm2-config --cflags | sed -e 's/.*\-I\(\/.*\)\/rtm\/idl/\1/'`
+        debug_echo "RTM_ROOT: " $RTM_ROOT
+        return 0
+    else
+        # new version: --rtm-idldir available
+        RTM_ROOT=`rtm2-config --rtm-idldir | sed -e 's/\/rtm\/idl$//'`
+        debug_echo "RTM_ROOT: " $RTM_ROOT
+        return 0
+    fi
+}
+
+#------------------------------------------------------------
+# check_RTM_ROOT
+#
+# This function check if RTM_ROOT environmental variable is valid.
+#
+#------------------------------------------------------------
+check_RTM_ROOT()
+{
+    debug_echo "TRACE: check_RTM_ROOT"
+    idl_files="BasicDataType.idl ExtendedDataTypes.idl InterfaceDataTypes.idl"
+    idl_dir=$RTM_ROOT/
+
+    debug_echo "Finding IDL files under: " $idl_dir
+    for idl in $idl_files; do
+        idl_path=`find $RTM_ROOT -name $idl`
+        debug_echo "idl_path: " $idl_path
+        if test "x$idl_path" = "x" ; then
+            debug_echo "IDL file: " $idl " not found under \$RTM_ROOT"
+            debug_echo "\$RTM_ROOT = " $RTM_ROOT
+            return 1
+        fi
+    done
+    return 0
+}
+
+
 find_OPENRTP_DIR()
 {
     openrtp_dir=`find /usr/lib /usr/lib64 -name 'openrtp'  2>/dev/null`
@@ -73,6 +175,17 @@ find_OPENRTP_DIR()
 #------------------------------
 # main
 #------------------------------
+
+set_RTM_ROOT
+if test $? != 0 ; then
+    echo "WARNING: RTM_ROOT not set."
+    echo "    This might cause failure of data type acquisition for"
+    echo "    data ports definition in RTCBuilder."
+    echo "    If you want use RTCBuilder, please install C++ version"
+    echo "    of OpenRTM-aist on this system."
+else
+    debug_echo "  RTM_ROOT     : " $RTM_ROOT
+fi
 
 find_OPENRTP_DIR
 

--- a/packages/deb/debian/changelog
+++ b/packages/deb/debian/changelog
@@ -1,3 +1,9 @@
+openrtp2 (2.0.2-1) experimental; urgency=low
+
+  * Fixed the openrtp2 script to set RTM_ROOT. 
+
+ -- Noriaki Ando <n-ando@aist.go.jp>   Mon, 17 Jun 2024 16:27:14 +0900
+
 openrtp2 (2.0.2-0) experimental; urgency=low
 
   * 2.0.2-0 (2.0.2-RELEASE). OpenRTP-2.0.2-RELEASE


### PR DESCRIPTION
#521 での修正不具合対応
- この時の修正は、C++版、Java版がインストールされていない環境でも openrtp2 コマンドで起動することを目指した
  - このため、環境変数RTM_ROOTとRTM_JAVA_ROOTの設定処理を外した
- RTM_ROOTの定義を外したことで、C++版、Java版がインストールされている環境でRTCBで新規RTC作成時、データ型一覧リストが表示されない

## Description of the Change
- RTM_ROOTの設定を復活させた
  - rtm2-configを利用し、RTM_ROOTに /usr/include/openrtm-2.0 をセット
  - ただし、rtm2-configがインストールされていない環境でもopenrtp2で起動できるようにした
   （rtm2-configがインストールされていない環境はRTSEとしてのみ使用を想定）
- RTM_JAVA_ROOTはopenrtm2-javaのインストール時に環境変数として設定されるため、openrtp2スクリプト内での定義は不要のため復活させてない
- 今回の修正で、debパッケージのバージョンを 2.0.2-1 へ更新

## Verification 

- OpenRTPの各2.0.2-1版debパッケージをテスト用パッケージリポジトリに配置し、aptでインストール
- OpenRTPのみ（他のOpenRTMパッケージがインストールされていない）のUbuntu20.04環境で、openrtp2コマンドで起動できることを確認
- OpenRTPを含むOpenRTMパッケージ全てをインストールしているUbuntu22.04環境で、openrtp2コマンドで起動し、RTCBでC++、JavaのRTCを作成できることを確認（データポート定義時データ型一覧は表示される）
- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  