### PR TITLE
[RTCB]サービスポートの｢接頭語｣と｢接尾語｣を入れ替え

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/BasicEditorFormPage.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/ui/editors/BasicEditorFormPage.java
@@ -689,9 +689,9 @@ public class BasicEditorFormPage extends AbstractEditorFormPage {
 		param.setConfigurationSuffix(store.getString(ComponentPreferenceManager.Generate_Configuration_Suffix));
 		//
 		param.setDataPortPrefix(store.getString(ComponentPreferenceManager.Generate_DataPort_Prefix));
-		param.setDataPortSuffix(store.getString(ComponentPreferenceManager.Generate_DataPort_Type));
-		param.setServicePortPrefix(store.getString(ComponentPreferenceManager.Generate_ServicePort_Suffix));
-		param.setServicePortSuffix(store.getString(ComponentPreferenceManager.Generate_ServicePort_Prefix));
+		param.setDataPortSuffix(store.getString(ComponentPreferenceManager.Generate_DataPort_Suffix));
+		param.setServicePortPrefix(store.getString(ComponentPreferenceManager.Generate_ServicePort_Prefix));
+		param.setServicePortSuffix(store.getString(ComponentPreferenceManager.Generate_ServicePort_Suffix));
 		param.setServiceIFPrefix(store.getString(ComponentPreferenceManager.Generate_ServiceIF_Prefix));
 		param.setServiceIFSuffix(store.getString(ComponentPreferenceManager.Generate_ServiceIF_Suffix));
 		param.setEventPortPrefix(store.getString(ComponentPreferenceManager.Generate_EventPort_Prefix));


### PR DESCRIPTION
Link to #572

## Description of the Change

設定画面の｢RTCBuilder｣→｢コード生成｣→｢ポート｣内の【ポート】画面内の｢サービスポート｣セクションで，
サービスポートの｢接頭語｣｢接尾語｣として指定した内容が，
コード生成時に逆になってしまっていたため修正させて頂きました．

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2020-06を使用
- [x] No warnings for the build?  Windows上でEclipse2020-06を使用
- [ ] Have you passed the unit tests? サンプルコードの内容を基にユニットテストも作成
