### PR TITLE
RTCBの言語選択へProcessingを追加

### DIFF
--- a/build_all
+++ b/build_all
@@ -84,6 +84,7 @@ PROJECTS="jp.go.aist.rtm.toolscommon.profiles
     jp.go.aist.rtm.rtcbuilder.java
     jp.go.aist.rtm.rtcbuilder.python
     jp.go.aist.rtm.rtcbuilder.lua
+    jp.go.aist.rtm.rtcbuilder.processing
     jp.go.aist.rtm.repositoryView
     jp.go.aist.rtm.repositoryView.nl1
     jp.go.aist.rtm.nameserviceview

--- a/build_features
+++ b/build_features
@@ -88,6 +88,7 @@ PROJECTS="jp.go.aist.rtm.toolscommon.profiles
     jp.go.aist.rtm.rtcbuilder.java
     jp.go.aist.rtm.rtcbuilder.python
     jp.go.aist.rtm.rtcbuilder.lua
+    jp.go.aist.rtm.rtcbuilder.processing
     jp.go.aist.rtm.repositoryView
     jp.go.aist.rtm.repositoryView.nl1
     jp.go.aist.rtm.nameserviceview

--- a/build_plugins
+++ b/build_plugins
@@ -81,6 +81,7 @@ PROJECTS="jp.go.aist.rtm.toolscommon.profiles
     jp.go.aist.rtm.rtcbuilder.java
     jp.go.aist.rtm.rtcbuilder.python
     jp.go.aist.rtm.rtcbuilder.lua
+    jp.go.aist.rtm.rtcbuilder.processing
     jp.go.aist.rtm.repositoryView
     jp.go.aist.rtm.repositoryView.nl1
     jp.go.aist.rtm.nameserviceview

--- a/buildall.bat
+++ b/buildall.bat
@@ -20,6 +20,7 @@ set TARGETS=^
 	jp.go.aist.rtm.rtcbuilder.java ^
 	jp.go.aist.rtm.rtcbuilder.python ^
 	jp.go.aist.rtm.rtcbuilder.lua ^
+	jp.go.aist.rtm.rtcbuilder.processing ^
 	jp.go.aist.rtm.repositoryView ^
 	jp.go.aist.rtm.repositoryView.nl1 ^
 	jp.go.aist.rtm.nameserviceview ^

--- a/check_packages
+++ b/check_packages
@@ -19,6 +19,7 @@ PROJECTS="jp.go.aist.rtm.toolscommon.profiles
     jp.go.aist.rtm.rtcbuilder.java
     jp.go.aist.rtm.rtcbuilder.python
     jp.go.aist.rtm.rtcbuilder.lua
+    jp.go.aist.rtm.rtcbuilder.processing
     jp.go.aist.rtm.repositoryView
     jp.go.aist.rtm.repositoryView.nl1
     jp.go.aist.rtm.nameserviceview

--- a/jp.go.aist.rtm.rtcbuilder.processing/build.xml
+++ b/jp.go.aist.rtm.rtcbuilder.processing/build.xml
@@ -1,0 +1,110 @@
+<project name="jp.go.aist.rtm.rtcbuilder.processing" default="jar"
+	xmlns:ant4eclipse="antlib:org.ant4eclipse"
+	xmlns:antcontrib="antlib:net.sf.antcontrib"	>
+
+	<property name="target.name" value="jp.go.aist.rtm.rtcbuilder.processing" />
+
+	<taskdef name="manifesttask" classname="aist.ManifestTask" />
+
+	<property name="source" value="src"/>
+
+	<property name="dist.dir" value="jar" />
+	<property name="build.dir" value="bin"/>
+	<property name="icons.dir" value="icons"/>
+	<property name="lib.dir" value="lib"/>
+
+	<property environment="env"/>
+	<property name="eclipse.home" value="${env.ECLIPSE_HOME}"/>
+	<!--
+	<taskdef resource="net/sf/ant4eclipse/antlib.xml" />
+	-->
+	<taskdef uri="antlib:net.sf.antcontrib"
+		resource="net/sf/antcontrib/antlib.xml" />
+	<taskdef uri="antlib:org.ant4eclipse"
+		resource="org/ant4eclipse/antlib.xml" />
+
+	<property name="targetPlatformLocation" value="${eclipse.home}" />
+	<property name="workspace" value="${basedir}/.." />
+	<property name="project.name" value="jp.go.aist.rtm.rtcbuilder.processing" />
+	<tstamp>
+		<format property="built.date" pattern="yyyy/MM/dd HH:mm:ss" />
+	</tstamp>
+
+	<target name="buildAll">
+		<antcall target="clean" />
+		<antcall target="compile" />
+		<antcall target="jar" />
+	</target>
+
+	<target name="clean" description="ビルドで生成されたファイルを削除します">
+		<delete includeEmptyDirs="true" quiet="true">
+			<fileset dir="${build.dir}" includes="**/*.class" />
+			<fileset dir="." includes="**/*.log" />
+		</delete>
+		<delete dir="${build.dir}/jp" quiet="true"/>
+		<delete dir="${dist.dir}" quiet="true"/>
+	</target>
+
+	<target name="compile" description="ソースをコンパイルします">
+<!--
+		<getEclipseClasspath pathid="build.classpath" targetplatformlocation="${targetPlatformLocation}"
+					workspace="${workspace}" projectname="${project.name}"/>
+-->
+		<ant4eclipse:targetPlatform id="eclipse-3.8">
+		  <location dir="${targetPlatformLocation}" />
+		</ant4eclipse:targetPlatform>
+		<ant4eclipse:jdtClassPathLibrary name="org.eclipse.jdt.junit.JUNIT_CONTAINER/4">
+			<fileset dir="${eclipse.home}/plugins/" includes="**/*junit4*.jar" />
+		</ant4eclipse:jdtClassPathLibrary>
+
+		<ant4eclipse:getJdtClassPath
+			pathid="build.classpath"
+			workspacedirectory="${workspace}"
+			projectname="${project.name}" >
+			<jdtclasspathcontainerargument key="target.platform" value="eclipse-3.8" />
+		</ant4eclipse:getJdtClassPath>
+
+
+		<javac srcdir="${source}" destdir="${build.dir}"
+			classpathref="build.classpath"  encoding="UTF-8" />
+	</target>
+
+	<target name="jar" description="jarファイルを作成します">
+		<copy todir="${build.dir}/jp/go/aist/rtm/rtcbuilder/processing/template">
+			<fileset dir="${source}/jp/go/aist/rtm/rtcbuilder/processing/template">
+				<include name="cmake/**/**.vsl" />
+				<include name="processing/**/**.vsl" />
+			</fileset>
+		</copy>
+		<mkdir dir="${dist.dir}" />
+		<delete>
+			<fileset dir="${dist.dir}" includes="${target.name}_*.jar" />
+		</delete>
+		<!-- Version settings -->
+		<manifesttask file="META-INF/MANIFEST.MF" key="Bundle-Version" property="manifest.project.version" />
+		<condition property="project.version"
+                   value="${env.PROJECT_VERSION}"
+                   else="${manifest.project.version}">
+			<isset property="env.PROJECT_VERSION" />
+		</condition>
+		<property name="jar.version" value="_${project.version}"/>
+		<property name="jar.name" value="${target.name}${jar.version}"/>
+		<!-- Updating MANIFEST.MF -->
+		<manifest file="META-INF/MANIFEST.MF" mode="update">
+			<attribute name="Bundle-Version" value="${project.version}"/>
+			<attribute name="Built-By" value="${user.name}"/>
+			<attribute name="Built-Date" value="${built.date}"/>
+		</manifest>
+		<!-- Creating a jar file -->
+		<jar destfile="${dist.dir}/${jar.name}.jar" manifest="META-INF/MANIFEST.MF">
+			<fileset dir="${build.dir}" />
+			<fileset dir=".">
+				<include name="icons/**.**" />
+				<include name="lib/**.**" />
+				<include name="plugin.xml" />
+				<include name="plugin.properties" />
+			</fileset>
+		</jar>
+	</target>
+
+</project>

--- a/sitetool/build.xml
+++ b/sitetool/build.xml
@@ -35,6 +35,7 @@
 		,jp.go.aist.rtm.rtcbuilder.java
 		,jp.go.aist.rtm.rtcbuilder.python
 		,jp.go.aist.rtm.rtcbuilder.lua
+		,jp.go.aist.rtm.rtcbuilder.processing
 		,jp.go.aist.rtm.toolscommon.profiles
 	" />
 

--- a/sitetool/jp.go.aist.rtm.rtcbuilder.feature/feature.xml
+++ b/sitetool/jp.go.aist.rtm.rtcbuilder.feature/feature.xml
@@ -54,6 +54,13 @@
          unpack="false"/>
 
    <plugin
+         id="jp.go.aist.rtm.rtcbuilder.processing"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="jp.go.aist.rtm.toolscommon.profiles"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
close #567 
## Identify the Bug
Link to #567 

## Description of the Change
Windows用msmやLinux用debパッケージを作成する際に用いる全部入りパッケージのビルド時、RTCBの言語選択にProcessingが含まれるように、Issueに示したファイルを修正、新規追加した


## Verification 
- 修正ソースから作成したOpenRTPのmsmを組み込んだ OpenRTM-aist-2.1.0-RC250529_x86_64.msi をインストールした環境で、Processing言語のRTCを生成できることを確認した

- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
