### PR TITLE
RCP版RTSEのRCPプラグインバージョンを2.1.0へ更新

### DIFF
--- a/jp.go.aist.rtm.systemeditor.RCP/META-INF/MANIFEST.MF
+++ b/jp.go.aist.rtm.systemeditor.RCP/META-INF/MANIFEST.MF
@@ -2,15 +2,15 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: jp.go.aist.rtm.systemeditor.RCP; singleton:=true
-Bundle-Version: 2.0.2
+Bundle-Version: 2.1.0
 Bundle-Activator: jp.go.aist.rtm.systemeditor.rcp.SystemEditorActivator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- jp.go.aist.rtm.nameserviceview;bundle-version="2.0.2",
- jp.go.aist.rtm.repositoryView;bundle-version="2.0.2",
- jp.go.aist.rtm.systemeditor;bundle-version="2.0.2",
- jp.go.aist.rtm.toolscommon;bundle-version="2.0.2",
- jp.go.aist.rtm.toolscommon.profiles;bundle-version="2.0.2"
+ jp.go.aist.rtm.nameserviceview;bundle-version="2.1.0",
+ jp.go.aist.rtm.repositoryView;bundle-version="2.1.0",
+ jp.go.aist.rtm.systemeditor;bundle-version="2.1.0",
+ jp.go.aist.rtm.toolscommon;bundle-version="2.1.0",
+ jp.go.aist.rtm.toolscommon.profiles;bundle-version="2.1.0"
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
 Export-Package: jp.go.aist.rtm.systemeditor.rcp


### PR DESCRIPTION
close #548 

Link to #548 

## Description of the Change
Issueに記載の通り、jp.go.aist.rtm.systemeditor.RCP/META-INF/MANIFEST.MF に記載されているバージョン番号を2.1.0へ更新した。

## Verification 
- 修正ソースからWindows用msiに含めるRCP版RTSEのビルドで、RCPプラグインの2.1.0版jarファイルが生成されることを確認した。（jp.go.aist.rtm.systemeditor.RCP_2.1.0.jar）
- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  