### PR TITLE
[RTCB]Lua版RTCで不要なコードを出力しないように修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder.java/src/jp/go/aist/rtm/rtcbuilder/java/manager/JavaConverter.java
+++ b/jp.go.aist.rtm.rtcbuilder.java/src/jp/go/aist/rtm/rtcbuilder/java/manager/JavaConverter.java
@@ -294,7 +294,11 @@ public class JavaConverter {
 	public String convCORBA2JavaforArg(ServiceArgumentParam typeDef, String strDirection, ServiceClassParam scp) {
 		String result = "";
 		String strType = getTypeDefs(typeDef.getType(), scp);
+		if(strType.endsWith("[]")) {
+			typeDef.setSequence(true);
+		}
 		strType = strType.replaceAll("::", ".");
+		
 
 		if( mapType.get(strType) != null){
 			if( strDirection.equals(dirIn) ) {

--- a/jp.go.aist.rtm.rtcbuilder.java/src/jp/go/aist/rtm/rtcbuilder/java/template/java/test/Java_Test_RTC_Impl.java.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.java/src/jp/go/aist/rtm/rtcbuilder/java/template/java/test/Java_Test_RTC_Impl.java.vsl
@@ -125,6 +125,7 @@ public class ${rtcParam.name}TestImpl extends DataFlowComponentBase {
 #end
 #foreach($port in ${rtcParam.inports})  
         m_${port.tmplVarName}_val = new ${javaConv.getDataTypeName(${port.type})}();
+        initializeParam(m_${port.tmplVarName}_val);
         m_${port.tmplVarName} = new DataRef<${javaConv.getDataTypeName(${port.type})}>(m_${port.tmplVarName}_val);
         m_${port.name}Out = new OutPort<${javaConv.getDataTypeName(${port.type})}>("${port.name}", m_${port.tmplVarName});
 #end

--- a/jp.go.aist.rtm.rtcbuilder.lua/src/jp/go/aist/rtm/rtcbuilder/lua/manager/LuaCMakeGenerateManager.java
+++ b/jp.go.aist.rtm.rtcbuilder.lua/src/jp/go/aist/rtm/rtcbuilder/lua/manager/LuaCMakeGenerateManager.java
@@ -103,8 +103,52 @@ public class LuaCMakeGenerateManager extends CMakeGenerateManager {
 
 	@Override
 	public GeneratedResult generateSrcCMakeLists(Map<String, Object> contextMap) {
-		GeneratedResult result = new GeneratedResult();
-		return result;
+		return new GeneratedResult();
+	}
+
+	@Override
+	public GeneratedResult generateDocCMakeLists(Map<String, Object> contextMap) {
+		return new GeneratedResult();
+	}
+
+	@Override
+	public GeneratedResult generateDocConfPy(Map<String, Object> contextMap) {
+		return new GeneratedResult();
+	}
+
+	@Override
+	public GeneratedResult generateDoxyfile(Map<String, Object> contextMap) {
+		return new GeneratedResult();
+	}
+
+	@Override
+	public GeneratedResult generateIncludeCMakeLists(Map<String, Object> contextMap) {
+		return new GeneratedResult();
+	}
+
+	@Override
+	public GeneratedResult generateIncModuleCMakeLists(Map<String, Object> contextMap) {
+		return new GeneratedResult();
+	}
+
+	@Override
+	public GeneratedResult generateTestCMakeLists(Map<String, Object> contextMap) {
+		return new GeneratedResult();
+	}
+
+	@Override
+	public GeneratedResult generateTestIncludeCMakeLists(Map<String, Object> contextMap) {
+		return new GeneratedResult();
+	}
+
+	@Override
+	public GeneratedResult generateTestIncModuleCMakeLists(Map<String, Object> contextMap) {
+		return new GeneratedResult();
+	}
+
+	@Override
+	public GeneratedResult generateTestSrcCMakeLists(Map<String, Object> contextMap) {
+		return new GeneratedResult();
 	}
 	/////
 	public GeneratedResult generateLua(String infile, String outfile,


### PR DESCRIPTION
Link to #576

## Description of the Change

Lua版RTCのコード生成を実行した際に，以下のコードが出力されないように修正させて頂きました．
- doc
　CMakeLists.txt, conf.py.in, doxyfile.in
- include
　CMakeLists.txt
- include/<Module Name>
　CMakeLists.txt
- test
　CMakeLists.txt
- test/include
　CMakeLists.txt
- test/include/<Module Name>
　CMakeLists.txt
- test/src
　CMakeLists.txt

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2020-06を使用
- [x] No warnings for the build?  Windows上でEclipse2020-06を使用
- [ ] Have you passed the unit tests? サンプルコードの内容を基にユニットテストも作成