### PR TITLE
[RTCB]設定画面｢ポート｣内の｢データポート｣セクションのラベル表示を修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/preference/CodeGeneratePortPreferencePage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/preference/CodeGeneratePortPreferencePage.java
@@ -101,7 +101,7 @@ public class CodeGeneratePortPreferencePage extends AbstarctFieldEditorPreferenc
 				Messages.getString("IPreferenceMessageConstants.PORT_TITLE_DATA_PORT"));
 		DigitAlphabetStringFieldEditor dataPortNameEditor = 
 			new DigitAlphabetStringFieldEditor(ComponentPreferenceManager.Generate_DataPort_Name,
-					Messages.getString("IMC.DATAPORT_LBL_DESCRIPTION"), dataportGroup);
+					Messages.getString("IMC.DATAPORT_LBL_PORTNAME"), dataportGroup);
 		addField(dataPortNameEditor);
 		StringFieldEditor dataPortTypeEditor = 
 			new StringFieldEditor(ComponentPreferenceManager.Generate_DataPort_Type,


### PR DESCRIPTION
Link to #571

## Description of the Change

設定画面の｢RTCBuilder｣→｢コード生成｣→｢ポート｣で表示される【ポート】画面において，｢データポート｣セクションの最初の項目が
　｢概要説明｣
となっていたのを
　｢ポート名｣
に修正


## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2020-06を使用
- [x] No warnings for the build?  Windows上でEclipse2020-06を使用
- [ ] Have you passed the unit tests? サンプルコードの内容を基にユニットテストも作成