### PR TITLE
[RTSE]ポートの接続方向を指定できるように修正

### DIFF
--- a/jp.go.aist.rtm.systemeditor.nl1/src/jp/go/aist/rtm/systemeditor/nl/messages_ja.properties
+++ b/jp.go.aist.rtm.systemeditor.nl1/src/jp/go/aist/rtm/systemeditor/nl/messages_ja.properties
@@ -94,8 +94,8 @@ ServiceConnectorCreaterDialog.combo.direction0=
 ServiceConnectorCreaterDialog.combo.direction1=\u2192
 ServiceConnectorCreaterDialog.combo.direction2=\u306b\u63a5\u7d9a\u3059\u308b
 
-ServiceConnectorCreaterDialog.label.direction1_1=ServicePort
-ServiceConnectorCreaterDialog.label.direction1_2=\u304b\u3089ServicePort
+ServiceConnectorCreaterDialog.label.direction1_1=
+ServiceConnectorCreaterDialog.label.direction1_2=\u304b\u3089
 ServiceConnectorCreaterDialog.label.direction1_3=\u306b\u30a2\u30af\u30bb\u30b9\u53ef\u80fd\u3067\u306a\u3044\u3068\u63a5\u7d9a\u306b\u5931\u6557\u3059\u308b\u5834\u5408\u304c\u3042\u308a\u307e\u3059\u3002
 ServiceConnectorCreaterDialog.label.direction2_1=
 ServiceConnectorCreaterDialog.label.direction2_2=\u304b\u3089

--- a/jp.go.aist.rtm.systemeditor.nl1/src/jp/go/aist/rtm/systemeditor/nl/messages_ja.properties
+++ b/jp.go.aist.rtm.systemeditor.nl1/src/jp/go/aist/rtm/systemeditor/nl/messages_ja.properties
@@ -51,15 +51,24 @@ ConnectorCreaterDialogBase.0=\u30d7\u30ed\u30d1\u30c6\u30a3\u540d\u304c\u91cd\u8
 ConnectorCreaterDialogBase.1=ConnectorProfile\u3092\u5165\u529b\u3057\u3066\u304f\u3060\u3055\u3044\u3002
 
 DataConnectorCreaterDialog.2=*\u4efb\u610f\u5165\u529b\u53ef
-DataConnectorCreaterDialog.19=Push Rate\u306f\u6b63\u306e\u6570\u5024\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
-DataConnectorCreaterDialog.22=\u8a73\u7d30...
-DataConnectorCreaterDialog.30=Skip count \u306f\u6b63\u306e\u6574\u6570\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
-DataConnectorCreaterDialog.31=Outport buffer length \u306f\u6b63\u306e\u6574\u6570\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
-DataConnectorCreaterDialog.32=Outport buffer write timeout \u306f\u6b63\u306e\u6570\u5024\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
-DataConnectorCreaterDialog.33=Outport buffer read timeout \u306f\u6b63\u306e\u6570\u5024\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
-DataConnectorCreaterDialog.34=Inport buffer length \u306f\u6b63\u306e\u6574\u6570\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
-DataConnectorCreaterDialog.35=Inport buffer write timeout \u306f\u6b63\u306e\u6570\u5024\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
-DataConnectorCreaterDialog.36=Inport buffer read timeout \u306f\u6b63\u306e\u6570\u5024\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
+DataConnectorCreaterDialog.msg.push_rate=Push Rate\u306f\u6b63\u306e\u6570\u5024\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
+DataConnectorCreaterDialog.msg.skip_count=Skip count \u306f\u6b63\u306e\u6574\u6570\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
+DataConnectorCreaterDialog.msg.outport_buff_length=Outport buffer length \u306f\u6b63\u306e\u6574\u6570\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
+DataConnectorCreaterDialog.msg.outport_write_timeout=Outport buffer write timeout \u306f\u6b63\u306e\u6570\u5024\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
+DataConnectorCreaterDialog.msg.outport_read_timeout=Outport buffer read timeout \u306f\u6b63\u306e\u6570\u5024\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
+DataConnectorCreaterDialog.msg.inport_buff_length=Inport buffer length \u306f\u6b63\u306e\u6574\u6570\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
+DataConnectorCreaterDialog.msg.inport_write_timeout=Inport buffer write timeout \u306f\u6b63\u306e\u6570\u5024\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
+DataConnectorCreaterDialog.msg.inport_read_timeout=Inport buffer read timeout \u306f\u6b63\u306e\u6570\u5024\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
+DataConnectorCreaterDialog.combo.direction1=InPort \u2192 OutPort \u306b\u63a5\u7d9a\u3059\u308b
+DataConnectorCreaterDialog.combo.direction2=OutPort \u2192 InPort \u306b\u63a5\u7d9a\u3059\u308b
+
+DataConnectorCreaterDialog.label.direction1_1=InPort
+DataConnectorCreaterDialog.label.direction1_2=\u304b\u3089OutPort
+DataConnectorCreaterDialog.label.direction1_3=\u306b\u30a2\u30af\u30bb\u30b9\u53ef\u80fd\u3067\u306a\u3044\u3068\u63a5\u7d9a\u306b\u5931\u6557\u3059\u308b\u5834\u5408\u304c\u3042\u308a\u307e\u3059\u3002
+DataConnectorCreaterDialog.label.direction2_1=OutPort
+DataConnectorCreaterDialog.label.direction2_2=\u304b\u3089InPort
+DataConnectorCreaterDialog.label.direction2_3=\u306b\u30a2\u30af\u30bb\u30b9\u53ef\u80fd\u3067\u306a\u3044\u3068\u63a5\u7d9a\u306b\u5931\u6557\u3059\u308b\u5834\u5408\u304c\u3042\u308a\u307e\u3059\u3002
+
 ProfileInformationDialog.4=\u53c2\u7167...
 ProfileInformationDialog.17=\u3059\u3079\u3066\u9078\u629e(&S)
 ProfileInformationDialog.18=\u3059\u3079\u3066\u89e3\u9664(&D)
@@ -75,11 +84,23 @@ DataConnectorCreaterDialog.tab.interface=\u30a4\u30f3\u30bf\u30fc\u30d5\u30a7\u3
 DataConnectorCreaterDialog.tab.properties=\u30d7\u30ed\u30d1\u30c6\u30a3
 
 
-ServiceConnectorCreaterDialog.3=\u4e00\u81f4\u3059\u308b\u30dd\u30fc\u30c8\u30a4\u30f3\u30bf\u30fc\u30d5\u30a7\u30fc\u30b9\u304c\u3042\u308a\u307e\u305b\u3093\u3002
-ServiceConnectorCreaterDialog.4=\u30dd\u30fc\u30c8\u30a4\u30f3\u30bf\u30fc\u30d5\u30a7\u30fc\u30b9\u306e\u4e00\u90e8\u304c\u4e00\u81f4\u3057\u307e\u305b\u3093\u3002
-ServiceConnectorCreaterDialog.11=\u8a73\u7d30...
-ServiceConnectorCreaterDialog.13=\u30a4\u30f3\u30bf\u30fc\u30d5\u30a7\u30fc\u30b9\u306e\u578b\u304c\u4e00\u81f4\u3057\u307e\u305b\u3093\u3002consumer={0} provider={1}
-ServiceConnectorCreaterDialog.14=\u30a4\u30f3\u30bf\u30fc\u30d5\u30a7\u30fc\u30b9\u306e\u30a4\u30f3\u30b9\u30bf\u30f3\u30b9\u540d\u304c\u4e00\u81f4\u3057\u307e\u305b\u3093\u3002consumer={0} provider={1}
+ServiceConnectorCreaterDialog.msg.interface_not_match=\u4e00\u81f4\u3059\u308b\u30dd\u30fc\u30c8\u30a4\u30f3\u30bf\u30fc\u30d5\u30a7\u30fc\u30b9\u304c\u3042\u308a\u307e\u305b\u3093\u3002
+ServiceConnectorCreaterDialog.msg.interface_part_not_match=\u30dd\u30fc\u30c8\u30a4\u30f3\u30bf\u30fc\u30d5\u30a7\u30fc\u30b9\u306e\u4e00\u90e8\u304c\u4e00\u81f4\u3057\u307e\u305b\u3093\u3002
+ServiceConnectorCreaterDialog.detail=\u8a73\u7d30...
+ServiceConnectorCreaterDialog.msg.type_not_match=\u30a4\u30f3\u30bf\u30fc\u30d5\u30a7\u30fc\u30b9\u306e\u578b\u304c\u4e00\u81f4\u3057\u307e\u305b\u3093\u3002consumer={0} provider={1}
+ServiceConnectorCreaterDialog.msg.name_not_match=\u30a4\u30f3\u30bf\u30fc\u30d5\u30a7\u30fc\u30b9\u306e\u30a4\u30f3\u30b9\u30bf\u30f3\u30b9\u540d\u304c\u4e00\u81f4\u3057\u307e\u305b\u3093\u3002consumer={0} provider={1}
+
+ServiceConnectorCreaterDialog.combo.direction0=
+ServiceConnectorCreaterDialog.combo.direction1=\u2192
+ServiceConnectorCreaterDialog.combo.direction2=\u306b\u63a5\u7d9a\u3059\u308b
+
+ServiceConnectorCreaterDialog.label.direction1_1=ServicePort
+ServiceConnectorCreaterDialog.label.direction1_2=\u304b\u3089ServicePort
+ServiceConnectorCreaterDialog.label.direction1_3=\u306b\u30a2\u30af\u30bb\u30b9\u53ef\u80fd\u3067\u306a\u3044\u3068\u63a5\u7d9a\u306b\u5931\u6557\u3059\u308b\u5834\u5408\u304c\u3042\u308a\u307e\u3059\u3002
+ServiceConnectorCreaterDialog.label.direction2_1=ServicePort
+ServiceConnectorCreaterDialog.label.direction2_2=\u304b\u3089ServicePort
+ServiceConnectorCreaterDialog.label.direction2_3=\u306b\u30a2\u30af\u30bb\u30b9\u53ef\u80fd\u3067\u306a\u3044\u3068\u63a5\u7d9a\u306b\u5931\u6557\u3059\u308b\u5834\u5408\u304c\u3042\u308a\u307e\u3059\u3002
+
 ConfigurationDialog.6=\u5236\u7d04\u6761\u4ef6[
 ConfigurationDialog.7=]\u3092\u6e80\u305f\u3057\u3066\u3044\u307e\u305b\u3093\u3002
 ConfigurationDialog.20=\u8b66\u544a

--- a/jp.go.aist.rtm.systemeditor.nl1/src/jp/go/aist/rtm/systemeditor/nl/messages_ja.properties
+++ b/jp.go.aist.rtm.systemeditor.nl1/src/jp/go/aist/rtm/systemeditor/nl/messages_ja.properties
@@ -97,8 +97,8 @@ ServiceConnectorCreaterDialog.combo.direction2=\u306b\u63a5\u7d9a\u3059\u308b
 ServiceConnectorCreaterDialog.label.direction1_1=ServicePort
 ServiceConnectorCreaterDialog.label.direction1_2=\u304b\u3089ServicePort
 ServiceConnectorCreaterDialog.label.direction1_3=\u306b\u30a2\u30af\u30bb\u30b9\u53ef\u80fd\u3067\u306a\u3044\u3068\u63a5\u7d9a\u306b\u5931\u6557\u3059\u308b\u5834\u5408\u304c\u3042\u308a\u307e\u3059\u3002
-ServiceConnectorCreaterDialog.label.direction2_1=ServicePort
-ServiceConnectorCreaterDialog.label.direction2_2=\u304b\u3089ServicePort
+ServiceConnectorCreaterDialog.label.direction2_1=
+ServiceConnectorCreaterDialog.label.direction2_2=\u304b\u3089
 ServiceConnectorCreaterDialog.label.direction2_3=\u306b\u30a2\u30af\u30bb\u30b9\u53ef\u80fd\u3067\u306a\u3044\u3068\u63a5\u7d9a\u306b\u5931\u6557\u3059\u308b\u5834\u5408\u304c\u3042\u308a\u307e\u3059\u3002
 
 ConfigurationDialog.6=\u5236\u7d04\u6761\u4ef6[

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/nl/messages.properties
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/nl/messages.properties
@@ -97,8 +97,8 @@ ServiceConnectorCreaterDialog.combo.direction2=
 ServiceConnectorCreaterDialog.label.direction1_1=If ServicePort
 ServiceConnectorCreaterDialog.label.direction1_2=is not able to access ServicePort
 ServiceConnectorCreaterDialog.label.direction1_3=, the connection may fail.
-ServiceConnectorCreaterDialog.label.direction2_1=If ServicePort
-ServiceConnectorCreaterDialog.label.direction2_2=is not able to access ServicePort
+ServiceConnectorCreaterDialog.label.direction2_1=If 
+ServiceConnectorCreaterDialog.label.direction2_2=is not able to access 
 ServiceConnectorCreaterDialog.label.direction2_3=, the connection may fail.
 
 ConfigurationDialog.6=Constraint [

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/nl/messages.properties
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/nl/messages.properties
@@ -94,8 +94,8 @@ ServiceConnectorCreaterDialog.combo.direction0=Connecting
 ServiceConnectorCreaterDialog.combo.direction1=->
 ServiceConnectorCreaterDialog.combo.direction2=
 
-ServiceConnectorCreaterDialog.label.direction1_1=If ServicePort
-ServiceConnectorCreaterDialog.label.direction1_2=is not able to access ServicePort
+ServiceConnectorCreaterDialog.label.direction1_1=If 
+ServiceConnectorCreaterDialog.label.direction1_2=is not able to access 
 ServiceConnectorCreaterDialog.label.direction1_3=, the connection may fail.
 ServiceConnectorCreaterDialog.label.direction2_1=If 
 ServiceConnectorCreaterDialog.label.direction2_2=is not able to access 

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/nl/messages.properties
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/nl/messages.properties
@@ -51,15 +51,24 @@ ConnectorCreaterDialogBase.0=Duplicate property name.
 ConnectorCreaterDialogBase.1=Please Input Connector Profile.
 
 DataConnectorCreaterDialog.2=*Any input
-DataConnectorCreaterDialog.19=Push Rate must be positive numeric.
-DataConnectorCreaterDialog.22=detail...
-DataConnectorCreaterDialog.30=Skip count must be positive integer.
-DataConnectorCreaterDialog.31=Outport buffer length must be positive integer.
-DataConnectorCreaterDialog.32=Outport buffer write timeout must be positive numeric.
-DataConnectorCreaterDialog.33=Outport buffer read timeout must be positive numeric.
-DataConnectorCreaterDialog.34=Inport buffer length must be positive integer.
-DataConnectorCreaterDialog.35=Inport buffer write timeout must be positive numeric.
-DataConnectorCreaterDialog.36=Inport buffer read timeout must be positive numeric.
+DataConnectorCreaterDialog.msg.push_rate=Push Rate must be positive numeric.
+DataConnectorCreaterDialog.msg.skip_count=Skip count must be positive integer.
+DataConnectorCreaterDialog.msg.outport_buff_length=Outport buffer length must be positive integer.
+DataConnectorCreaterDialog.msg.outport_write_timeout=Outport buffer write timeout must be positive numeric.
+DataConnectorCreaterDialog.msg.outport_read_timeout=Outport buffer read timeout must be positive numeric.
+DataConnectorCreaterDialog.msg.inport_buff_length=Inport buffer length must be positive integer.
+DataConnectorCreaterDialog.msg.inport_write_timeout=Inport buffer write timeout must be positive numeric.
+DataConnectorCreaterDialog.msg.inport_read_timeout=Inport buffer read timeout must be positive numeric.
+DataConnectorCreaterDialog.combo.direction1=Connecting InPort -> OutPort
+DataConnectorCreaterDialog.combo.direction2=Connecting OutPort -> InPort
+
+DataConnectorCreaterDialog.label.direction1_1=If InPort
+DataConnectorCreaterDialog.label.direction1_2= is not able to access OutPort
+DataConnectorCreaterDialog.label.direction1_3=, the connection may fail.
+DataConnectorCreaterDialog.label.direction2_1=If OutPort
+DataConnectorCreaterDialog.label.direction2_2= is not able to access InPort
+DataConnectorCreaterDialog.label.direction2_3=, the connection may fail.
+
 ProfileInformationDialog.4=Browse...
 ProfileInformationDialog.17=&Select All
 ProfileInformationDialog.18=&Deselect All
@@ -75,11 +84,23 @@ DataConnectorCreaterDialog.tab.interface=Interface option
 DataConnectorCreaterDialog.tab.properties=Properties
 
 
-ServiceConnectorCreaterDialog.3=No corresponding port interface.
-ServiceConnectorCreaterDialog.4=Port interfaces do not match completely.
-ServiceConnectorCreaterDialog.11=detail...
-ServiceConnectorCreaterDialog.13=Unmatch interface type consumer={0} provider={1}
-ServiceConnectorCreaterDialog.14=Unmatch interface instance_name consumer={0} provider={1}
+ServiceConnectorCreaterDialog.msg.interface_not_match=No corresponding port interface.
+ServiceConnectorCreaterDialog.msg.interface_part_not_match=Port interfaces do not match completely.
+ServiceConnectorCreaterDialog.detail=detail...
+ServiceConnectorCreaterDialog.msg_type_not_match=Unmatch interface type consumer={0} provider={1}
+ServiceConnectorCreaterDialog.msg.name_not_match=Unmatch interface instance_name consumer={0} provider={1}
+
+ServiceConnectorCreaterDialog.combo.direction0=Connecting
+ServiceConnectorCreaterDialog.combo.direction1=->
+ServiceConnectorCreaterDialog.combo.direction2=
+
+ServiceConnectorCreaterDialog.label.direction1_1=If ServicePort
+ServiceConnectorCreaterDialog.label.direction1_2=is not able to access ServicePort
+ServiceConnectorCreaterDialog.label.direction1_3=, the connection may fail.
+ServiceConnectorCreaterDialog.label.direction2_1=If ServicePort
+ServiceConnectorCreaterDialog.label.direction2_2=is not able to access ServicePort
+ServiceConnectorCreaterDialog.label.direction2_3=, the connection may fail.
+
 ConfigurationDialog.6=Constraint [
 ConfigurationDialog.7=] is not satisfied.
 ConfigurationDialog.20=Warning

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ConnectorDialogBase.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ConnectorDialogBase.java
@@ -6,6 +6,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import jp.go.aist.rtm.systemeditor.nl.Messages;
+import jp.go.aist.rtm.toolscommon.corba.CorbaUtil;
+import jp.go.aist.rtm.toolscommon.model.component.Component;
+import jp.go.aist.rtm.toolscommon.model.component.Port;
 
 import org.eclipse.jface.dialogs.IMessageProvider;
 import org.eclipse.jface.dialogs.TitleAreaDialog;
@@ -152,6 +155,34 @@ public class ConnectorDialogBase extends TitleAreaDialog {
 		return true;
 	}
 	
+	protected String getPortIndo(Port source) {
+		StringBuilder builder = new StringBuilder();
+		
+		String ip = getPortAddress(source);
+		if(ip.length() == 0) return "";
+		
+		builder.append("(");
+		builder.append(source.getNameL());
+		builder.append(":");
+		builder.append(ip);
+		builder.append(")");
+		
+		return builder.toString();
+	}
+	
+	protected String getPortAddress(Port source) {
+		Component component = (Component) source.eContainer();
+		Object first = component.getSynchronizationSupport().getRemoteObjects()[0];
+		if(first instanceof org.omg.CORBA.Object) {
+			org.omg.CORBA.Object corbaObj = (org.omg.CORBA.Object)first;
+			CorbaUtil.IORInfo info = CorbaUtil.getIORInfo(corbaObj);
+			if( 0<info.taggedProfiles.size() ) {
+				return info.taggedProfiles.get(0).host;
+			}
+		}
+		return "";
+	}
+
 	public class AdditionalEntry {
 		private String name;
 		private String value;

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ConnectorDialogBase.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ConnectorDialogBase.java
@@ -155,15 +155,17 @@ public class ConnectorDialogBase extends TitleAreaDialog {
 		return true;
 	}
 	
-	protected String getPortInfo(Port source, boolean withPort) {
+	protected String getPortInfo(Port source, boolean withComp, boolean withPort) {
 		StringBuilder builder = new StringBuilder();
 		
 		String ip = getPortAddress(source, withPort);
 		if(ip.length() == 0) return "";
 		
+		if(withComp) {
+			builder.append(source.getNameL());
+			builder.append(":");
+		}
 		builder.append("(");
-		builder.append(source.getNameL());
-		builder.append(":");
 		builder.append(ip);
 		builder.append(")");
 		

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ConnectorDialogBase.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ConnectorDialogBase.java
@@ -155,10 +155,10 @@ public class ConnectorDialogBase extends TitleAreaDialog {
 		return true;
 	}
 	
-	protected String getPortIndo(Port source, boolean witPort) {
+	protected String getPortInfo(Port source, boolean withPort) {
 		StringBuilder builder = new StringBuilder();
 		
-		String ip = getPortAddress(source, witPort);
+		String ip = getPortAddress(source, withPort);
 		if(ip.length() == 0) return "";
 		
 		builder.append("(");

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ConnectorDialogBase.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ConnectorDialogBase.java
@@ -155,10 +155,10 @@ public class ConnectorDialogBase extends TitleAreaDialog {
 		return true;
 	}
 	
-	protected String getPortIndo(Port source) {
+	protected String getPortIndo(Port source, boolean witPort) {
 		StringBuilder builder = new StringBuilder();
 		
-		String ip = getPortAddress(source);
+		String ip = getPortAddress(source, witPort);
 		if(ip.length() == 0) return "";
 		
 		builder.append("(");
@@ -170,14 +170,18 @@ public class ConnectorDialogBase extends TitleAreaDialog {
 		return builder.toString();
 	}
 	
-	protected String getPortAddress(Port source) {
+	protected String getPortAddress(Port source, boolean witPort) {
 		Component component = (Component) source.eContainer();
 		Object first = component.getSynchronizationSupport().getRemoteObjects()[0];
 		if(first instanceof org.omg.CORBA.Object) {
 			org.omg.CORBA.Object corbaObj = (org.omg.CORBA.Object)first;
 			CorbaUtil.IORInfo info = CorbaUtil.getIORInfo(corbaObj);
 			if( 0<info.taggedProfiles.size() ) {
-				return info.taggedProfiles.get(0).host;
+				if(witPort) {
+					return info.taggedProfiles.get(0).host + " : " + info.taggedProfiles.get(0).port;
+				} else {
+					return info.taggedProfiles.get(0).host;
+				}
 			}
 		}
 		return "";

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
@@ -65,17 +65,6 @@ import jp.go.aist.rtm.toolscommon.util.ConnectorUtil.SerializerInfo;
 public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 	private static final int NAME_WIDTH = 150;
 
-	static final String LABEL_DETAIL = Messages.getString("DataConnectorCreaterDialog.22");
-
-	static final String MSG_ERROR_PUSH_RATE_NOT_NUMERIC = Messages.getString("DataConnectorCreaterDialog.19");
-	static final String MSG_ERROR_SKIP_COUNT_NOT_INTEGER = Messages.getString("DataConnectorCreaterDialog.30");
-	static final String MSG_ERROR_OUTPORT_BUFF_LENGTH_NOT_INTEGER = Messages.getString("DataConnectorCreaterDialog.31");
-	static final String MSG_ERROR_OUTPORT_WRITE_TIMEOUT_NOT_NUMERIC = Messages.getString("DataConnectorCreaterDialog.32");
-	static final String MSG_ERROR_OUTPORT_READ_TIMEOUT_NOT_NUMERIC = Messages.getString("DataConnectorCreaterDialog.33");
-	static final String MSG_ERROR_INPORT_BUFF_LENGTH_NOT_INTEGER = Messages.getString("DataConnectorCreaterDialog.34");
-	static final String MSG_ERROR_INPORT_WRITE_TIMEOUT_NOT_NUMERIC = Messages.getString("DataConnectorCreaterDialog.35");
-	static final String MSG_ERROR_INPORT_READ_TIMEOUT_NOT_NUMERIC = Messages.getString("DataConnectorCreaterDialog.36");
-
 	private static final String NORMAL_COLOR = "NORMAL_COLOR"; // @jve:decl-index=0: //$NON-NLS-1$
 	private static final String ERROR_COLOR = "ERROR_COLOR"; //$NON-NLS-1$
 
@@ -90,6 +79,11 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 	private Combo pushPolicyCombo;
 	private Text skipCountText;
 	private Combo timePolicyCombo;
+	
+	private Combo directionCombo;
+	private Label directionLabel;
+	private String outportIP;
+	private String inportIP;
 
 	private ScrolledComposite propertyScrollArea;
 	
@@ -514,6 +508,108 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 			}
 		});
 		createLabel(portProfileEditComposite, "");
+		
+		//Direction
+		createLabel(portProfileEditComposite, "Connect Direction :");
+		style = SWT.DROP_DOWN | SWT.READ_ONLY;
+		directionCombo = new Combo(portProfileEditComposite, style);
+		gd = new GridData();
+		gd.horizontalAlignment = GridData.FILL;
+		gd.grabExcessHorizontalSpace = true;
+		directionCombo.setLayoutData(gd);
+		if(connectorProfile.isIsReverse()) {
+			directionCombo.add(Messages.getString("DataConnectorCreaterDialog.combo.direction1"));
+			directionCombo.add(Messages.getString("DataConnectorCreaterDialog.combo.direction2"));
+		} else {
+			directionCombo.add(Messages.getString("DataConnectorCreaterDialog.combo.direction2"));
+			directionCombo.add(Messages.getString("DataConnectorCreaterDialog.combo.direction1"));
+		}
+		directionCombo.select(0);
+		directionCombo.addSelectionListener(new SelectionListener() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				int selected = directionCombo.getSelectionIndex();
+				if(selected == 0) {
+					if(connectorProfile.isIsReverse()) {
+						directionLabel.setText(Messages.getString("DataConnectorCreaterDialog.label.direction1_1")
+												+ " "
+												+ inportIP
+												+ " "
+												+ Messages.getString("DataConnectorCreaterDialog.label.direction1_2")
+												+ " "
+												+ outportIP
+												+ " "
+												+ Messages.getString("DataConnectorCreaterDialog.label.direction1_3"));
+					} else {
+						directionLabel.setText(Messages.getString("DataConnectorCreaterDialog.label.direction2_1")
+												+ " "
+												+ outportIP
+												+ " "
+												+ Messages.getString("DataConnectorCreaterDialog.label.direction2_2")
+												+ " "
+												+ inportIP
+												+ " "
+												+ Messages.getString("DataConnectorCreaterDialog.label.direction2_3"));
+					}
+				} else {
+					if(connectorProfile.isIsReverse()) {
+						directionLabel.setText(Messages.getString("DataConnectorCreaterDialog.label.direction2_1")
+								+ " "
+								+ outportIP
+								+ " "
+								+ Messages.getString("DataConnectorCreaterDialog.label.direction2_2")
+								+ inportIP
+								+ " "
+								+ Messages.getString("DataConnectorCreaterDialog.label.direction2_3"));
+					} else {
+						directionLabel.setText(Messages.getString("DataConnectorCreaterDialog.label.direction1_1")
+								+ " "
+								+ inportIP
+								+ " "
+								+ Messages.getString("DataConnectorCreaterDialog.label.direction1_2")
+								+ outportIP
+								+ " "
+								+ Messages.getString("DataConnectorCreaterDialog.label.direction1_3"));
+					}
+				}
+			}
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) {
+			}
+		});
+		createLabel(portProfileEditComposite, "");
+		//
+		createLabel(portProfileEditComposite, "");
+		
+		outportIP = getPortIndo(outport);
+		inportIP = getPortIndo(inport);
+		
+		directionLabel = new Label(portProfileEditComposite, SWT.WRAP);
+		if(connectorProfile.isIsReverse()) {
+			directionLabel.setText(Messages.getString("DataConnectorCreaterDialog.label.direction1_1")
+					+ " "
+					+ inportIP
+					+ " "
+					+ Messages.getString("DataConnectorCreaterDialog.label.direction1_2")
+					+ outportIP
+					+ " "
+					+ Messages.getString("DataConnectorCreaterDialog.label.direction1_3"));
+		} else {
+			directionLabel.setText(Messages.getString("DataConnectorCreaterDialog.label.direction2_1")
+					+ " "
+					+ outportIP
+					+ " "
+					+ Messages.getString("DataConnectorCreaterDialog.label.direction2_2")
+					+ inportIP
+					+ " "
+					+ Messages.getString("DataConnectorCreaterDialog.label.direction2_3"));
+		}
+		gd = new GridData();
+		gd.horizontalAlignment = GridData.FILL;
+		gd.grabExcessHorizontalSpace = true;
+		gd.horizontalSpan = 2;
+		directionLabel.setLayoutData(gd);
+		
 		return portProfileEditComposite;
 	}
 
@@ -1569,6 +1665,11 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 				}
 			}
 		}
+		
+		if(directionCombo.getSelectionIndex() == 1) {
+			connectorProfile.setIsReverse(!connectorProfile.isIsReverse());
+		}
+		
 		if (additionalTableViewer != null) {
 			List<AdditionalEntry> additional = (List<AdditionalEntry>) additionalTableViewer
 					.getInput();
@@ -1627,7 +1728,7 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 			}
 
 			if (!isDouble) {
-				setMessage(MSG_ERROR_PUSH_RATE_NOT_NUMERIC,
+				setMessage(Messages.getString("DataConnectorCreaterDialog.msg.push_rate"),
 						IMessageProvider.ERROR);
 			}
 		}
@@ -1643,7 +1744,7 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 				// void
 			}
 			if (!isInt) {
-				setMessage(MSG_ERROR_SKIP_COUNT_NOT_INTEGER,
+				setMessage(Messages.getString("DataConnectorCreaterDialog.msg.skip_count"),
 						IMessageProvider.ERROR);
 			}
 		}
@@ -1659,7 +1760,7 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 				// void
 			}
 			if (!isInt) {
-				setMessage(MSG_ERROR_OUTPORT_BUFF_LENGTH_NOT_INTEGER,
+				setMessage(Messages.getString("DataConnectorCreaterDialog.msg.outport_buff_length"),
 						IMessageProvider.ERROR);
 			}
 			//
@@ -1674,7 +1775,7 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 					// void
 				}
 				if (!isDouble) {
-					setMessage(MSG_ERROR_OUTPORT_WRITE_TIMEOUT_NOT_NUMERIC,
+					setMessage(Messages.getString("DataConnectorCreaterDialog.msg.outport_write_timeout"),
 							IMessageProvider.ERROR);
 				}
 			}
@@ -1690,7 +1791,7 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 					// void
 				}
 				if (!isDouble) {
-					setMessage(MSG_ERROR_OUTPORT_READ_TIMEOUT_NOT_NUMERIC,
+					setMessage(Messages.getString("DataConnectorCreaterDialog.msg.outport_read_timeout"),
 							IMessageProvider.ERROR);
 				}
 			}
@@ -1707,7 +1808,7 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 				// void
 			}
 			if (!isInt) {
-				setMessage(MSG_ERROR_INPORT_BUFF_LENGTH_NOT_INTEGER,
+				setMessage(Messages.getString("DataConnectorCreaterDialog.msg.inport_buff_length"),
 						IMessageProvider.ERROR);
 			}
 			//
@@ -1722,7 +1823,7 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 					// void
 				}
 				if (!isDouble) {
-					setMessage(MSG_ERROR_INPORT_WRITE_TIMEOUT_NOT_NUMERIC,
+					setMessage(Messages.getString("DataConnectorCreaterDialog.msg.inport_write_timeout"),
 							IMessageProvider.ERROR);
 				}
 			}
@@ -1738,7 +1839,7 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 					// void
 				}
 				if (!isDouble) {
-					setMessage(MSG_ERROR_INPORT_READ_TIMEOUT_NOT_NUMERIC,
+					setMessage(Messages.getString("DataConnectorCreaterDialog.msg.inport_read_timeout"),
 							IMessageProvider.ERROR);
 				}
 			}
@@ -1752,11 +1853,12 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 
 	@Override
 	protected Point getInitialSize() {
-		int height = 500;
+		int height = 530;
+		int width = 560;
 		if(existIFOpt) {
-			height = 800;
+			height = 830;
 		}
-		return getShell().computeSize(SWT.DEFAULT, height, true);
+		return getShell().computeSize(width, height, true);
 	}
 
 }

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
@@ -593,10 +593,10 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 		});
 		createLabel(portProfileEditComposite, "");
 		//
-		String outportIP = getPortIndo(outport, false);
-		String inportIP = getPortIndo(inport, false);
-		String outportIPPort = getPortIndo(outport, true);
-		String inportIPPort = getPortIndo(inport,true);
+		String outportIP = getPortInfo(outport, false);
+		String inportIP = getPortInfo(inport, false);
+		String outportIPPort = getPortInfo(outport, true);
+		String inportIPPort = getPortInfo(inport,true);
 		
 		outport2inPort = Messages.getString("DataConnectorCreaterDialog.label.direction2_1")
 				+ " "

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
@@ -82,8 +82,10 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 	
 	private Combo directionCombo;
 	private Label directionLabel;
-	private String outportIP;
-	private String inportIP;
+	private Label directionLabel2;
+
+	private String outport2inPort;
+	private String inport2outPort;
 
 	private ScrolledComposite propertyScrollArea;
 	
@@ -370,6 +372,31 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 				notifyModified();
 			}
 		});
+		dataflowTypeCombo.addSelectionListener(new SelectionListener() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				int selected = dataflowTypeCombo.getSelectionIndex();
+				int selectedDir = directionCombo.getSelectionIndex();
+				directionLabel2.setText("");
+				if(selected == 0) {
+					if((selectedDir == 0 && connectorProfile.isIsReverse())
+							|| (selectedDir == 1 && connectorProfile.isIsReverse() == false)) {
+						directionLabel2.setText(outport2inPort);
+					}
+				} else {
+					if((selectedDir == 1 && connectorProfile.isIsReverse())
+							|| (selectedDir == 0 && connectorProfile.isIsReverse() == false)) {
+						directionLabel2.setText(inport2outPort);
+					}
+				}
+				directionLabel2.pack();
+				portProfileEditComposite.layout();
+				
+			}
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) {
+			}
+		});
 		Label dataflowTypeFooterLabel = new Label(portProfileEditComposite,
 				SWT.NONE);
 		dataflowTypeFooterLabel.setText(ConnectorUtil
@@ -531,45 +558,32 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 				int selected = directionCombo.getSelectionIndex();
 				if(selected == 0) {
 					if(connectorProfile.isIsReverse()) {
-						directionLabel.setText(Messages.getString("DataConnectorCreaterDialog.label.direction1_1")
-												+ " "
-												+ inportIP
-												+ " "
-												+ Messages.getString("DataConnectorCreaterDialog.label.direction1_2")
-												+ " "
-												+ outportIP
-												+ " "
-												+ Messages.getString("DataConnectorCreaterDialog.label.direction1_3"));
+						directionLabel.setText(inport2outPort);
+						if(dataflowTypeCombo.getSelectionIndex() == 0) {
+							directionLabel2.setText(outport2inPort);
+						} else {
+							directionLabel2.setText("");
+						}
+						directionLabel2.pack();
+						portProfileEditComposite.layout();
 					} else {
-						directionLabel.setText(Messages.getString("DataConnectorCreaterDialog.label.direction2_1")
-												+ " "
-												+ outportIP
-												+ " "
-												+ Messages.getString("DataConnectorCreaterDialog.label.direction2_2")
-												+ " "
-												+ inportIP
-												+ " "
-												+ Messages.getString("DataConnectorCreaterDialog.label.direction2_3"));
+						directionLabel.setText(outport2inPort);
+						directionLabel2.setText("");
 					}
 				} else {
 					if(connectorProfile.isIsReverse()) {
-						directionLabel.setText(Messages.getString("DataConnectorCreaterDialog.label.direction2_1")
-								+ " "
-								+ outportIP
-								+ " "
-								+ Messages.getString("DataConnectorCreaterDialog.label.direction2_2")
-								+ inportIP
-								+ " "
-								+ Messages.getString("DataConnectorCreaterDialog.label.direction2_3"));
+						directionLabel.setText(outport2inPort);
+						directionLabel2.setText("");
+
 					} else {
-						directionLabel.setText(Messages.getString("DataConnectorCreaterDialog.label.direction1_1")
-								+ " "
-								+ inportIP
-								+ " "
-								+ Messages.getString("DataConnectorCreaterDialog.label.direction1_2")
-								+ outportIP
-								+ " "
-								+ Messages.getString("DataConnectorCreaterDialog.label.direction1_3"));
+						directionLabel.setText(inport2outPort);
+						if(dataflowTypeCombo.getSelectionIndex() == 0) {
+							directionLabel2.setText(outport2inPort);
+						} else {
+							directionLabel2.setText("");
+						}
+						directionLabel2.pack();
+						portProfileEditComposite.layout();
 					}
 				}
 			}
@@ -579,36 +593,52 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 		});
 		createLabel(portProfileEditComposite, "");
 		//
+		String outportIP = getPortIndo(outport, false);
+		String inportIP = getPortIndo(inport, false);
+		String outportIPPort = getPortIndo(outport, true);
+		String inportIPPort = getPortIndo(inport,true);
+		
+		outport2inPort = Messages.getString("DataConnectorCreaterDialog.label.direction2_1")
+				+ " "
+				+ outportIP
+				+ " "
+				+ Messages.getString("DataConnectorCreaterDialog.label.direction2_2")
+				+ inportIPPort
+				+ " "
+				+ Messages.getString("DataConnectorCreaterDialog.label.direction2_3");
+		inport2outPort = Messages.getString("DataConnectorCreaterDialog.label.direction1_1")
+				+ " "
+				+ inportIP
+				+ " "
+				+ Messages.getString("DataConnectorCreaterDialog.label.direction1_2")
+				+ outportIPPort
+				+ " "
+				+ Messages.getString("DataConnectorCreaterDialog.label.direction1_3"); 
+		
 		createLabel(portProfileEditComposite, "");
-		
-		outportIP = getPortIndo(outport);
-		inportIP = getPortIndo(inport);
-		
 		directionLabel = new Label(portProfileEditComposite, SWT.WRAP);
 		if(connectorProfile.isIsReverse()) {
-			directionLabel.setText(Messages.getString("DataConnectorCreaterDialog.label.direction1_1")
-					+ " "
-					+ inportIP
-					+ " "
-					+ Messages.getString("DataConnectorCreaterDialog.label.direction1_2")
-					+ outportIP
-					+ " "
-					+ Messages.getString("DataConnectorCreaterDialog.label.direction1_3"));
+			directionLabel.setText(inport2outPort);
 		} else {
-			directionLabel.setText(Messages.getString("DataConnectorCreaterDialog.label.direction2_1")
-					+ " "
-					+ outportIP
-					+ " "
-					+ Messages.getString("DataConnectorCreaterDialog.label.direction2_2")
-					+ inportIP
-					+ " "
-					+ Messages.getString("DataConnectorCreaterDialog.label.direction2_3"));
+			directionLabel.setText(outport2inPort);
 		}
 		gd = new GridData();
 		gd.horizontalAlignment = GridData.FILL;
 		gd.grabExcessHorizontalSpace = true;
 		gd.horizontalSpan = 2;
 		directionLabel.setLayoutData(gd);
+		
+		createLabel(portProfileEditComposite, "");
+		directionLabel2 = new Label(portProfileEditComposite, SWT.WRAP);
+		if(connectorProfile.isIsReverse()) {
+			directionLabel2.setText(outport2inPort);
+		}
+		gd = new GridData();
+		gd.horizontalAlignment = GridData.FILL;
+		gd.grabExcessHorizontalSpace = true;
+		gd.horizontalSpan = 2;
+		directionLabel2.setLayoutData(gd);
+
 		
 		return portProfileEditComposite;
 	}
@@ -1853,7 +1883,7 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 
 	@Override
 	protected Point getInitialSize() {
-		int height = 530;
+		int height = 580;
 		int width = 560;
 		if(existIFOpt) {
 			height = 830;

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/DataConnectorCreaterDialog.java
@@ -593,10 +593,10 @@ public class DataConnectorCreaterDialog extends ConnectorDialogBase {
 		});
 		createLabel(portProfileEditComposite, "");
 		//
-		String outportIP = getPortInfo(outport, false);
-		String inportIP = getPortInfo(inport, false);
-		String outportIPPort = getPortInfo(outport, true);
-		String inportIPPort = getPortInfo(inport,true);
+		String outportIP = getPortInfo(outport, false, false);
+		String inportIP = getPortInfo(inport, false, false);
+		String outportIPPort = getPortInfo(outport, false, true);
+		String inportIPPort = getPortInfo(inport, false, true);
 		
 		outport2inPort = Messages.getString("DataConnectorCreaterDialog.label.direction2_1")
 				+ " "

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ServiceConnectorCreaterDialog.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ServiceConnectorCreaterDialog.java
@@ -45,6 +45,7 @@ import jp.go.aist.rtm.systemeditor.nl.Messages;
 import jp.go.aist.rtm.toolscommon.model.component.Component;
 import jp.go.aist.rtm.toolscommon.model.component.ComponentFactory;
 import jp.go.aist.rtm.toolscommon.model.component.ConnectorProfile;
+import jp.go.aist.rtm.toolscommon.model.component.Port;
 import jp.go.aist.rtm.toolscommon.model.component.PortInterfaceProfile;
 import jp.go.aist.rtm.toolscommon.model.component.ServicePort;
 
@@ -79,6 +80,7 @@ public class ServiceConnectorCreaterDialog extends ConnectorDialogBase {
 
 	private Combo directionCombo;
 	private Label directionLabel;
+	private Label directionLabel2;
 
 	private String firstPort2secondPort;
 	private String secondPort2firstPort;
@@ -308,20 +310,37 @@ public class ServiceConnectorCreaterDialog extends ConnectorDialogBase {
 		directionCombo.addSelectionListener(new SelectionListener() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
+				directionLabel2.setText("");
 				int selected = directionCombo.getSelectionIndex();
 				if(selected == 0) {
+					boolean disp2 = checkInterface(first, second);
 					if(connectorProfile.isIsReverse()) {
 						directionLabel.setText(secondPort2firstPort);
+						if(disp2) {
+							directionLabel2.setText(firstPort2secondPort);
+						}
 					} else {
 						directionLabel.setText(firstPort2secondPort);
+						if(disp2) {
+							directionLabel2.setText(secondPort2firstPort);
+						}
 					}
 				} else {
+					boolean disp2 = checkInterface(second, first);
 					if(connectorProfile.isIsReverse()) {
 						directionLabel.setText(firstPort2secondPort);
+						if(disp2) {
+							directionLabel2.setText(secondPort2firstPort);
+						}
 					} else {
 						directionLabel.setText(secondPort2firstPort);
+						if(disp2) {
+							directionLabel2.setText(firstPort2secondPort);
+						}
 					}
 				}
+				directionLabel2.pack();
+				mainComposite.layout();
 			}
 			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {
@@ -331,10 +350,10 @@ public class ServiceConnectorCreaterDialog extends ConnectorDialogBase {
 		//
 		createLabel(portProfileEditComposite, "");
 		
-		String firstPortIP = getPortIndo(first, false);
-		String secondPortIP = getPortIndo(second, false);
-		String firstPortIPPort = getPortIndo(first, true);
-		String secondPortIPPort = getPortIndo(second, true);
+		String firstPortIP = getPortInfo(first, false);
+		String secondPortIP = getPortInfo(second, false);
+		String firstPortIPPort = getPortInfo(first, true);
+		String secondPortIPPort = getPortInfo(second, true);
 		
 		firstPort2secondPort = Messages.getString("ServiceConnectorCreaterDialog.label.direction2_1")
 								+ firstPortIP
@@ -358,6 +377,21 @@ public class ServiceConnectorCreaterDialog extends ConnectorDialogBase {
 		gd.grabExcessHorizontalSpace = true;
 		gd.horizontalSpan = 2;
 		directionLabel.setLayoutData(gd);
+		//
+		createLabel(portProfileEditComposite, "");
+		directionLabel2 = new Label(portProfileEditComposite, SWT.WRAP);
+		if(checkInterface(first, second)) {
+			if(connectorProfile.isIsReverse()) {
+				directionLabel2.setText(firstPort2secondPort);
+			} else {
+				directionLabel2.setText(secondPort2firstPort);
+			}
+		}
+		gd = new GridData();
+		gd.horizontalAlignment = GridData.FILL;
+		gd.grabExcessHorizontalSpace = true;
+		gd.horizontalSpan = 2;
+		directionLabel2.setLayoutData(gd);
 		//
 		final Button detailCheck = new Button(portProfileEditComposite,
 				SWT.CHECK);
@@ -386,11 +420,24 @@ public class ServiceConnectorCreaterDialog extends ConnectorDialogBase {
 
 		loadData();
 	}
+	
+	private boolean checkInterface(Port first, Port second) {
+		for(PortInterfaceProfile eachSecond : second.getInterfaces()) {
+			if(eachSecond.getPolarity().equals("REQUIRED") == false ) continue;
+			String ifName = eachSecond.getTypeName();
+			for(PortInterfaceProfile eachFirst : first.getInterfaces()) {
+				if(eachFirst.getPolarity().equals("PROVIDED") == false ) continue;
+				if(eachFirst.getTypeName().equals(ifName) == false) continue;
+				return true;
+			}
+		}
+		return false;
+	}
 
 	/**
 	 * 詳細設定の表示部を作成する
 	 */
-	Composite createDetailComposite(Composite parent) {
+	private Composite createDetailComposite(Composite parent) {
 		GridLayout gl;
 		GridData gd;
 
@@ -710,7 +757,7 @@ public class ServiceConnectorCreaterDialog extends ConnectorDialogBase {
 	@Override
 	protected Point getInitialSize() {
 		int width = 600;
-		int height = 280;
+		int height = 330;
 		return getShell().computeSize(width, height, true);
 	}
 

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ServiceConnectorCreaterDialog.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ServiceConnectorCreaterDialog.java
@@ -79,8 +79,9 @@ public class ServiceConnectorCreaterDialog extends ConnectorDialogBase {
 
 	private Combo directionCombo;
 	private Label directionLabel;
-	private String firstPortIP;
-	private String secondPortIP;
+
+	private String firstPort2secondPort;
+	private String secondPort2firstPort;
 
 	private Composite detailComposite;
 
@@ -302,6 +303,7 @@ public class ServiceConnectorCreaterDialog extends ConnectorDialogBase {
 			directionCombo.add(firstItem);
 			directionCombo.add(secondItem);
 		}
+		
 		directionCombo.select(0);
 		directionCombo.addSelectionListener(new SelectionListener() {
 			@Override
@@ -309,31 +311,15 @@ public class ServiceConnectorCreaterDialog extends ConnectorDialogBase {
 				int selected = directionCombo.getSelectionIndex();
 				if(selected == 0) {
 					if(connectorProfile.isIsReverse()) {
-						directionLabel.setText(Messages.getString("ServiceConnectorCreaterDialog.label.direction1_1")
-												+ secondPortIP
-												+ Messages.getString("ServiceConnectorCreaterDialog.label.direction1_2")
-												+ firstPortIP
-												+ Messages.getString("ServiceConnectorCreaterDialog.label.direction1_3"));
+						directionLabel.setText(secondPort2firstPort);
 					} else {
-						directionLabel.setText(Messages.getString("DataConnectorCreaterDialog.label.direction2_1")
-												+ firstPortIP
-												+ Messages.getString("ServiceConnectorCreaterDialog.label.direction2_2")
-												+ secondPortIP
-												+ Messages.getString("ServiceConnectorCreaterDialog.label.direction2_3"));
+						directionLabel.setText(firstPort2secondPort);
 					}
 				} else {
 					if(connectorProfile.isIsReverse()) {
-						directionLabel.setText(Messages.getString("ServiceConnectorCreaterDialog.label.direction2_1")
-								+ firstPortIP
-								+ Messages.getString("ServiceConnectorCreaterDialog.label.direction2_2")
-								+ secondPortIP
-								+ Messages.getString("ServiceConnectorCreaterDialog.label.direction2_3"));
+						directionLabel.setText(firstPort2secondPort);
 					} else {
-						directionLabel.setText(Messages.getString("ServiceConnectorCreaterDialog.label.direction1_1")
-								+ secondPortIP
-								+ Messages.getString("ServiceConnectorCreaterDialog.label.direction1_2")
-								+ firstPortIP
-								+ Messages.getString("ServiceConnectorCreaterDialog.label.direction1_3"));
+						directionLabel.setText(secondPort2firstPort);
 					}
 				}
 			}
@@ -345,22 +331,27 @@ public class ServiceConnectorCreaterDialog extends ConnectorDialogBase {
 		//
 		createLabel(portProfileEditComposite, "");
 		
-		firstPortIP = getPortIndo(first);
-		secondPortIP = getPortIndo(second);
+		String firstPortIP = getPortIndo(first, false);
+		String secondPortIP = getPortIndo(second, false);
+		String firstPortIPPort = getPortIndo(first, true);
+		String secondPortIPPort = getPortIndo(second, true);
 		
+		firstPort2secondPort = Messages.getString("ServiceConnectorCreaterDialog.label.direction2_1")
+								+ firstPortIP
+								+ Messages.getString("ServiceConnectorCreaterDialog.label.direction2_2")
+								+ secondPortIPPort
+								+ Messages.getString("ServiceConnectorCreaterDialog.label.direction2_3");
+		secondPort2firstPort = Messages.getString("ServiceConnectorCreaterDialog.label.direction1_1")
+								+ secondPortIP
+								+ Messages.getString("ServiceConnectorCreaterDialog.label.direction1_2")
+								+ firstPortIPPort
+								+ Messages.getString("ServiceConnectorCreaterDialog.label.direction1_3");
+
 		directionLabel = new Label(portProfileEditComposite, SWT.WRAP);
 		if(connectorProfile.isIsReverse()) {
-			directionLabel.setText(Messages.getString("ServiceConnectorCreaterDialog.label.direction1_1")
-					+ secondPortIP
-					+ Messages.getString("ServiceConnectorCreaterDialog.label.direction1_2")
-					+ firstPortIP
-					+ Messages.getString("ServiceConnectorCreaterDialog.label.direction1_3"));
+			directionLabel.setText(secondPort2firstPort);
 		} else {
-			directionLabel.setText(Messages.getString("ServiceConnectorCreaterDialog.label.direction2_1")
-					+ firstPortIP
-					+ Messages.getString("ServiceConnectorCreaterDialog.label.direction2_2")
-					+ secondPortIP
-					+ Messages.getString("ServiceConnectorCreaterDialog.label.direction2_3"));
+			directionLabel.setText(firstPort2secondPort);
 		}
 		gd = new GridData();
 		gd.horizontalAlignment = GridData.FILL;

--- a/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ServiceConnectorCreaterDialog.java
+++ b/jp.go.aist.rtm.systemeditor/src/jp/go/aist/rtm/systemeditor/ui/dialog/ServiceConnectorCreaterDialog.java
@@ -350,10 +350,10 @@ public class ServiceConnectorCreaterDialog extends ConnectorDialogBase {
 		//
 		createLabel(portProfileEditComposite, "");
 		
-		String firstPortIP = getPortInfo(first, false);
-		String secondPortIP = getPortInfo(second, false);
-		String firstPortIPPort = getPortInfo(first, true);
-		String secondPortIPPort = getPortInfo(second, true);
+		String firstPortIP = getPortInfo(first, true, false);
+		String secondPortIP = getPortInfo(second, true, false);
+		String firstPortIPPort = getPortInfo(first, true, true);
+		String secondPortIPPort = getPortInfo(second, true, true);
 		
 		firstPort2secondPort = Messages.getString("ServiceConnectorCreaterDialog.label.direction2_1")
 								+ firstPortIP


### PR DESCRIPTION
Link to #540

## Description of the Change

#540 でご相談させて頂きました仕様を基に，ポートの接続方向を指定できるように修正させて頂きました．
修正したコネクタプロファイル設定画面を以下に示します．

○DataPortの場合
![image](https://github.com/user-attachments/assets/da409193-bb8f-41a1-85b6-36ebe9f9562b)

○ServicePortの場合
![image](https://github.com/user-attachments/assets/b5112b26-d684-4884-a09f-8cbf0a6eca40)

ServicePortの場合，コンボボックスの内容をどうすれば良いのか迷ったのですが，ポートの名称を表示するようにしております．
また，接続方法設定用コンボボックス，ラベルは，常に表示するようにしております．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2020-06を使用
- [x] No warnings for the build?  Windows上でEclipse2020-06を使用
- [ ] Have you passed the unit tests? ユニットテストなし