### PR TITLE
[RTCB]Lua版RTCの生成コードを修正

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder.lua/src/jp/go/aist/rtm/rtcbuilder/lua/template/lua/Lns_RTC.lns.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.lua/src/jp/go/aist/rtm/rtcbuilder/lua/template/lua/Lns_RTC.lns.vsl
@@ -228,9 +228,10 @@ class ${rtcParam.name} extend openrtm_lns.RTObjectBase {
 #end
         */
         self._${configParam.tmplVarName} = new openrtm_lns.config_int(${luaConv.convDefaultVal(${configParam})});
+#end
     }
     // </rtc-template>
-#if(${rtcParam.getDocActionOverView(0).length()}>0)    - ${tmpltHelperLua.convertDescDocLua(${rtcParam.getDocActionOverView(0)})}
+#if(${rtcParam.getDocActionOverView(0).length()}>0)    // ${tmpltHelperLua.convertDescDocLua(${rtcParam.getDocActionOverView(0)})}
 #end
     //
     // The initialize action (on CREATED->ALIVE transition)
@@ -295,18 +296,18 @@ class ${rtcParam.name} extend openrtm_lns.RTObjectBase {
         return openrtm_lns.ReturnCode_t.RTC_OK;
     }
 
-#if(${rtcParam.getDocActionOverView(1).length()}>0)	#if(${rtcParam.IsNotImplemented(1)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(1)})}
+#if(${rtcParam.getDocActionOverView(1).length()}>0)   #if(${rtcParam.IsNotImplemented(1)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(1)})}
 #end
-    #if(${rtcParam.IsNotImplemented(1)}) //	#end//
-    #if(${rtcParam.IsNotImplemented(1)}) //	#end// The finalize action (on ALIVE->END transition)
-    #if(${rtcParam.IsNotImplemented(1)}) //	#end// formaer rtc_exiting_entry()
-    #if(${rtcParam.IsNotImplemented(1)}) //	#end//
-    #if(${rtcParam.IsNotImplemented(1)}) //	#end// @return RTC::ReturnCode_t
-    #if(${rtcParam.IsNotImplemented(1)}) //	#end
+    #if(${rtcParam.IsNotImplemented(1)})//	#end//
+    #if(${rtcParam.IsNotImplemented(1)})//	#end// The finalize action (on ALIVE->END transition)
+    #if(${rtcParam.IsNotImplemented(1)})//	#end// formaer rtc_exiting_entry()
+    #if(${rtcParam.IsNotImplemented(1)})//	#end//
+    #if(${rtcParam.IsNotImplemented(1)})//	#end// @return RTC::ReturnCode_t
+    #if(${rtcParam.IsNotImplemented(1)})//	#end
 
-#if(${rtcParam.getDocActionPreCondition(1).length()}>0)	#if(${rtcParam.IsNotImplemented(1)})//#end        // @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(1)})}
+#if(${rtcParam.getDocActionPreCondition(1).length()}>0)#if(${rtcParam.IsNotImplemented(1)})//#end    // @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(1)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(1).length()}>0)	#if(${rtcParam.IsNotImplemented(1)})//#end        // @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(1)})}
+#if(${rtcParam.getDocActionPostCondition(1).length()}>0)#if(${rtcParam.IsNotImplemented(1)})//#end    // @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(1)})}
 #end
     #if(${rtcParam.IsNotImplemented(1)})//	#end//
    #if(${rtcParam.IsNotImplemented(1)}) //	#end pub override fn onFinalize mut : openrtm_lns.ReturnCode_t {
@@ -317,7 +318,7 @@ class ${rtcParam.name} extend openrtm_lns.RTObjectBase {
     #if(${rtcParam.IsNotImplemented(1)})//	#end        return openrtm_lns.ReturnCode_t.RTC_OK;
    #if(${rtcParam.IsNotImplemented(1)}) //	#end }
 
-#if(${rtcParam.getDocActionOverView(2).length()}>0)	#if(${rtcParam.IsNotImplemented(2)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(2)})}
+#if(${rtcParam.getDocActionOverView(2).length()}>0)   #if(${rtcParam.IsNotImplemented(2)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(2)})}
 #end
     #if(${rtcParam.IsNotImplemented(2)})//	#end//
     #if(${rtcParam.IsNotImplemented(2)})//	#end// The startup action when ExecutionContext startup
@@ -327,9 +328,9 @@ class ${rtcParam.name} extend openrtm_lns.RTObjectBase {
     #if(${rtcParam.IsNotImplemented(2)})//	#end//
     #if(${rtcParam.IsNotImplemented(2)})//	#end// @return RTC::ReturnCode_t
     #if(${rtcParam.IsNotImplemented(2)})//	#end//
-#if(${rtcParam.getDocActionPreCondition(2).length()}>0)	#if(${rtcParam.IsNotImplemented(2)})//#end	// @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(2)})}
+#if(${rtcParam.getDocActionPreCondition(2).length()}>0)#if(${rtcParam.IsNotImplemented(2)})//#end    // @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(2)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(2).length()}>0)	#if(${rtcParam.IsNotImplemented(2)})//#end	// @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(2)})}
+#if(${rtcParam.getDocActionPostCondition(2).length()}>0)#if(${rtcParam.IsNotImplemented(2)})//#end    // @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(2)})}
 #end
     #if(${rtcParam.IsNotImplemented(2)})//	#end//
    #if(${rtcParam.IsNotImplemented(2)}) //	#end pub override fn onStartup(ec_id:int) mut : openrtm_lns.ReturnCode_t {
@@ -340,7 +341,7 @@ class ${rtcParam.name} extend openrtm_lns.RTObjectBase {
     #if(${rtcParam.IsNotImplemented(2)})//	#end    return openrtm_lns.ReturnCode_t.RTC_OK;
    #if(${rtcParam.IsNotImplemented(2)}) //	#end }
 
-#if(${rtcParam.getDocActionOverView(3).length()}>0)	#if(${rtcParam.IsNotImplemented(3)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(3)})}
+#if(${rtcParam.getDocActionOverView(3).length()}>0)   #if(${rtcParam.IsNotImplemented(3)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(3)})}
 #end
     #if(${rtcParam.IsNotImplemented(3)})//	#end//
     #if(${rtcParam.IsNotImplemented(3)})//	#end// The shutdown action when ExecutionContext stop
@@ -350,11 +351,11 @@ class ${rtcParam.name} extend openrtm_lns.RTObjectBase {
     #if(${rtcParam.IsNotImplemented(3)})//	#end//
     #if(${rtcParam.IsNotImplemented(3)})//	#end// @return RTC::ReturnCode_t
     #if(${rtcParam.IsNotImplemented(3)})//	#end//
-#if(${rtcParam.getDocActionPreCondition(3).length()}>0)	#if(${rtcParam.IsNotImplemented(3)})//#end	// @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(3)})}
+#if(${rtcParam.getDocActionPreCondition(3).length()}>0)#if(${rtcParam.IsNotImplemented(3)})//#end    // @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(3)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(3).length()}>0)	#if(${rtcParam.IsNotImplemented(3)})//#end	// @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(3)})}
+#if(${rtcParam.getDocActionPostCondition(3).length()}>0)#if(${rtcParam.IsNotImplemented(3)})//#end    // @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(3)})}
 #end
-    #if(${rtcParam.IsNotImplemented(3)})//	#end //
+    #if(${rtcParam.IsNotImplemented(3)})//	#end//
    #if(${rtcParam.IsNotImplemented(3)}) //	#end pub override fn onShutdown(ec_id:int) mut : openrtm_lns.ReturnCode_t {
     #if(${rtcParam.IsNotImplemented(3)})//	#end
 #if(${tmpltHelper.checkDetailContent(3,${rtcParam})})		${rtcParam.getDetailContent(3)}
@@ -363,7 +364,7 @@ class ${rtcParam.name} extend openrtm_lns.RTObjectBase {
     #if(${rtcParam.IsNotImplemented(3)})//	#end    return openrtm_lns.ReturnCode_t.RTC_OK;
    #if(${rtcParam.IsNotImplemented(3)}) //	#end }
 
-#if(${rtcParam.getDocActionOverView(4).length()}>0)	#if(${rtcParam.IsNotImplemented(4)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(4)})}
+#if(${rtcParam.getDocActionOverView(4).length()}>0)   #if(${rtcParam.IsNotImplemented(4)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(4)})}
 #end
     #if(${rtcParam.IsNotImplemented(4)})//	#end//
     #if(${rtcParam.IsNotImplemented(4)})//	#end// The activated action (Active state entry action)
@@ -373,9 +374,9 @@ class ${rtcParam.name} extend openrtm_lns.RTObjectBase {
     #if(${rtcParam.IsNotImplemented(4)})//	#end//
     #if(${rtcParam.IsNotImplemented(4)})//	#end// @return RTC::ReturnCode_t
     #if(${rtcParam.IsNotImplemented(4)})//	#end//
-#if(${rtcParam.getDocActionPreCondition(4).length()}>0)	#if(${rtcParam.IsNotImplemented(4)})//#end	// @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(4)})}
+#if(${rtcParam.getDocActionPreCondition(4).length()}>0)#if(${rtcParam.IsNotImplemented(4)})//#end    // @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(4)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(4).length()}>0)	#if(${rtcParam.IsNotImplemented(4)})//#end	// @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(4)})}
+#if(${rtcParam.getDocActionPostCondition(4).length()}>0)#if(${rtcParam.IsNotImplemented(4)})//#end    // @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(4)})}
 #end
     #if(${rtcParam.IsNotImplemented(4)})//	#end//
    #if(${rtcParam.IsNotImplemented(4)}) //	#end pub override fn onActivated(ec_id:int) mut : openrtm_lns.ReturnCode_t {
@@ -386,21 +387,21 @@ class ${rtcParam.name} extend openrtm_lns.RTObjectBase {
     #if(${rtcParam.IsNotImplemented(4)})//	#end    return openrtm_lns.ReturnCode_t.RTC_OK;
    #if(${rtcParam.IsNotImplemented(4)}) //	#end }
 
-#if(${rtcParam.getDocActionOverView(5).length()}>0)	#if(${rtcParam.IsNotImplemented(5)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(5)})}
+#if(${rtcParam.getDocActionOverView(5).length()}>0)   #if(${rtcParam.IsNotImplemented(5)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(5)})}
 #end
-    #if(${rtcParam.IsNotImplemented(5)})//	#end //
-    #if(${rtcParam.IsNotImplemented(5)})//	#end // The deactivated action (Active state exit action)
-    #if(${rtcParam.IsNotImplemented(5)})//	#end // former rtc_active_exit()
-    #if(${rtcParam.IsNotImplemented(5)})//	#end //
-    #if(${rtcParam.IsNotImplemented(5)})//	#end // @param ec_id target ExecutionContext Id
-    #if(${rtcParam.IsNotImplemented(5)})//	#end //
-    #if(${rtcParam.IsNotImplemented(5)})//	#end // @return RTC::ReturnCode_t
-    #if(${rtcParam.IsNotImplemented(5)})//	#end //
-#if(${rtcParam.getDocActionPreCondition(5).length()}>0)	#if(${rtcParam.IsNotImplemented(5)})//#end	// @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(5)})}
+    #if(${rtcParam.IsNotImplemented(5)})//	#end//
+    #if(${rtcParam.IsNotImplemented(5)})//	#end// The deactivated action (Active state exit action)
+    #if(${rtcParam.IsNotImplemented(5)})//	#end// former rtc_active_exit()
+    #if(${rtcParam.IsNotImplemented(5)})//	#end//
+    #if(${rtcParam.IsNotImplemented(5)})//	#end// @param ec_id target ExecutionContext Id
+    #if(${rtcParam.IsNotImplemented(5)})//	#end//
+    #if(${rtcParam.IsNotImplemented(5)})//	#end// @return RTC::ReturnCode_t
+    #if(${rtcParam.IsNotImplemented(5)})//	#end//
+#if(${rtcParam.getDocActionPreCondition(5).length()}>0)#if(${rtcParam.IsNotImplemented(5)})//#end    // @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(5)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(5).length()}>0)	#if(${rtcParam.IsNotImplemented(5)})//#end	// @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(5)})}
+#if(${rtcParam.getDocActionPostCondition(5).length()}>0)#if(${rtcParam.IsNotImplemented(5)})//#end    // @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(5)})}
 #end
-    #if(${rtcParam.IsNotImplemented(5)})//	#end //
+    #if(${rtcParam.IsNotImplemented(5)})//	#end//
    #if(${rtcParam.IsNotImplemented(5)}) //	#end pub override fn onDeactivated(ec_id:int) mut : openrtm_lns.ReturnCode_t {
     #if(${rtcParam.IsNotImplemented(5)})//	#end
 #if(${tmpltHelper.checkDetailContent(5,${rtcParam})})		${rtcParam.getDetailContent(5)}
@@ -409,21 +410,21 @@ class ${rtcParam.name} extend openrtm_lns.RTObjectBase {
     #if(${rtcParam.IsNotImplemented(5)})//	#end    return openrtm_lns.ReturnCode_t.RTC_OK;
    #if(${rtcParam.IsNotImplemented(5)}) //	#end }
 
-#if(${rtcParam.getDocActionOverView(9).length()}>0)	#if(${rtcParam.IsNotImplemented(9)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(9)})}
+#if(${rtcParam.getDocActionOverView(9).length()}>0)   #if(${rtcParam.IsNotImplemented(9)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(9)})}
 #end
-    #if(${rtcParam.IsNotImplemented(9)})//	#end //
-    #if(${rtcParam.IsNotImplemented(9)})//	#end // The execution action that is invoked periodically
-    #if(${rtcParam.IsNotImplemented(9)})//	#end // former rtc_active_do()
-    #if(${rtcParam.IsNotImplemented(9)})//	#end //
-    #if(${rtcParam.IsNotImplemented(9)})//	#end // @param ec_id target ExecutionContext Id
-    #if(${rtcParam.IsNotImplemented(9)})//	#end //
-    #if(${rtcParam.IsNotImplemented(9)})//	#end // @return RTC::ReturnCode_t
-    #if(${rtcParam.IsNotImplemented(9)})//	#end //
-#if(${rtcParam.getDocActionPreCondition(9).length()}>0)	#if(${rtcParam.IsNotImplemented(9)})//#end	// @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(9)})}
+    #if(${rtcParam.IsNotImplemented(9)})//	#end//
+    #if(${rtcParam.IsNotImplemented(9)})//	#end// The execution action that is invoked periodically
+    #if(${rtcParam.IsNotImplemented(9)})//	#end// former rtc_active_do()
+    #if(${rtcParam.IsNotImplemented(9)})//	#end//
+    #if(${rtcParam.IsNotImplemented(9)})//	#end// @param ec_id target ExecutionContext Id
+    #if(${rtcParam.IsNotImplemented(9)})//	#end//
+    #if(${rtcParam.IsNotImplemented(9)})//	#end// @return RTC::ReturnCode_t
+    #if(${rtcParam.IsNotImplemented(9)})//	#end//
+#if(${rtcParam.getDocActionPreCondition(9).length()}>0)#if(${rtcParam.IsNotImplemented(9)})//#end    // @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(9)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(9).length()}>0)	#if(${rtcParam.IsNotImplemented(9)})//#end	// @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(9)})}
+#if(${rtcParam.getDocActionPostCondition(9).length()}>0)#if(${rtcParam.IsNotImplemented(9)})//#end    // @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(9)})}
 #end
-    #if(${rtcParam.IsNotImplemented(9)})//	#end //
+    #if(${rtcParam.IsNotImplemented(9)})//	#end//
    #if(${rtcParam.IsNotImplemented(9)}) //	#end pub override fn onExecute(ec_id:int) mut : openrtm_lns.ReturnCode_t {
     #if(${rtcParam.IsNotImplemented(9)})//	#end
 #if(${tmpltHelper.checkDetailContent(9,${rtcParam})})		${rtcParam.getDetailContent(9)}
@@ -432,21 +433,21 @@ class ${rtcParam.name} extend openrtm_lns.RTObjectBase {
     #if(${rtcParam.IsNotImplemented(9)})//	#end    return openrtm_lns.ReturnCode_t.RTC_OK;
    #if(${rtcParam.IsNotImplemented(9)}) //	#end }
 
-#if(${rtcParam.getDocActionOverView(6).length()}>0)	#if(${rtcParam.IsNotImplemented(6)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(6)})}
+#if(${rtcParam.getDocActionOverView(6).length()}>0)   #if(${rtcParam.IsNotImplemented(6)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(6)})}
 #end
-    #if(${rtcParam.IsNotImplemented(6)})//	#end //
-    #if(${rtcParam.IsNotImplemented(6)})//	#end // The aborting action when main logic error occurred.
-    #if(${rtcParam.IsNotImplemented(6)})//	#end // former rtc_aborting_entry()
-    #if(${rtcParam.IsNotImplemented(6)})//	#end //
-    #if(${rtcParam.IsNotImplemented(6)})//	#end // @param ec_id target ExecutionContext Id
-    #if(${rtcParam.IsNotImplemented(6)})//	#end //
-    #if(${rtcParam.IsNotImplemented(6)})//	#end // @return RTC::ReturnCode_t
-    #if(${rtcParam.IsNotImplemented(6)})//	#end //
-#if(${rtcParam.getDocActionPreCondition(6).length()}>0)	#if(${rtcParam.IsNotImplemented(6)})//#end	// @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(6)})}
+    #if(${rtcParam.IsNotImplemented(6)})//	#end//
+    #if(${rtcParam.IsNotImplemented(6)})//	#end// The aborting action when main logic error occurred.
+    #if(${rtcParam.IsNotImplemented(6)})//	#end// former rtc_aborting_entry()
+    #if(${rtcParam.IsNotImplemented(6)})//	#end//
+    #if(${rtcParam.IsNotImplemented(6)})//	#end// @param ec_id target ExecutionContext Id
+    #if(${rtcParam.IsNotImplemented(6)})//	#end//
+    #if(${rtcParam.IsNotImplemented(6)})//	#end// @return RTC::ReturnCode_t
+    #if(${rtcParam.IsNotImplemented(6)})//	#end//
+#if(${rtcParam.getDocActionPreCondition(6).length()}>0)#if(${rtcParam.IsNotImplemented(6)})//#end    // @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(6)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(6).length()}>0)	#if(${rtcParam.IsNotImplemented(6)})//#end	// @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(6)})}
+#if(${rtcParam.getDocActionPostCondition(6).length()}>0)#if(${rtcParam.IsNotImplemented(6)})//#end    // @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(6)})}
 #end
-    #if(${rtcParam.IsNotImplemented(6)})//	#end //
+    #if(${rtcParam.IsNotImplemented(6)})//	#end//
    #if(${rtcParam.IsNotImplemented(6)}) //	#end pub override fn onAborting(ec_id:int) mut : openrtm_lns.ReturnCode_t {
     #if(${rtcParam.IsNotImplemented(6)})//	#end
 #if(${tmpltHelper.checkDetailContent(6,${rtcParam})})		${rtcParam.getDetailContent(6)}
@@ -455,21 +456,21 @@ class ${rtcParam.name} extend openrtm_lns.RTObjectBase {
     #if(${rtcParam.IsNotImplemented(6)})//	#end    return openrtm_lns.ReturnCode_t.RTC_OK;
    #if(${rtcParam.IsNotImplemented(6)}) //	#end }
 
-#if(${rtcParam.getDocActionOverView(7).length()}>0)	#if(${rtcParam.IsNotImplemented(7)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(7)})}
+#if(${rtcParam.getDocActionOverView(7).length()}>0)   #if(${rtcParam.IsNotImplemented(7)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(7)})}
 #end
-    #if(${rtcParam.IsNotImplemented(7)})//	#end //
-    #if(${rtcParam.IsNotImplemented(7)})//	#end // The error action in ERROR state
-    #if(${rtcParam.IsNotImplemented(7)})//	#end // former rtc_error_do()
-    #if(${rtcParam.IsNotImplemented(7)})//	#end //
-    #if(${rtcParam.IsNotImplemented(7)})//	#end // @param ec_id target ExecutionContext Id
-    #if(${rtcParam.IsNotImplemented(7)})//	#end //
-    #if(${rtcParam.IsNotImplemented(7)})//	#end // @return RTC::ReturnCode_t
-    #if(${rtcParam.IsNotImplemented(7)})//	#end //
-#if(${rtcParam.getDocActionPreCondition(7).length()}>0)	#if(${rtcParam.IsNotImplemented(7)})//#end	// @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(7)})}
+    #if(${rtcParam.IsNotImplemented(7)})//	#end//
+    #if(${rtcParam.IsNotImplemented(7)})//	#end// The error action in ERROR state
+    #if(${rtcParam.IsNotImplemented(7)})//	#end// former rtc_error_do()
+    #if(${rtcParam.IsNotImplemented(7)})//	#end//
+    #if(${rtcParam.IsNotImplemented(7)})//	#end// @param ec_id target ExecutionContext Id
+    #if(${rtcParam.IsNotImplemented(7)})//	#end//
+    #if(${rtcParam.IsNotImplemented(7)})//	#end// @return RTC::ReturnCode_t
+    #if(${rtcParam.IsNotImplemented(7)})//	#end//
+#if(${rtcParam.getDocActionPreCondition(7).length()}>0)#if(${rtcParam.IsNotImplemented(7)})//#end    // @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(7)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(7).length()}>0)	#if(${rtcParam.IsNotImplemented(7)})//#end	// @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(7)})}
+#if(${rtcParam.getDocActionPostCondition(7).length()}>0)#if(${rtcParam.IsNotImplemented(7)})//#end    // @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(7)})}
 #end
-    #if(${rtcParam.IsNotImplemented(7)})//	#end //
+    #if(${rtcParam.IsNotImplemented(7)})//	#end//
    #if(${rtcParam.IsNotImplemented(7)}) //	#end pub override fn onError(ec_id:int) mut : openrtm_lns.ReturnCode_t {
     #if(${rtcParam.IsNotImplemented(7)})//	#end
 #if(${tmpltHelper.checkDetailContent(7,${rtcParam})})		${rtcParam.getDetailContent(7)}
@@ -478,21 +479,21 @@ class ${rtcParam.name} extend openrtm_lns.RTObjectBase {
     #if(${rtcParam.IsNotImplemented(7)})//	#end    return openrtm_lns.ReturnCode_t.RTC_OK;
    #if(${rtcParam.IsNotImplemented(7)}) //	#end }
 
-#if(${rtcParam.getDocActionOverView(8).length()}>0)	#if(${rtcParam.IsNotImplemented(8)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(8)})}
+#if(${rtcParam.getDocActionOverView(8).length()}>0)   #if(${rtcParam.IsNotImplemented(8)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(8)})}
 #end
-    #if(${rtcParam.IsNotImplemented(8)})//	#end //
-    #if(${rtcParam.IsNotImplemented(8)})//	#end // The reset action that is invoked resetting
-    #if(${rtcParam.IsNotImplemented(8)})//	#end // This is same but different the former rtc_init_entry()
-    #if(${rtcParam.IsNotImplemented(8)})//	#end //
-    #if(${rtcParam.IsNotImplemented(8)})//	#end // @param ec_id target ExecutionContext Id
-    #if(${rtcParam.IsNotImplemented(8)})//	#end //
-    #if(${rtcParam.IsNotImplemented(8)})//	#end // @return RTC::ReturnCode_t
-    #if(${rtcParam.IsNotImplemented(8)})//	#end //
-#if(${rtcParam.getDocActionPreCondition(8).length()}>0)	#if(${rtcParam.IsNotImplemented(8)})//#end	// @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(8)})}
+    #if(${rtcParam.IsNotImplemented(8)})//	#end//
+    #if(${rtcParam.IsNotImplemented(8)})//	#end// The reset action that is invoked resetting
+    #if(${rtcParam.IsNotImplemented(8)})//	#end// This is same but different the former rtc_init_entry()
+    #if(${rtcParam.IsNotImplemented(8)})//	#end//
+    #if(${rtcParam.IsNotImplemented(8)})//	#end// @param ec_id target ExecutionContext Id
+    #if(${rtcParam.IsNotImplemented(8)})//	#end//
+    #if(${rtcParam.IsNotImplemented(8)})//	#end// @return RTC::ReturnCode_t
+    #if(${rtcParam.IsNotImplemented(8)})//	#end//
+#if(${rtcParam.getDocActionPreCondition(8).length()}>0)#if(${rtcParam.IsNotImplemented(8)})//#end    // @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(8)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(8).length()}>0)	#if(${rtcParam.IsNotImplemented(8)})//#end	// @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(8)})}
+#if(${rtcParam.getDocActionPostCondition(8).length()}>0)#if(${rtcParam.IsNotImplemented(8)})//#end    // @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(8)})}
 #end
-    #if(${rtcParam.IsNotImplemented(8)})//	#end //
+    #if(${rtcParam.IsNotImplemented(8)})//	#end//
    #if(${rtcParam.IsNotImplemented(8)}) //	#end pub override fn onReset(ec_id:int) mut : openrtm_lns.ReturnCode_t {
     #if(${rtcParam.IsNotImplemented(8)})//	#end
 #if(${tmpltHelper.checkDetailContent(8,${rtcParam})})		${rtcParam.getDetailContent(8)}
@@ -501,22 +502,22 @@ class ${rtcParam.name} extend openrtm_lns.RTObjectBase {
     #if(${rtcParam.IsNotImplemented(8)})//	#end    return openrtm_lns.ReturnCode_t.RTC_OK;
    #if(${rtcParam.IsNotImplemented(8)}) //	#end }
 
-#if(${rtcParam.getDocActionOverView(10).length()}>0)	#if(${rtcParam.IsNotImplemented(10)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(10)})}
+#if(${rtcParam.getDocActionOverView(10).length()}>0)   #if(${rtcParam.IsNotImplemented(10)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(10)})}
 #end
-    #if(${rtcParam.IsNotImplemented(10)})//	#end //
-    #if(${rtcParam.IsNotImplemented(10)})//	#end // The state update action that is invoked after onExecute() action
-    #if(${rtcParam.IsNotImplemented(10)})//	#end // no corresponding operation exists in OpenRTm-aist-0.2.0
-    #if(${rtcParam.IsNotImplemented(10)})//	#end //
-    #if(${rtcParam.IsNotImplemented(10)})//	#end // @param ec_id target ExecutionContext Id
-    #if(${rtcParam.IsNotImplemented(10)})//	#end //
-    #if(${rtcParam.IsNotImplemented(10)})//	#end // @return RTC::ReturnCode_t
-    #if(${rtcParam.IsNotImplemented(10)})//	#end //
+    #if(${rtcParam.IsNotImplemented(10)})//	#end//
+    #if(${rtcParam.IsNotImplemented(10)})//	#end// The state update action that is invoked after onExecute() action
+    #if(${rtcParam.IsNotImplemented(10)})//	#end// no corresponding operation exists in OpenRTm-aist-0.2.0
+    #if(${rtcParam.IsNotImplemented(10)})//	#end//
+    #if(${rtcParam.IsNotImplemented(10)})//	#end// @param ec_id target ExecutionContext Id
+    #if(${rtcParam.IsNotImplemented(10)})//	#end//
+    #if(${rtcParam.IsNotImplemented(10)})//	#end// @return RTC::ReturnCode_t
+    #if(${rtcParam.IsNotImplemented(10)})//	#end//
 
-#if(${rtcParam.getDocActionPreCondition(10).length()}>0)	#if(${rtcParam.IsNotImplemented(10)})//#end	// @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(10)})}
+#if(${rtcParam.getDocActionPreCondition(10).length()}>0)#if(${rtcParam.IsNotImplemented(10)})//#end    // @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(10)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(10).length()}>0)	#if(${rtcParam.IsNotImplemented(10)})//#end	// @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(10)})}
+#if(${rtcParam.getDocActionPostCondition(10).length()}>0)#if(${rtcParam.IsNotImplemented(10)})//#end    // @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(10)})}
 #end
-    #if(${rtcParam.IsNotImplemented(10)})//	#end //
+    #if(${rtcParam.IsNotImplemented(10)})//	#end//
    #if(${rtcParam.IsNotImplemented(10)}) //	#end pub override fn onStateUpdate(ec_id:int) mut : openrtm_lns.ReturnCode_t {
     #if(${rtcParam.IsNotImplemented(10)})//	#end
 #if(${tmpltHelper.checkDetailContent(10,${rtcParam})})		${rtcParam.getDetailContent(10)}
@@ -525,21 +526,21 @@ class ${rtcParam.name} extend openrtm_lns.RTObjectBase {
     #if(${rtcParam.IsNotImplemented(10)})//	#end    return openrtm_lns.ReturnCode_t.RTC_OK;
    #if(${rtcParam.IsNotImplemented(10)}) //	#end }
 
-#if(${rtcParam.getDocActionOverView(11).length()}>0)	#if(${rtcParam.IsNotImplemented(11)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(11)})}
+#if(${rtcParam.getDocActionOverView(11).length()}>0)   #if(${rtcParam.IsNotImplemented(11)})//#end // ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(11)})}
 #end
-    #if(${rtcParam.IsNotImplemented(11)})//	#end //
-    #if(${rtcParam.IsNotImplemented(11)})//	#end // The action that is invoked when execution context's rate is changed
-    #if(${rtcParam.IsNotImplemented(11)})//	#end // no corresponding operation exists in OpenRTm-aist-0.2.0
-    #if(${rtcParam.IsNotImplemented(11)})//	#end //
-    #if(${rtcParam.IsNotImplemented(11)})//	#end // @param ec_id target ExecutionContext Id
-    #if(${rtcParam.IsNotImplemented(11)})//	#end //
-    #if(${rtcParam.IsNotImplemented(11)})//	#end // @return RTC::ReturnCode_t
-    #if(${rtcParam.IsNotImplemented(11)})//	#end //
-#if(${rtcParam.getDocActionPreCondition(11).length()}>0)	#if(${rtcParam.IsNotImplemented(11)})//#end	// @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(11)})}
+    #if(${rtcParam.IsNotImplemented(11)})//	#end//
+    #if(${rtcParam.IsNotImplemented(11)})//	#end// The action that is invoked when execution context's rate is changed
+    #if(${rtcParam.IsNotImplemented(11)})//	#end// no corresponding operation exists in OpenRTm-aist-0.2.0
+    #if(${rtcParam.IsNotImplemented(11)})//	#end//
+    #if(${rtcParam.IsNotImplemented(11)})//	#end// @param ec_id target ExecutionContext Id
+    #if(${rtcParam.IsNotImplemented(11)})//	#end//
+    #if(${rtcParam.IsNotImplemented(11)})//	#end// @return RTC::ReturnCode_t
+    #if(${rtcParam.IsNotImplemented(11)})//	#end//
+#if(${rtcParam.getDocActionPreCondition(11).length()}>0)#if(${rtcParam.IsNotImplemented(11)})//#end    // @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(11)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(11).length()}>0)	#if(${rtcParam.IsNotImplemented(11)})//#end	// @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(11)})}
+#if(${rtcParam.getDocActionPostCondition(11).length()}>0)#if(${rtcParam.IsNotImplemented(11)})//#end    // @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(11)})}
 #end
-    #if(${rtcParam.IsNotImplemented(11)})//	#end //
+    #if(${rtcParam.IsNotImplemented(11)})//	#end//
    #if(${rtcParam.IsNotImplemented(11)}) //	#end pub override fn onRateChanged(ec_id:int) mut : openrtm_lns.ReturnCode_t {
     #if(${rtcParam.IsNotImplemented(11)})//	#end
 #if(${tmpltHelper.checkDetailContent(11,${rtcParam})})		${rtcParam.getDetailContent(11)}
@@ -547,7 +548,6 @@ class ${rtcParam.name} extend openrtm_lns.RTObjectBase {
 
     #if(${rtcParam.IsNotImplemented(11)})//	#end    return openrtm_lns.ReturnCode_t.RTC_OK;
    #if(${rtcParam.IsNotImplemented(11)}) //	#end }
-#end
 
 }
 

--- a/jp.go.aist.rtm.rtcbuilder.lua/src/jp/go/aist/rtm/rtcbuilder/lua/template/lua/Lua_RTC.lua.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.lua/src/jp/go/aist/rtm/rtcbuilder/lua/template/lua/Lua_RTC.lua.vsl
@@ -224,9 +224,9 @@ ${rtcParam.name}.new = function(manager)
 	--
 	-- @return RTC::ReturnCode_t
 	--
-#if(${rtcParam.getDocActionPreCondition(0).length()}>0)	-- @pre ${tmpltHelperLua.convertPreDocLua(${rtcParam.getDocActionPreCondition(0)})}
+#if(${rtcParam.getDocActionPreCondition(0).length()}>0)    -- @pre ${tmpltHelperLua.convertPreDocLua(${rtcParam.getDocActionPreCondition(0)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(0).length()}>0)	-- @post ${tmpltHelperLua.convertPostDocLua(${rtcParam.getDocActionPostCondition(0)})}
+#if(${rtcParam.getDocActionPostCondition(0).length()}>0)    -- @post ${tmpltHelperLua.convertPostDocLua(${rtcParam.getDocActionPostCondition(0)})}
 #end
 	--
 	function obj:onInitialize()
@@ -288,9 +288,9 @@ ${rtcParam.name}.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(1)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(1)})--	#end
 
-#if(${rtcParam.getDocActionPreCondition(1).length()}>0)	#if(${rtcParam.IsNotImplemented(1)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(1)})}
+#if(${rtcParam.getDocActionPreCondition(1).length()}>0)#if(${rtcParam.IsNotImplemented(1)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(1)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(1).length()}>0)	#if(${rtcParam.IsNotImplemented(1)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(1)})}
+#if(${rtcParam.getDocActionPostCondition(1).length()}>0)#if(${rtcParam.IsNotImplemented(1)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(1)})}
 #end
 	#if(${rtcParam.IsNotImplemented(1)})--	#end--
 	#if(${rtcParam.IsNotImplemented(1)})--	#end${function} obj:onFinalize()
@@ -311,9 +311,9 @@ ${rtcParam.name}.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(2)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(2)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(2)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(2).length()}>0)	#if(${rtcParam.IsNotImplemented(2)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(2)})}
+#if(${rtcParam.getDocActionPreCondition(2).length()}>0)#if(${rtcParam.IsNotImplemented(2)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(2)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(2).length()}>0)	#if(${rtcParam.IsNotImplemented(2)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(2)})}
+#if(${rtcParam.getDocActionPostCondition(2).length()}>0)#if(${rtcParam.IsNotImplemented(2)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(2)})}
 #end
 	#if(${rtcParam.IsNotImplemented(2)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(2)})--	#end${function} obj:onStartup(ec_id)
@@ -334,9 +334,9 @@ ${rtcParam.name}.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(3)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(3)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(3)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(3).length()}>0)	#if(${rtcParam.IsNotImplemented(3)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(3)})}
+#if(${rtcParam.getDocActionPreCondition(3).length()}>0)#if(${rtcParam.IsNotImplemented(3)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(3)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(3).length()}>0)	#if(${rtcParam.IsNotImplemented(3)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(3)})}
+#if(${rtcParam.getDocActionPostCondition(3).length()}>0)#if(${rtcParam.IsNotImplemented(3)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(3)})}
 #end
 	#if(${rtcParam.IsNotImplemented(3)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(3)})--	#end${function} obj:onShutdown(ec_id)
@@ -357,9 +357,9 @@ ${rtcParam.name}.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(4)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(4)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(4)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(4).length()}>0)	#if(${rtcParam.IsNotImplemented(4)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(4)})}
+#if(${rtcParam.getDocActionPreCondition(4).length()}>0)#if(${rtcParam.IsNotImplemented(4)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(4)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(4).length()}>0)	#if(${rtcParam.IsNotImplemented(4)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(4)})}
+#if(${rtcParam.getDocActionPostCondition(4).length()}>0)#if(${rtcParam.IsNotImplemented(4)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(4)})}
 #end
 	#if(${rtcParam.IsNotImplemented(4)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(4)})--	#end${function} obj:onActivated(ec_id)
@@ -380,9 +380,9 @@ ${rtcParam.name}.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(5)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(5)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(5)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(5).length()}>0)	#if(${rtcParam.IsNotImplemented(5)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(5)})}
+#if(${rtcParam.getDocActionPreCondition(5).length()}>0)#if(${rtcParam.IsNotImplemented(5)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(5)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(5).length()}>0)	#if(${rtcParam.IsNotImplemented(5)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(5)})}
+#if(${rtcParam.getDocActionPostCondition(5).length()}>0)#if(${rtcParam.IsNotImplemented(5)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(5)})}
 #end
 	#if(${rtcParam.IsNotImplemented(5)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(5)})--	#end${function} obj:onDeactivated(ec_id)
@@ -403,9 +403,9 @@ ${rtcParam.name}.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(9)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(9)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(9)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(9).length()}>0)	#if(${rtcParam.IsNotImplemented(9)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(9)})}
+#if(${rtcParam.getDocActionPreCondition(9).length()}>0)#if(${rtcParam.IsNotImplemented(9)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(9)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(9).length()}>0)	#if(${rtcParam.IsNotImplemented(9)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(9)})}
+#if(${rtcParam.getDocActionPostCondition(9).length()}>0)#if(${rtcParam.IsNotImplemented(9)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(9)})}
 #end
 	#if(${rtcParam.IsNotImplemented(9)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(9)})--	#end${function} obj:onExecute(ec_id)
@@ -426,9 +426,9 @@ ${rtcParam.name}.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(6)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(6)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(6)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(6).length()}>0)	#if(${rtcParam.IsNotImplemented(6)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(6)})}
+#if(${rtcParam.getDocActionPreCondition(6).length()}>0)#if(${rtcParam.IsNotImplemented(6)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(6)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(6).length()}>0)	#if(${rtcParam.IsNotImplemented(6)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(6)})}
+#if(${rtcParam.getDocActionPostCondition(6).length()}>0)#if(${rtcParam.IsNotImplemented(6)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(6)})}
 #end
 	#if(${rtcParam.IsNotImplemented(6)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(6)})--	#end${function} obj:onAborting(ec_id)
@@ -449,9 +449,9 @@ ${rtcParam.name}.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(7)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(7)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(7)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(7).length()}>0)	#if(${rtcParam.IsNotImplemented(7)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(7)})}
+#if(${rtcParam.getDocActionPreCondition(7).length()}>0)#if(${rtcParam.IsNotImplemented(7)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(7)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(7).length()}>0)	#if(${rtcParam.IsNotImplemented(7)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(7)})}
+#if(${rtcParam.getDocActionPostCondition(7).length()}>0)#if(${rtcParam.IsNotImplemented(7)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(7)})}
 #end
 	#if(${rtcParam.IsNotImplemented(7)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(7)})--	#end${function} obj:onError(ec_id)
@@ -472,9 +472,9 @@ ${rtcParam.name}.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(8)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(8)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(8)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(8).length()}>0)	#if(${rtcParam.IsNotImplemented(8)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(8)})}
+#if(${rtcParam.getDocActionPreCondition(8).length()}>0)#if(${rtcParam.IsNotImplemented(8)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(8)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(8).length()}>0)	#if(${rtcParam.IsNotImplemented(8)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(8)})}
+#if(${rtcParam.getDocActionPostCondition(8).length()}>0)#if(${rtcParam.IsNotImplemented(8)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(8)})}
 #end
 	#if(${rtcParam.IsNotImplemented(8)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(8)})--	#end${function} obj:onReset(ec_id)
@@ -496,9 +496,9 @@ ${rtcParam.name}.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(10)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(10)})--	#end${minusminus}
 
-#if(${rtcParam.getDocActionPreCondition(10).length()}>0)	#if(${rtcParam.IsNotImplemented(10)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(10)})}
+#if(${rtcParam.getDocActionPreCondition(10).length()}>0)#if(${rtcParam.IsNotImplemented(10)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(10)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(10).length()}>0)	#if(${rtcParam.IsNotImplemented(10)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(10)})}
+#if(${rtcParam.getDocActionPostCondition(10).length()}>0)#if(${rtcParam.IsNotImplemented(10)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(10)})}
 #end
 	#if(${rtcParam.IsNotImplemented(10)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(10)})--	#end${function} obj:onStateUpdate(ec_id)
@@ -519,9 +519,9 @@ ${rtcParam.name}.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(11)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(11)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(11)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(11).length()}>0)	#if(${rtcParam.IsNotImplemented(11)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(11)})}
+#if(${rtcParam.getDocActionPreCondition(11).length()}>0)#if(${rtcParam.IsNotImplemented(11)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(11)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(11).length()}>0)	#if(${rtcParam.IsNotImplemented(11)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(11)})}
+#if(${rtcParam.getDocActionPostCondition(11).length()}>0)#if(${rtcParam.IsNotImplemented(11)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(11)})}
 #end
 	#if(${rtcParam.IsNotImplemented(11)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(11)})--	#end${function} obj:onRateChanged(ec_id)

--- a/jp.go.aist.rtm.rtcbuilder.lua/src/jp/go/aist/rtm/rtcbuilder/lua/template/lua/Moon_RTC.moon.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.lua/src/jp/go/aist/rtm/rtcbuilder/lua/template/lua/Moon_RTC.moon.vsl
@@ -277,7 +277,7 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
 
         return self._ReturnCode_t.RTC_OK
 
-#if(${rtcParam.getDocActionOverView(1).length()}>0)	#if(${rtcParam.IsNotImplemented(1)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(1)})}
+#if(${rtcParam.getDocActionOverView(1).length()}>0)    #if(${rtcParam.IsNotImplemented(1)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(1)})}
 #end
     #if(${rtcParam.IsNotImplemented(1)})--	#end${minusminus}
     #if(${rtcParam.IsNotImplemented(1)})--	#end${minusminus} The finalize action (on ALIVE->END transition)
@@ -286,12 +286,12 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(1)})--	#end${minusminus} @return RTC::ReturnCode_t
     #if(${rtcParam.IsNotImplemented(1)})--	#end
 
-#if(${rtcParam.getDocActionPreCondition(1).length()}>0)	#if(${rtcParam.IsNotImplemented(1)})--#end        -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(1)})}
+#if(${rtcParam.getDocActionPreCondition(1).length()}>0)#if(${rtcParam.IsNotImplemented(1)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(1)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(1).length()}>0)	#if(${rtcParam.IsNotImplemented(1)})--#end        -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(1)})}
+#if(${rtcParam.getDocActionPostCondition(1).length()}>0)#if(${rtcParam.IsNotImplemented(1)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(1)})}
 #end
     #if(${rtcParam.IsNotImplemented(1)})--	#end--
-   #if(${rtcParam.IsNotImplemented(1)}) --	#end onFinalize: =>
+    #if(${rtcParam.IsNotImplemented(1)})--	#end onFinalize: =>
     #if(${rtcParam.IsNotImplemented(1)})--	#end
 #if(${tmpltHelper.checkDetailContent(1,${rtcParam})})		${rtcParam.getDetailContent(1)}
 #end
@@ -299,7 +299,7 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(1)})--	#end        return self._ReturnCode_t.RTC_OK
     #if(${rtcParam.IsNotImplemented(1)})--	#end
 
-#if(${rtcParam.getDocActionOverView(2).length()}>0)	#if(${rtcParam.IsNotImplemented(2)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(2)})}
+#if(${rtcParam.getDocActionOverView(2).length()}>0)    #if(${rtcParam.IsNotImplemented(2)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(2)})}
 #end
     #if(${rtcParam.IsNotImplemented(2)})--	#end${minusminus}
     #if(${rtcParam.IsNotImplemented(2)})--	#end${minusminus} The startup action when ExecutionContext startup
@@ -309,12 +309,12 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(2)})--	#end${minusminus}
     #if(${rtcParam.IsNotImplemented(2)})--	#end${minusminus} @return RTC::ReturnCode_t
     #if(${rtcParam.IsNotImplemented(2)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(2).length()}>0)	#if(${rtcParam.IsNotImplemented(2)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(2)})}
+#if(${rtcParam.getDocActionPreCondition(2).length()}>0)#if(${rtcParam.IsNotImplemented(2)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(2)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(2).length()}>0)	#if(${rtcParam.IsNotImplemented(2)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(2)})}
+#if(${rtcParam.getDocActionPostCondition(2).length()}>0)#if(${rtcParam.IsNotImplemented(2)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(2)})}
 #end
     #if(${rtcParam.IsNotImplemented(2)})--	#end${minusminus}
-   #if(${rtcParam.IsNotImplemented(2)}) --	#end onStartup: (ec_id) =>
+    #if(${rtcParam.IsNotImplemented(2)})--	#end onStartup: (ec_id) =>
     #if(${rtcParam.IsNotImplemented(2)})--	#end
 #if(${tmpltHelper.checkDetailContent(2,${rtcParam})})		${rtcParam.getDetailContent(2)}
 #end
@@ -322,7 +322,7 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(2)})--	#end    return self._ReturnCode_t.RTC_OK
     #if(${rtcParam.IsNotImplemented(2)})--	#end
 
-#if(${rtcParam.getDocActionOverView(3).length()}>0)	#if(${rtcParam.IsNotImplemented(3)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(3)})}
+#if(${rtcParam.getDocActionOverView(3).length()}>0)    #if(${rtcParam.IsNotImplemented(3)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(3)})}
 #end
     #if(${rtcParam.IsNotImplemented(3)})--	#end${minusminus}
     #if(${rtcParam.IsNotImplemented(3)})--	#end${minusminus} The shutdown action when ExecutionContext stop
@@ -332,12 +332,12 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(3)})--	#end${minusminus}
     #if(${rtcParam.IsNotImplemented(3)})--	#end${minusminus} @return RTC::ReturnCode_t
     #if(${rtcParam.IsNotImplemented(3)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(3).length()}>0)	#if(${rtcParam.IsNotImplemented(3)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(3)})}
+#if(${rtcParam.getDocActionPreCondition(3).length()}>0)#if(${rtcParam.IsNotImplemented(3)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(3)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(3).length()}>0)	#if(${rtcParam.IsNotImplemented(3)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(3)})}
+#if(${rtcParam.getDocActionPostCondition(3).length()}>0)#if(${rtcParam.IsNotImplemented(3)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(3)})}
 #end
     #if(${rtcParam.IsNotImplemented(3)})--	#end${minusminus}
-   #if(${rtcParam.IsNotImplemented(3)}) --	#end onShutdown: (ec_id) =>
+    #if(${rtcParam.IsNotImplemented(3)})--	#end onShutdown: (ec_id) =>
     #if(${rtcParam.IsNotImplemented(3)})--	#end
 #if(${tmpltHelper.checkDetailContent(3,${rtcParam})})		${rtcParam.getDetailContent(3)}
 #end
@@ -345,7 +345,7 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(3)})--	#end    return self._ReturnCode_t.RTC_OK
     #if(${rtcParam.IsNotImplemented(3)})--	#end
 
-#if(${rtcParam.getDocActionOverView(4).length()}>0)	#if(${rtcParam.IsNotImplemented(4)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(4)})}
+#if(${rtcParam.getDocActionOverView(4).length()}>0)    #if(${rtcParam.IsNotImplemented(4)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(4)})}
 #end
     #if(${rtcParam.IsNotImplemented(4)})--	#end${minusminus}
     #if(${rtcParam.IsNotImplemented(4)})--	#end${minusminus} The activated action (Active state entry action)
@@ -355,12 +355,12 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(4)})--	#end${minusminus}
     #if(${rtcParam.IsNotImplemented(4)})--	#end${minusminus} @return RTC::ReturnCode_t
     #if(${rtcParam.IsNotImplemented(4)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(4).length()}>0)	#if(${rtcParam.IsNotImplemented(4)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(4)})}
+#if(${rtcParam.getDocActionPreCondition(4).length()}>0)#if(${rtcParam.IsNotImplemented(4)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(4)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(4).length()}>0)	#if(${rtcParam.IsNotImplemented(4)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(4)})}
+#if(${rtcParam.getDocActionPostCondition(4).length()}>0)#if(${rtcParam.IsNotImplemented(4)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(4)})}
 #end
     #if(${rtcParam.IsNotImplemented(4)})--	#end${minusminus}
-   #if(${rtcParam.IsNotImplemented(4)}) --	#end onActivated: (ec_id) =>
+    #if(${rtcParam.IsNotImplemented(4)})--	#end onActivated: (ec_id) =>
     #if(${rtcParam.IsNotImplemented(4)})--	#end
 #if(${tmpltHelper.checkDetailContent(4,${rtcParam})})		${rtcParam.getDetailContent(4)}
 #end
@@ -368,7 +368,7 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(4)})--	#end    return self._ReturnCode_t.RTC_OK
     #if(${rtcParam.IsNotImplemented(4)})--	#end
 
-#if(${rtcParam.getDocActionOverView(5).length()}>0)	#if(${rtcParam.IsNotImplemented(5)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(5)})}
+#if(${rtcParam.getDocActionOverView(5).length()}>0)    #if(${rtcParam.IsNotImplemented(5)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(5)})}
 #end
     #if(${rtcParam.IsNotImplemented(5)})--	#end${minusminus}
     #if(${rtcParam.IsNotImplemented(5)})--	#end${minusminus} The deactivated action (Active state exit action)
@@ -378,12 +378,12 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(5)})--	#end${minusminus}
     #if(${rtcParam.IsNotImplemented(5)})--	#end${minusminus} @return RTC::ReturnCode_t
     #if(${rtcParam.IsNotImplemented(5)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(5).length()}>0)	#if(${rtcParam.IsNotImplemented(5)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(5)})}
+#if(${rtcParam.getDocActionPreCondition(5).length()}>0)#if(${rtcParam.IsNotImplemented(5)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(5)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(5).length()}>0)	#if(${rtcParam.IsNotImplemented(5)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(5)})}
+#if(${rtcParam.getDocActionPostCondition(5).length()}>0)#if(${rtcParam.IsNotImplemented(5)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(5)})}
 #end
     #if(${rtcParam.IsNotImplemented(5)})--	#end${minusminus}
-   #if(${rtcParam.IsNotImplemented(5)}) --	#end onDeactivated: (ec_id) =>
+    #if(${rtcParam.IsNotImplemented(5)})--	#end onDeactivated: (ec_id) =>
     #if(${rtcParam.IsNotImplemented(5)})--	#end
 #if(${tmpltHelper.checkDetailContent(5,${rtcParam})})		${rtcParam.getDetailContent(5)}
 #end
@@ -391,7 +391,7 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(5)})--	#end    return self._ReturnCode_t.RTC_OK
     #if(${rtcParam.IsNotImplemented(5)})--	#end
 
-#if(${rtcParam.getDocActionOverView(9).length()}>0)	#if(${rtcParam.IsNotImplemented(9)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(9)})}
+#if(${rtcParam.getDocActionOverView(9).length()}>0)    #if(${rtcParam.IsNotImplemented(9)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(9)})}
 #end
     #if(${rtcParam.IsNotImplemented(9)})--	#end${minusminus}
     #if(${rtcParam.IsNotImplemented(9)})--	#end${minusminus} The execution action that is invoked periodically
@@ -401,12 +401,12 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(9)})--	#end${minusminus}
     #if(${rtcParam.IsNotImplemented(9)})--	#end${minusminus} @return RTC::ReturnCode_t
     #if(${rtcParam.IsNotImplemented(9)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(9).length()}>0)	#if(${rtcParam.IsNotImplemented(9)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(9)})}
+#if(${rtcParam.getDocActionPreCondition(9).length()}>0)#if(${rtcParam.IsNotImplemented(9)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(9)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(9).length()}>0)	#if(${rtcParam.IsNotImplemented(9)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(9)})}
+#if(${rtcParam.getDocActionPostCondition(9).length()}>0)#if(${rtcParam.IsNotImplemented(9)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(9)})}
 #end
     #if(${rtcParam.IsNotImplemented(9)})--	#end${minusminus}
-   #if(${rtcParam.IsNotImplemented(9)}) --	#end onExecute: (ec_id) =>
+    #if(${rtcParam.IsNotImplemented(9)})--	#end onExecute: (ec_id) =>
     #if(${rtcParam.IsNotImplemented(9)})--	#end
 #if(${tmpltHelper.checkDetailContent(9,${rtcParam})})		${rtcParam.getDetailContent(9)}
 #end
@@ -414,7 +414,7 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(9)})--	#end    return self._ReturnCode_t.RTC_OK
     #if(${rtcParam.IsNotImplemented(9)})--	#end
 
-#if(${rtcParam.getDocActionOverView(6).length()}>0)	#if(${rtcParam.IsNotImplemented(6)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(6)})}
+#if(${rtcParam.getDocActionOverView(6).length()}>0)    #if(${rtcParam.IsNotImplemented(6)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(6)})}
 #end
     #if(${rtcParam.IsNotImplemented(6)})--	#end${minusminus}
     #if(${rtcParam.IsNotImplemented(6)})--	#end${minusminus} The aborting action when main logic error occurred.
@@ -424,12 +424,12 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(6)})--	#end${minusminus}
     #if(${rtcParam.IsNotImplemented(6)})--	#end${minusminus} @return RTC::ReturnCode_t
     #if(${rtcParam.IsNotImplemented(6)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(6).length()}>0)	#if(${rtcParam.IsNotImplemented(6)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(6)})}
+#if(${rtcParam.getDocActionPreCondition(6).length()}>0)#if(${rtcParam.IsNotImplemented(6)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(6)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(6).length()}>0)	#if(${rtcParam.IsNotImplemented(6)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(6)})}
+#if(${rtcParam.getDocActionPostCondition(6).length()}>0)#if(${rtcParam.IsNotImplemented(6)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(6)})}
 #end
     #if(${rtcParam.IsNotImplemented(6)})--	#end${minusminus}
-   #if(${rtcParam.IsNotImplemented(6)}) --	#end onAborting: (ec_id) =>
+    #if(${rtcParam.IsNotImplemented(6)})--	#end onAborting: (ec_id) =>
     #if(${rtcParam.IsNotImplemented(6)})--	#end
 #if(${tmpltHelper.checkDetailContent(6,${rtcParam})})		${rtcParam.getDetailContent(6)}
 #end
@@ -437,7 +437,7 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(6)})--	#end    return self._ReturnCode_t.RTC_OK
     #if(${rtcParam.IsNotImplemented(6)})--	#end
 
-#if(${rtcParam.getDocActionOverView(7).length()}>0)	#if(${rtcParam.IsNotImplemented(7)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(7)})}
+#if(${rtcParam.getDocActionOverView(7).length()}>0)    #if(${rtcParam.IsNotImplemented(7)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(7)})}
 #end
     #if(${rtcParam.IsNotImplemented(7)})--	#end${minusminus}
     #if(${rtcParam.IsNotImplemented(7)})--	#end${minusminus} The error action in ERROR state
@@ -447,12 +447,12 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(7)})--	#end${minusminus}
     #if(${rtcParam.IsNotImplemented(7)})--	#end${minusminus} @return RTC::ReturnCode_t
     #if(${rtcParam.IsNotImplemented(7)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(7).length()}>0)	#if(${rtcParam.IsNotImplemented(7)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(7)})}
+#if(${rtcParam.getDocActionPreCondition(7).length()}>0)#if(${rtcParam.IsNotImplemented(7)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(7)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(7).length()}>0)	#if(${rtcParam.IsNotImplemented(7)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(7)})}
+#if(${rtcParam.getDocActionPostCondition(7).length()}>0)#if(${rtcParam.IsNotImplemented(7)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(7)})}
 #end
     #if(${rtcParam.IsNotImplemented(7)})--	#end${minusminus}
-   #if(${rtcParam.IsNotImplemented(7)}) --	#end onError: (ec_id) =>
+    #if(${rtcParam.IsNotImplemented(7)})--	#end onError: (ec_id) =>
     #if(${rtcParam.IsNotImplemented(7)})--	#end
 #if(${tmpltHelper.checkDetailContent(7,${rtcParam})})		${rtcParam.getDetailContent(7)}
 #end
@@ -460,7 +460,7 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(7)})--	#end    return self._ReturnCode_t.RTC_OK
     #if(${rtcParam.IsNotImplemented(7)})--	#end
 
-#if(${rtcParam.getDocActionOverView(8).length()}>0)	#if(${rtcParam.IsNotImplemented(8)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(8)})}
+#if(${rtcParam.getDocActionOverView(8).length()}>0)    #if(${rtcParam.IsNotImplemented(8)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(8)})}
 #end
     #if(${rtcParam.IsNotImplemented(8)})--	#end${minusminus}
     #if(${rtcParam.IsNotImplemented(8)})--	#end${minusminus} The reset action that is invoked resetting
@@ -470,12 +470,12 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(8)})--	#end${minusminus}
     #if(${rtcParam.IsNotImplemented(8)})--	#end${minusminus} @return RTC::ReturnCode_t
     #if(${rtcParam.IsNotImplemented(8)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(8).length()}>0)	#if(${rtcParam.IsNotImplemented(8)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(8)})}
+#if(${rtcParam.getDocActionPreCondition(8).length()}>0)#if(${rtcParam.IsNotImplemented(8)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(8)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(8).length()}>0)	#if(${rtcParam.IsNotImplemented(8)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(8)})}
+#if(${rtcParam.getDocActionPostCondition(8).length()}>0)#if(${rtcParam.IsNotImplemented(8)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(8)})}
 #end
     #if(${rtcParam.IsNotImplemented(8)})--	#end${minusminus}
-   #if(${rtcParam.IsNotImplemented(8)}) --	#end onReset: (ec_id) =>
+    #if(${rtcParam.IsNotImplemented(8)})--	#end onReset: (ec_id) =>
     #if(${rtcParam.IsNotImplemented(8)})--	#end
 #if(${tmpltHelper.checkDetailContent(8,${rtcParam})})		${rtcParam.getDetailContent(8)}
 #end
@@ -483,7 +483,7 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(8)})--	#end    return self._ReturnCode_t.RTC_OK
     #if(${rtcParam.IsNotImplemented(8)})--	#end
 
-#if(${rtcParam.getDocActionOverView(10).length()}>0)	#if(${rtcParam.IsNotImplemented(10)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(10)})}
+#if(${rtcParam.getDocActionOverView(10).length()}>0)    #if(${rtcParam.IsNotImplemented(10)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(10)})}
 #end
     #if(${rtcParam.IsNotImplemented(10)})--	#end${minusminus}
     #if(${rtcParam.IsNotImplemented(10)})--	#end${minusminus} The state update action that is invoked after onExecute() action
@@ -494,12 +494,12 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(10)})--	#end${minusminus} @return RTC::ReturnCode_t
     #if(${rtcParam.IsNotImplemented(10)})--	#end${minusminus}
 
-#if(${rtcParam.getDocActionPreCondition(10).length()}>0)	#if(${rtcParam.IsNotImplemented(10)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(10)})}
+#if(${rtcParam.getDocActionPreCondition(10).length()}>0)#if(${rtcParam.IsNotImplemented(10)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(10)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(10).length()}>0)	#if(${rtcParam.IsNotImplemented(10)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(10)})}
+#if(${rtcParam.getDocActionPostCondition(10).length()}>0)#if(${rtcParam.IsNotImplemented(10)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(10)})}
 #end
     #if(${rtcParam.IsNotImplemented(10)})--	#end${minusminus}
-   #if(${rtcParam.IsNotImplemented(10)}) --	#end onStateUpdate: (ec_id) =>
+    #if(${rtcParam.IsNotImplemented(10)})--	#end onStateUpdate: (ec_id) =>
     #if(${rtcParam.IsNotImplemented(10)})--	#end
 #if(${tmpltHelper.checkDetailContent(10,${rtcParam})})		${rtcParam.getDetailContent(10)}
 #end
@@ -507,7 +507,7 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(10)})--	#end    return self._ReturnCode_t.RTC_OK
     #if(${rtcParam.IsNotImplemented(10)})--	#end
 
-#if(${rtcParam.getDocActionOverView(11).length()}>0)	#if(${rtcParam.IsNotImplemented(11)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(11)})}
+#if(${rtcParam.getDocActionOverView(11).length()}>0)    #if(${rtcParam.IsNotImplemented(11)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(11)})}
 #end
     #if(${rtcParam.IsNotImplemented(11)})--	#end${minusminus}
     #if(${rtcParam.IsNotImplemented(11)})--	#end${minusminus} The action that is invoked when execution context's rate is changed
@@ -517,12 +517,12 @@ class ${rtcParam.name} extends openrtm_ms.RTObject
     #if(${rtcParam.IsNotImplemented(11)})--	#end${minusminus}
     #if(${rtcParam.IsNotImplemented(11)})--	#end${minusminus} @return RTC::ReturnCode_t
     #if(${rtcParam.IsNotImplemented(11)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(11).length()}>0)	#if(${rtcParam.IsNotImplemented(11)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(11)})}
+#if(${rtcParam.getDocActionPreCondition(11).length()}>0)#if(${rtcParam.IsNotImplemented(11)})--#end    -- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(11)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(11).length()}>0)	#if(${rtcParam.IsNotImplemented(11)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(11)})}
+#if(${rtcParam.getDocActionPostCondition(11).length()}>0)#if(${rtcParam.IsNotImplemented(11)})--#end    -- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(11)})}
 #end
     #if(${rtcParam.IsNotImplemented(11)})--	#end${minusminus}
-   #if(${rtcParam.IsNotImplemented(11)}) --	#end onRateChanged: (ec_id) =>
+    #if(${rtcParam.IsNotImplemented(11)})--	#end onRateChanged: (ec_id) =>
     #if(${rtcParam.IsNotImplemented(11)})--	#end
 #if(${tmpltHelper.checkDetailContent(11,${rtcParam})})		${rtcParam.getDetailContent(11)}
 #end

--- a/jp.go.aist.rtm.rtcbuilder.lua/src/jp/go/aist/rtm/rtcbuilder/lua/template/lua/test/Lua_Test_RTC.lua.vsl
+++ b/jp.go.aist.rtm.rtcbuilder.lua/src/jp/go/aist/rtm/rtcbuilder/lua/template/lua/test/Lua_Test_RTC.lua.vsl
@@ -5,11 +5,11 @@
 --! @date \$Date$
 
 #if( ${rtcParam.docCreator.length()} > 0 )
---! @author ${tmpltHelperPy.convertAuthorDocPy(${rtcParam.docCreator})}
+--! @author ${tmpltHelperLua.convertAuthorDocLua(${rtcParam.docCreator})}
 #end
 #if( ${rtcParam.docLicense.length()} > 0 )
 
---! ${tmpltHelperPy.convertDocPy(${rtcParam.docLicense})}
+--! ${tmpltHelperLua.convertDocLua(${rtcParam.docLicense})}
 #end
 ---------------------------------
 
@@ -275,9 +275,9 @@ ${rtcParam.name}Test.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(1)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(1)})--#end
 
-#if(${rtcParam.getDocActionPreCondition(1).length()}>0)	#if(${rtcParam.IsNotImplemented(1)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(1)})}
+#if(${rtcParam.getDocActionPreCondition(1).length()}>0)#if(${rtcParam.IsNotImplemented(1)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(1)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(1).length()}>0)	#if(${rtcParam.IsNotImplemented(1)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(1)})}
+#if(${rtcParam.getDocActionPostCondition(1).length()}>0)#if(${rtcParam.IsNotImplemented(1)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(1)})}
 #end
 	#if(${rtcParam.IsNotImplemented(1)})--	#end--
 	#if(${rtcParam.IsNotImplemented(1)})--	#end${function} obj:onFinalize()
@@ -298,9 +298,9 @@ ${rtcParam.name}Test.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(2)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(2)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(2)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(2).length()}>0)	#if(${rtcParam.IsNotImplemented(2)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(2)})}
+#if(${rtcParam.getDocActionPreCondition(2).length()}>0)#if(${rtcParam.IsNotImplemented(2)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(2)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(2).length()}>0)	#if(${rtcParam.IsNotImplemented(2)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(2)})}
+#if(${rtcParam.getDocActionPostCondition(2).length()}>0)#if(${rtcParam.IsNotImplemented(2)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(2)})}
 #end
 	#if(${rtcParam.IsNotImplemented(2)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(2)})--	#end${function} obj:onStartup(ec_id)
@@ -321,9 +321,9 @@ ${rtcParam.name}Test.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(3)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(3)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(3)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(3).length()}>0)	#if(${rtcParam.IsNotImplemented(3)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(3)})}
+#if(${rtcParam.getDocActionPreCondition(3).length()}>0)#if(${rtcParam.IsNotImplemented(3)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(3)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(3).length()}>0)	#if(${rtcParam.IsNotImplemented(3)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(3)})}
+#if(${rtcParam.getDocActionPostCondition(3).length()}>0)#if(${rtcParam.IsNotImplemented(3)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(3)})}
 #end
 	#if(${rtcParam.IsNotImplemented(3)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(3)})--	#end${function} obj:onShutdown(ec_id)
@@ -344,18 +344,18 @@ ${rtcParam.name}Test.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(4)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(4)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(4)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(4).length()}>0)	#if(${rtcParam.IsNotImplemented(4)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(4)})}
+#if(${rtcParam.getDocActionPreCondition(4).length()}>0)#if(${rtcParam.IsNotImplemented(4)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(4)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(4).length()}>0)	#if(${rtcParam.IsNotImplemented(4)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(4)})}
+#if(${rtcParam.getDocActionPostCondition(4).length()}>0)#if(${rtcParam.IsNotImplemented(4)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(4)})}
 #end
-	#if(${rtcParam.IsNotImplemented(4)})--#end${minusminus}
-	#if(${rtcParam.IsNotImplemented(4)})--#end${function} obj:onActivated(ec_id)
-	#if(${rtcParam.IsNotImplemented(4)})--#end
+	#if(${rtcParam.IsNotImplemented(4)})--	#end${minusminus}
+	#if(${rtcParam.IsNotImplemented(4)})--	#end${function} obj:onActivated(ec_id)
+	#if(${rtcParam.IsNotImplemented(4)})--	#end
 #if(${tmpltHelper.checkDetailContent(4,${rtcParam})})		${rtcParam.getDetailContent(4)}
 #end
 
-	#if(${rtcParam.IsNotImplemented(4)})--#end	return self._ReturnCode_t.RTC_OK
-	#if(${rtcParam.IsNotImplemented(4)})--#end${end}
+	#if(${rtcParam.IsNotImplemented(4)})--	#end	return self._ReturnCode_t.RTC_OK
+	#if(${rtcParam.IsNotImplemented(4)})--	#end${end}
 
 #if(${rtcParam.getDocActionOverView(5).length()}>0)	#if(${rtcParam.IsNotImplemented(5)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(5)})}
 #end
@@ -367,9 +367,9 @@ ${rtcParam.name}Test.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(5)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(5)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(5)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(5).length()}>0)	#if(${rtcParam.IsNotImplemented(5)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(5)})}
+#if(${rtcParam.getDocActionPreCondition(5).length()}>0)#if(${rtcParam.IsNotImplemented(5)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(5)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(5).length()}>0)	#if(${rtcParam.IsNotImplemented(5)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(5)})}
+#if(${rtcParam.getDocActionPostCondition(5).length()}>0)#if(${rtcParam.IsNotImplemented(5)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(5)})}
 #end
 	#if(${rtcParam.IsNotImplemented(5)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(5)})--	#end${function} obj:onDeactivated(ec_id)
@@ -390,9 +390,9 @@ ${rtcParam.name}Test.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(9)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(9)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(9)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(9).length()}>0)	#if(${rtcParam.IsNotImplemented(9)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(9)})}
+#if(${rtcParam.getDocActionPreCondition(9).length()}>0)#if(${rtcParam.IsNotImplemented(9)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(9)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(9).length()}>0)	#if(${rtcParam.IsNotImplemented(9)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(9)})}
+#if(${rtcParam.getDocActionPostCondition(9).length()}>0)#if(${rtcParam.IsNotImplemented(9)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(9)})}
 #end
 	#if(${rtcParam.IsNotImplemented(9)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(9)})--	#end${function} obj:onExecute(ec_id)
@@ -400,8 +400,8 @@ ${rtcParam.name}Test.new = function(manager)
 #if(${tmpltHelper.checkDetailContent(9,${rtcParam})})		${rtcParam.getDetailContent(9)}
 #end
 
-	#if(${rtcParam.IsNotImplemented(9)})--#end	return self._ReturnCode_t.RTC_OK
-	#if(${rtcParam.IsNotImplemented(9)})--#end${end}
+	#if(${rtcParam.IsNotImplemented(9)})--	#end	return self._ReturnCode_t.RTC_OK
+	#if(${rtcParam.IsNotImplemented(9)})--	#end${end}
 
 #if(${rtcParam.getDocActionOverView(6).length()}>0)	#if(${rtcParam.IsNotImplemented(6)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(6)})}
 #end
@@ -413,9 +413,9 @@ ${rtcParam.name}Test.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(6)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(6)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(6)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(6).length()}>0)	#if(${rtcParam.IsNotImplemented(6)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(6)})}
+#if(${rtcParam.getDocActionPreCondition(6).length()}>0)#if(${rtcParam.IsNotImplemented(6)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(6)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(6).length()}>0)	#if(${rtcParam.IsNotImplemented(6)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(6)})}
+#if(${rtcParam.getDocActionPostCondition(6).length()}>0)#if(${rtcParam.IsNotImplemented(6)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(6)})}
 #end
 	#if(${rtcParam.IsNotImplemented(6)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(6)})--	#end${function} obj:onAborting(ec_id)
@@ -423,8 +423,8 @@ ${rtcParam.name}Test.new = function(manager)
 #if(${tmpltHelper.checkDetailContent(6,${rtcParam})})		${rtcParam.getDetailContent(6)}
 #end
 
-	#if(${rtcParam.IsNotImplemented(6)})--#end	return self._ReturnCode_t.RTC_OK
-	#if(${rtcParam.IsNotImplemented(6)})--#end${end}
+	#if(${rtcParam.IsNotImplemented(6)})--	#end	return self._ReturnCode_t.RTC_OK
+	#if(${rtcParam.IsNotImplemented(6)})--	#end${end}
 
 #if(${rtcParam.getDocActionOverView(7).length()}>0)	#if(${rtcParam.IsNotImplemented(7)})--#end${minusminus} ${tmpltHelperLua.convertActivityDocLua(${rtcParam.getDocActionOverView(7)})}
 #end
@@ -436,9 +436,9 @@ ${rtcParam.name}Test.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(7)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(7)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(7)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(7).length()}>0)	#if(${rtcParam.IsNotImplemented(7)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(7)})}
+#if(${rtcParam.getDocActionPreCondition(7).length()}>0)#if(${rtcParam.IsNotImplemented(7)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(7)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(7).length()}>0)	#if(${rtcParam.IsNotImplemented(7)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(7)})}
+#if(${rtcParam.getDocActionPostCondition(7).length()}>0)#if(${rtcParam.IsNotImplemented(7)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(7)})}
 #end
 	#if(${rtcParam.IsNotImplemented(7)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(7)})--	#end${function} obj:onError(ec_id)
@@ -459,9 +459,9 @@ ${rtcParam.name}Test.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(8)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(8)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(8)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(8).length()}>0)	#if(${rtcParam.IsNotImplemented(8)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(8)})}
+#if(${rtcParam.getDocActionPreCondition(8).length()}>0)#if(${rtcParam.IsNotImplemented(8)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(8)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(8).length()}>0)	#if(${rtcParam.IsNotImplemented(8)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(8)})}
+#if(${rtcParam.getDocActionPostCondition(8).length()}>0)#if(${rtcParam.IsNotImplemented(8)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(8)})}
 #end
 	#if(${rtcParam.IsNotImplemented(8)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(8)})--	#end${function} obj:onReset(ec_id)
@@ -483,9 +483,9 @@ ${rtcParam.name}Test.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(10)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(10)})--	#end${minusminus}
 
-#if(${rtcParam.getDocActionPreCondition(10).length()}>0)	#if(${rtcParam.IsNotImplemented(10)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(10)})}
+#if(${rtcParam.getDocActionPreCondition(10).length()}>0)#if(${rtcParam.IsNotImplemented(10)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(10)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(10).length()}>0)	#if(${rtcParam.IsNotImplemented(10)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(10)})}
+#if(${rtcParam.getDocActionPostCondition(10).length()}>0)#if(${rtcParam.IsNotImplemented(10)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(10)})}
 #end
 	#if(${rtcParam.IsNotImplemented(10)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(10)})--	#end${function} obj:onStateUpdate(ec_id)
@@ -506,9 +506,9 @@ ${rtcParam.name}Test.new = function(manager)
 	#if(${rtcParam.IsNotImplemented(11)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(11)})--	#end${minusminus} @return RTC::ReturnCode_t
 	#if(${rtcParam.IsNotImplemented(11)})--	#end${minusminus}
-#if(${rtcParam.getDocActionPreCondition(11).length()}>0)	#if(${rtcParam.IsNotImplemented(11)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(11)})}
+#if(${rtcParam.getDocActionPreCondition(11).length()}>0)#if(${rtcParam.IsNotImplemented(11)})--#end	-- @pre ${tmpltHelperLua.convertPreShDocLua(${rtcParam.getDocActionPreCondition(11)})}
 #end
-#if(${rtcParam.getDocActionPostCondition(11).length()}>0)	#if(${rtcParam.IsNotImplemented(11)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(11)})}
+#if(${rtcParam.getDocActionPostCondition(11).length()}>0)#if(${rtcParam.IsNotImplemented(11)})--#end	-- @post ${tmpltHelperLua.convertPostShDocLua(${rtcParam.getDocActionPostCondition(11)})}
 #end
 	#if(${rtcParam.IsNotImplemented(11)})--	#end${minusminus}
 	#if(${rtcParam.IsNotImplemented(11)})--	#end${function} obj:onRateChanged(ec_id)


### PR DESCRIPTION
Link to #577

## Description of the Change

Lua版RTCのコード生成を行った際に，生成されたコードの内容がおかしかったので修正させて頂きました．
- ポートやコンフィギュレーションセットを定義しない状態でコード生成を行うと，拡張子が｢lns｣のファイルの内容がおかしくなる
- test以下に生成されるluaファイルの内容がおかしい
　→tmpltHelperがPython向けの名称になってしまっており，正常に変換されていない

## Verification 

- [x] Did you succesed the build?  Windows上でEclipse2020-06を使用
- [x] No warnings for the build?  Windows上でEclipse2020-06を使用
- [ ] Have you passed the unit tests? サンプルコードの内容を基にユニットテストも作成